### PR TITLE
Console warnings cleanup

### DIFF
--- a/src/containers/Tag/Tag.tsx
+++ b/src/containers/Tag/Tag.tsx
@@ -20,7 +20,7 @@ export interface TagProps {
 export const Tag: React.SFC<TagProps> = (props) => {
   const languages = useQuery(GET_LANGUAGES, {
     onCompleted: (data) => {
-      setLanguageId('1');
+      setLanguageId(data.languages[0].id);
     },
   });
   const tagId = props.match.params.id ? props.match.params.id : false;

--- a/src/containers/Tag/TagList/TagList.tsx
+++ b/src/containers/Tag/TagList/TagList.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Redirect, Link } from 'react-router-dom';
-import { useQuery, useLazyQuery, useMutation } from '@apollo/client';
+import { useQuery, useMutation } from '@apollo/client';
 import { useApolloClient } from '@apollo/client';
 import { setNotification } from '../../../common/notification';
 import {
@@ -28,9 +28,9 @@ export const TagList: React.SFC<TagListProps> = (props) => {
   const client = useApolloClient();
   const [newTag, setNewTag] = useState(false);
 
-  const [getTags, { loading, data }] = useLazyQuery(GET_TAGS);
+  const { loading, error, data } = useQuery(GET_TAGS);
 
-  const [messages, message] = useLazyQuery(NOTIFICATION);
+  const message = useQuery(NOTIFICATION);
 
   let deleteId: number = 0;
   const [deleteTag] = useMutation(DELETE_TAG, {
@@ -44,11 +44,6 @@ export const TagList: React.SFC<TagListProps> = (props) => {
       });
     },
   });
-
-  useEffect(() => {
-    getTags();
-    messages();
-  }, [getTags, data, messages]);
 
   const closeToastMessage = () => {
     setNotification(client, null);
@@ -64,6 +59,8 @@ export const TagList: React.SFC<TagListProps> = (props) => {
   }
 
   if (loading) return <p>Loading...</p>;
+  if (error) return <p>Error :(</p>;
+  const tagList = data.tags;
 
   const deleteHandler = (id: number) => {
     deleteId = id;
@@ -72,8 +69,8 @@ export const TagList: React.SFC<TagListProps> = (props) => {
   };
 
   let listing: any;
-  if (data && data.tags.length > 0) {
-    listing = data.tags.map((n: any) => {
+  if (tagList.length > 0) {
+    listing = tagList.map((n: any) => {
       return (
         <TableRow key={n.id}>
           <TableCell component="th" scope="row">

--- a/src/containers/Tag/TagList/TagList.tsx
+++ b/src/containers/Tag/TagList/TagList.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Redirect, Link } from 'react-router-dom';
-import { useQuery, useMutation } from '@apollo/client';
+import { useQuery, useLazyQuery, useMutation } from '@apollo/client';
 import { useApolloClient } from '@apollo/client';
 import { setNotification } from '../../../common/notification';
 import {
@@ -28,9 +28,9 @@ export const TagList: React.SFC<TagListProps> = (props) => {
   const client = useApolloClient();
   const [newTag, setNewTag] = useState(false);
 
-  const { loading, error, data } = useQuery(GET_TAGS);
+  const [getTags, { loading, data }] = useLazyQuery(GET_TAGS);
 
-  const message = useQuery(NOTIFICATION);
+  const [messages, message] = useLazyQuery(NOTIFICATION);
 
   let deleteId: number = 0;
   const [deleteTag] = useMutation(DELETE_TAG, {
@@ -44,6 +44,11 @@ export const TagList: React.SFC<TagListProps> = (props) => {
       });
     },
   });
+
+  useEffect(() => {
+    getTags();
+    messages();
+  }, [getTags, data, messages]);
 
   const closeToastMessage = () => {
     setNotification(client, null);
@@ -59,8 +64,6 @@ export const TagList: React.SFC<TagListProps> = (props) => {
   }
 
   if (loading) return <p>Loading...</p>;
-  if (error) return <p>Error :(</p>;
-  const tagList = data.tags;
 
   const deleteHandler = (id: number) => {
     deleteId = id;
@@ -69,8 +72,8 @@ export const TagList: React.SFC<TagListProps> = (props) => {
   };
 
   let listing: any;
-  if (tagList.length > 0) {
-    listing = tagList.map((n: any) => {
+  if (data && data.tags.length > 0) {
+    listing = data.tags.map((n: any) => {
       return (
         <TableRow key={n.id}>
           <TableCell component="th" scope="row">


### PR DESCRIPTION
## Summary

Removed console warnings in Tag Add/Edit functionality.

###  Note
Not all warnings have been removed. A couple of them like the `unmounted component` and `DOM render in Dropdown` are library related issues. These will go away when the library is updated.

Apollo React PR for `unmounted component`:
https://github.com/apollographql/react-apollo/pull/4021

I suggest to wait for a few days to get these merged. We'll update the package to clean these warnings.

Also, these warnings only appear in React strictmode. These will not show up in production version.

## Test Plan

No test cases here. Tag edit/add test cases to be covered in #14 
