### PR TITLE
Taglist cache update bug fix

### DIFF
--- a/src/containers/Tag/TagList/TagList.tsx
+++ b/src/containers/Tag/TagList/TagList.tsx
@@ -85,7 +85,6 @@ export const TagList: React.SFC<TagListProps> = (props) => {
   );
   useEffect(() => {
     if (searchVal !== '') {
-      console.log('dd');
       refetch(filterPayload());
       refetchCount({
         filter: {

--- a/src/containers/Tag/TagList/TagList.tsx
+++ b/src/containers/Tag/TagList/TagList.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { Redirect, Link } from 'react-router-dom';
 import { useQuery, useMutation } from '@apollo/client';
 import { useApolloClient } from '@apollo/client';

--- a/src/containers/Tag/TagList/TagList.tsx
+++ b/src/containers/Tag/TagList/TagList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Redirect, Link } from 'react-router-dom';
 import { useQuery, useMutation } from '@apollo/client';
 import { useApolloClient } from '@apollo/client';
@@ -83,6 +83,17 @@ export const TagList: React.SFC<TagListProps> = (props) => {
       },
     }
   );
+  useEffect(() => {
+    if (searchVal !== '') {
+      console.log('dd');
+      refetch(filterPayload());
+      refetchCount({
+        filter: {
+          label: searchVal,
+        },
+      });
+    }
+  }, [searchVal]);
 
   // Get tag data here
   const { loading, error, data, refetch } = useQuery(FILTER_TAGS, {
@@ -152,15 +163,6 @@ export const TagList: React.SFC<TagListProps> = (props) => {
 
   if (loading || l) return <Loading />;
   if (error || e) return <p>Error :(</p>;
-
-  if (searchVal !== '') {
-    refetch(filterPayload());
-    refetchCount({
-      filter: {
-        label: searchVal,
-      },
-    });
-  }
 
   const deleteHandler = (id: number) => {
     deleteId = id;

--- a/src/containers/Tag/TagList/TagList.tsx
+++ b/src/containers/Tag/TagList/TagList.tsx
@@ -72,19 +72,6 @@ export const TagList: React.SFC<TagListProps> = (props) => {
     };
   };
 
-  useEffect(() => {
-    refetch(filterPayload());
-  }, [searchVal, setTableVals]);
-
-  // Make a new count request for a new count of the # of rows from this query in the back-end.
-  useEffect(() => {
-    refetchCount({
-      filter: {
-        label: searchVal,
-      },
-    });
-  }, [searchVal]);
-
   // Get the total number of tags here
   const { loading: l, error: e, data: countData, refetch: refetchCount } = useQuery(
     GET_TAGS_COUNT,
@@ -100,7 +87,6 @@ export const TagList: React.SFC<TagListProps> = (props) => {
   // Get tag data here
   const { loading, error, data, refetch } = useQuery(FILTER_TAGS, {
     variables: filterPayload(),
-    fetchPolicy: 'cache-and-network',
   });
 
   const message = useQuery(NOTIFICATION);
@@ -166,6 +152,15 @@ export const TagList: React.SFC<TagListProps> = (props) => {
 
   if (loading || l) return <Loading />;
   if (error || e) return <p>Error :(</p>;
+
+  if (searchVal !== '') {
+    refetch(filterPayload());
+    refetchCount({
+      filter: {
+        label: searchVal,
+      },
+    });
+  }
 
   const deleteHandler = (id: number) => {
     deleteId = id;

--- a/src/graphql/mutations/Tag.ts
+++ b/src/graphql/mutations/Tag.ts
@@ -18,11 +18,6 @@ export const CREATE_TAG = gql`
         id
         description
         label
-        isActive
-        isReserved
-        language {
-          id
-        }
       }
     }
   }
@@ -34,16 +29,7 @@ export const UPDATE_TAG = gql`
       tag {
         id
         label
-        isActive
-        isReserved
         description
-        language {
-          id
-        }
-      }
-      errors {
-        key
-        message
       }
     }
   }


### PR DESCRIPTION
## Summary

While testing Chat messages, I found a bug in the functionality and realized a similar bug is also there in the Taglist page. The functionality before was not using cached data properly and instead doing a re-fetch adding unnecessary API calls.

## Test Plan

No change in functionality as such. Just avoiding additional API calls.