### PR TITLE
filter conversation should return same message object as others

### DIFF
--- a/src/graphql/queries/Chat.ts
+++ b/src/graphql/queries/Chat.ts
@@ -64,8 +64,17 @@ export const FILTER_CONVERSATIONS_QUERY = gql`
       messages {
         id
         body
-        flow
-        type
+        insertedAt
+        receiver {
+          id
+        }
+        sender {
+          id
+        }
+        tags {
+          id
+          label
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/glific/glific-frontend) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Please ensure coding standard and conventions are followed. You can find the details at https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing

-->

## Summary

* Message object in Filter query should return same message object as a conversations message object

## Test Plan

* Not needed.
