### PR TITLE
Editor enhancements according to feedbacks

### DIFF
--- a/src/common/RichEditor.tsx
+++ b/src/common/RichEditor.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import reactStringReplace from 'react-string-replace';
 import { convertToRaw, convertFromRaw } from 'draft-js';
-import { markdownToDraft } from 'markdown-draft-js';
+const MarkDownConvertor = require('markdown-draft-js');
 
 // Indicates how to replace different parts of the text from WhatsApp to HTML.
 export const TextReplacements: any = [
@@ -10,7 +10,7 @@ export const TextReplacements: any = [
       char: '*',
       tag: 'b',
       replace: (text: string) => {
-        return <b>{text}</b>;
+        return <b key={text}>{text}</b>;
       },
     },
   },
@@ -34,7 +34,7 @@ export const TextReplacements: any = [
   },
   {
     codeBlock: {
-      char: '```',
+      char: '``',
       tag: 'code',
       replace: (text: string) => {
         return <code>{text}</code>;
@@ -83,11 +83,14 @@ export const convertToWhatsApp = (editorState: any) => {
 
 export const WhatsAppToDraftEditor = (text: string) => {
   const regexforBold = /[*][^*]*[*]/gi;
+
   const addedBold = text.replace(regexforBold, function (str: any) {
     return '*' + str + '*';
   });
 
-  const rawData = markdownToDraft(addedBold);
+  const rawData = MarkDownConvertor.markdownToDraft(addedBold, {
+    preserveNewlines: true,
+  });
   const contentState = convertFromRaw(rawData);
   return contentState;
 };

--- a/src/components/UI/Form/EmojiInput/EmojiInput.tsx
+++ b/src/components/UI/Form/EmojiInput/EmojiInput.tsx
@@ -1,10 +1,10 @@
-import React, { useState, useEffect, forwardRef } from 'react';
+import React, { useState } from 'react';
 import { Editor, RichUtils, Modifier } from 'draft-js';
 import { InputAdornment, IconButton, ClickAwayListener } from '@material-ui/core';
 import { Picker } from 'emoji-mart';
 import 'emoji-mart/css/emoji-mart.css';
 import { Input } from '../Input/Input';
-import { EditorState, ContentState } from 'draft-js';
+import { EditorState } from 'draft-js';
 import Styles from './EmojiInput.module.css';
 
 export interface EmojiInputProps {
@@ -23,6 +23,9 @@ export const EmojiInput: React.FC<EmojiInputProps> = ({
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
 
   const handleKeyCommand = (command: any, editorState: any) => {
+    if (command === 'underline') {
+      return 'handled';
+    }
     const newState = RichUtils.handleKeyCommand(editorState, command);
     if (newState) {
       props.form.setFieldValue(rest.name, newState);
@@ -56,13 +59,16 @@ export const EmojiInput: React.FC<EmojiInputProps> = ({
 
     return <Component ref={ref} {...other} />;
   };
-
+  const draftJsChange = (editorState: any) => {
+    props.form.setFieldValue(rest.name, editorState);
+  };
   const inputComponent = InputWrapper;
   const inputProps = {
     component: Editor,
     editorState: props.form.values[rest.name],
     handleKeyCommand: handleKeyCommand,
     onBlur: props.form.handleBlur,
+    onChange: draftJsChange,
   };
 
   const editor = { inputComponent: inputComponent, inputProps: inputProps };
@@ -78,10 +84,6 @@ export const EmojiInput: React.FC<EmojiInputProps> = ({
   ) : (
     <></>
   );
-
-  const draftJsChange = (editorState: any) => {
-    props.form.setFieldValue(rest.name, editorState);
-  };
 
   const handleClickAway = () => {
     setShowEmojiPicker(false);
@@ -107,14 +109,7 @@ export const EmojiInput: React.FC<EmojiInputProps> = ({
     </ClickAwayListener>
   );
 
-  const input = (
-    <Input
-      field={{ onChange: draftJsChange, ...rest }}
-      {...props}
-      editor={editor}
-      emojiPicker={picker}
-    />
-  );
+  const input = <Input field={{ ...rest }} {...props} editor={editor} emojiPicker={picker} />;
 
   return input;
 };

--- a/src/components/UI/Form/EmojiInput/EmojiInput.tsx
+++ b/src/components/UI/Form/EmojiInput/EmojiInput.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, forwardRef } from 'react';
 import { Editor, RichUtils, Modifier } from 'draft-js';
-import { InputAdornment, IconButton } from '@material-ui/core';
+import { InputAdornment, IconButton, ClickAwayListener } from '@material-ui/core';
 import { Picker } from 'emoji-mart';
 import 'emoji-mart/css/emoji-mart.css';
 import { Input } from '../Input/Input';
@@ -75,28 +75,36 @@ export const EmojiInput: React.FC<EmojiInputProps> = ({
       style={{ position: 'absolute', top: '10px', right: '0px', zIndex: 2 }}
       onSelect={updateValue}
     />
-  ) : null;
+  ) : (
+    <></>
+  );
 
   const draftJsChange = (editorState: any) => {
     props.form.setFieldValue(rest.name, editorState);
   };
 
-  const picker = (
-    <InputAdornment position="end" className={Styles.EmojiPosition}>
-      <IconButton
-        color="primary"
-        aria-label="pick emoji"
-        component="span"
-        className={Styles.Emoji}
-        onClick={() => setShowEmojiPicker(!showEmojiPicker)}
-      >
-        <span role="img" aria-label="pick emoji" data-testid="emoji-picker">
-          😀
-        </span>
-      </IconButton>
+  const handleClickAway = () => {
+    setShowEmojiPicker(false);
+  };
 
-      {emojiPicker}
-    </InputAdornment>
+  const picker = (
+    <ClickAwayListener onClickAway={handleClickAway}>
+      <InputAdornment position="end" className={Styles.EmojiPosition}>
+        <IconButton
+          color="primary"
+          aria-label="pick emoji"
+          component="span"
+          className={Styles.Emoji}
+          onClick={() => setShowEmojiPicker(!showEmojiPicker)}
+        >
+          <span role="img" aria-label="pick emoji" data-testid="emoji-picker">
+            😀
+          </span>
+        </IconButton>
+
+        {emojiPicker}
+      </InputAdornment>
+    </ClickAwayListener>
   );
 
   const input = (

--- a/src/components/UI/Form/WhatsAppEditor/WhatsAppEditor.tsx
+++ b/src/components/UI/Form/WhatsAppEditor/WhatsAppEditor.tsx
@@ -28,6 +28,9 @@ export const WhatsAppEditor: React.SFC<WhatsAppEditorProps> = (props) => {
       props.sendMessage(convertToWhatsApp(editorState));
       return 'handled';
     }
+    if (command === 'underline') {
+      return 'handled';
+    }
 
     const newState = RichUtils.handleKeyCommand(editorState, command);
     if (newState) {

--- a/src/containers/Chat/ChatMessages/ChatInput/ChatInput.tsx
+++ b/src/containers/Chat/ChatMessages/ChatInput/ChatInput.tsx
@@ -4,7 +4,7 @@ import { Container, Button, ClickAwayListener, Fade } from '@material-ui/core';
 import 'emoji-mart/css/emoji-mart.css';
 import clsx from 'clsx';
 
-import { convertToWhatsApp } from '../../../../common/RichEditor';
+import { convertToWhatsApp, WhatsAppToDraftEditor } from '../../../../common/RichEditor';
 import styles from './ChatInput.module.css';
 import sendMessageIcon from '../../../../assets/images/icons/SendMessage.svg';
 import SearchBar from '../../../../components/UI/SearchBar/SearchBar';
@@ -54,12 +54,7 @@ export const ChatInput: React.SFC<ChatInputProps> = (props) => {
 
   const handleSelectText = (obj: any) => {
     // Conversion from HTML text to EditorState
-    const blocksFromHTML = convertFromHTML(obj.body);
-    const state = ContentState.createFromBlockArray(
-      blocksFromHTML.contentBlocks,
-      blocksFromHTML.entityMap
-    );
-    setEditorState(EditorState.createWithContent(state));
+    setEditorState(EditorState.createWithContent(WhatsAppToDraftEditor(obj.body)));
   };
 
   const handleSearch = (e: any) => {

--- a/src/containers/Chat/ChatMessages/ChatTemplates/ChatTemplates.module.css
+++ b/src/containers/Chat/ChatMessages/ChatTemplates/ChatTemplates.module.css
@@ -28,8 +28,9 @@
 }
 
 .Text {
-  align-items: flex-start;
   margin: 0;
+  display: flex;
+  white-space: pre-line;
 }
 
 .PopperListItem {

--- a/src/containers/Chat/ChatMessages/ChatTemplates/ChatTemplates.tsx
+++ b/src/containers/Chat/ChatMessages/ChatTemplates/ChatTemplates.tsx
@@ -46,7 +46,7 @@ export const ChatTemplates: React.SFC<ChatTemplatesProps> = (props) => {
             >
               <p className={styles.Text}>
                 <b style={{ marginRight: '5px' }}>{obj.label}:</b>
-                {WhatsAppToJsx(obj.body)}
+                <span>{WhatsAppToJsx(obj.body)}</span>
               </p>
             </ListItem>
             <Divider light />

--- a/src/containers/Template/List/Template.module.css
+++ b/src/containers/Template/List/Template.module.css
@@ -30,5 +30,6 @@
   font-size: 16px;
   color: #93a29b;
   line-height: 1.25;
+  white-space: pre-line;
   margin: 0;
 }


### PR DESCRIPTION
## Summary

- [x]  Remove underline, as it is not supported by Whatsapp.
- [x]  We should support: https://faq.whatsapp.com/general/chats/how-to-format-your-messages/?lang=fb
- [x]  Spacing between 2 paragraphs is currently removed
- [x]  On the chat screen, when we select speed send or template, it is populated incorrectly. spacing etc is removed.
- [x]  On add/edit speed send clicking on the emoticon icon shows the option to select emoticons. It should close pop up if you click anywhere outside.
