### PR TITLE
Organisation language support

### DIFF
--- a/src/containers/Automation/Automation.test.tsx
+++ b/src/containers/Automation/Automation.test.tsx
@@ -3,10 +3,15 @@ import React from 'react';
 import { Automation } from './Automation';
 import { MockedProvider } from '@apollo/client/testing';
 import { render, wait, fireEvent } from '@testing-library/react';
-import { getOrganizationQuery } from '../../mocks/Organization';
+import { getOrganizationLanguagesQuery, getOrganizationQuery } from '../../mocks/Organization';
 import { getAutomationQuery, filterAutomationQuery } from '../../mocks/Automation';
 
-const mocks = [...getOrganizationQuery, getAutomationQuery, filterAutomationQuery];
+const mocks = [
+  ...getOrganizationQuery,
+  getAutomationQuery,
+  filterAutomationQuery,
+  getOrganizationLanguagesQuery,
+];
 const automation = (
   <MockedProvider mocks={mocks} addTypename={false}>
     <Automation match={{ params: { id: 1 } }} />

--- a/src/containers/Collection/Collection.test.helper.ts
+++ b/src/containers/Collection/Collection.test.helper.ts
@@ -13,7 +13,7 @@ import { GET_GROUPS } from '../../graphql/queries/Group';
 import { GET_TAGS } from '../../graphql/queries/Tag';
 import { GET_LANGUAGES } from '../../graphql/queries/List';
 import { GET_USERS } from '../../graphql/queries/User';
-import { getOrganizationQuery } from '../../mocks/Organization';
+import { getOrganizationLanguagesQuery, getOrganizationQuery } from '../../mocks/Organization';
 
 export const listItemProps = {
   deleteItemQuery: DELETE_COLLECTION,
@@ -243,5 +243,6 @@ export const LIST_ITEM_MOCKS = [
       },
     },
   },
-  ...getOrganizationQuery
+  ...getOrganizationQuery,
+  getOrganizationLanguagesQuery,
 ];

--- a/src/containers/Form/FormLayout.test.helper.ts
+++ b/src/containers/Form/FormLayout.test.helper.ts
@@ -2,7 +2,7 @@ import { GET_TAG, GET_TAGS, GET_TAGS_COUNT, FILTER_TAGS } from '../../graphql/qu
 import { CREATE_TAG, DELETE_TAG, UPDATE_TAG } from '../../graphql/mutations/Tag';
 import { Input } from '../../components/UI/Form/Input/Input';
 import { getTagsQuery } from '../../mocks/Tag';
-import { getOrganizationQuery } from '../../mocks/Organization';
+import { getOrganizationLanguagesQuery, getOrganizationQuery } from '../../mocks/Organization';
 
 export const listItemProps = {
   deleteItemQuery: DELETE_TAG,
@@ -257,5 +257,6 @@ export const LIST_ITEM_MOCKS = [
     },
   },
   getTagsQuery,
-  ...getOrganizationQuery
+  ...getOrganizationQuery,
+  getOrganizationLanguagesQuery,
 ];

--- a/src/containers/Form/FormLayout.tsx
+++ b/src/containers/Form/FormLayout.tsx
@@ -110,7 +110,11 @@ export const FormLayout: React.SFC<FormLayoutProps> = ({
   let toastMessage: {} | null | undefined;
 
   // get the organization for current user and have languages option set to that.
-  const organization = useQuery(ORGANIZATION_LANGUAGES);
+  const organization = useQuery(ORGANIZATION_LANGUAGES, {
+    onCompleted: (data: any) => {
+      setLanguageId(data.currentUser.user.organization.defaultLanguage.id);
+    },
+  });
 
   const capitalListItemName = listItemName[0].toUpperCase() + listItemName.slice(1);
 
@@ -126,7 +130,6 @@ export const FormLayout: React.SFC<FormLayoutProps> = ({
         setLanguageId(languageSupport ? item.language.id : null);
       }
     },
-    fetchPolicy: 'cache-and-network',
   });
   const camelCaseItem = listItem[0].toUpperCase() + listItem.slice(1);
 

--- a/src/containers/Form/FormLayout.tsx
+++ b/src/containers/Form/FormLayout.tsx
@@ -17,7 +17,7 @@ import { SEARCH_QUERY } from '../../graphql/queries/Search';
 import { SEARCH_QUERY_VARIABLES } from '../../common/constants';
 import { ToastMessage } from '../../components/UI/ToastMessage/ToastMessage';
 import { NOTIFICATION } from '../../graphql/queries/Notification';
-import { GET_ORGANIZATION } from '../../graphql/queries/Organization';
+import { ORGANIZATION_LANGUAGES } from '../../graphql/queries/Organization';
 
 export interface FormLayoutProps {
   match: any;
@@ -110,13 +110,9 @@ export const FormLayout: React.SFC<FormLayoutProps> = ({
   let toastMessage: {} | null | undefined;
 
   // get the organization for current user and have languages option set to that.
-  const organization = useQuery(GET_ORGANIZATION, {
+  const organization = useQuery(ORGANIZATION_LANGUAGES, {
     onCompleted: (data) => {
-      setLanguageId(data.organization.organization.activeLanguages[0].id);
-      client.writeQuery({
-        query: GET_ORGANIZATION,
-        data: data.organization,
-      });
+      setLanguageId(organization.data.currentUser.user.organization.activeLanguages[0].id);
     },
   });
 
@@ -292,7 +288,7 @@ export const FormLayout: React.SFC<FormLayoutProps> = ({
   };
 
   let languageOptions = organization.data
-    ? organization.data.organization.organization.activeLanguages.slice()
+    ? organization.data.currentUser.user.organization.activeLanguages.slice()
     : [];
   // sort languages by their name
   languageOptions.sort((first: any, second: any) => {

--- a/src/containers/Form/FormLayout.tsx
+++ b/src/containers/Form/FormLayout.tsx
@@ -17,7 +17,7 @@ import { SEARCH_QUERY } from '../../graphql/queries/Search';
 import { SEARCH_QUERY_VARIABLES } from '../../common/constants';
 import { ToastMessage } from '../../components/UI/ToastMessage/ToastMessage';
 import { NOTIFICATION } from '../../graphql/queries/Notification';
-import { ORGANIZATION_LANGUAGES } from '../../graphql/queries/Organization';
+import { USER_LANGUAGES } from '../../graphql/queries/Organization';
 
 export interface FormLayoutProps {
   match: any;
@@ -110,7 +110,7 @@ export const FormLayout: React.SFC<FormLayoutProps> = ({
   let toastMessage: {} | null | undefined;
 
   // get the organization for current user and have languages option set to that.
-  const organization = useQuery(ORGANIZATION_LANGUAGES, {
+  const organization = useQuery(USER_LANGUAGES, {
     onCompleted: (data: any) => {
       setLanguageId(data.currentUser.user.organization.defaultLanguage.id);
     },

--- a/src/containers/Form/FormLayout.tsx
+++ b/src/containers/Form/FormLayout.tsx
@@ -110,11 +110,7 @@ export const FormLayout: React.SFC<FormLayoutProps> = ({
   let toastMessage: {} | null | undefined;
 
   // get the organization for current user and have languages option set to that.
-  const organization = useQuery(ORGANIZATION_LANGUAGES, {
-    onCompleted: (data) => {
-      setLanguageId(organization.data.currentUser.user.organization.activeLanguages[0].id);
-    },
-  });
+  const organization = useQuery(ORGANIZATION_LANGUAGES);
 
   const capitalListItemName = listItemName[0].toUpperCase() + listItemName.slice(1);
 
@@ -130,6 +126,7 @@ export const FormLayout: React.SFC<FormLayoutProps> = ({
         setLanguageId(languageSupport ? item.language.id : null);
       }
     },
+    fetchPolicy: 'cache-and-network',
   });
   const camelCaseItem = listItem[0].toUpperCase() + listItem.slice(1);
 
@@ -153,6 +150,11 @@ export const FormLayout: React.SFC<FormLayoutProps> = ({
     onError: (error: ApolloError) => {
       setErrorMessage(client, error);
       return null;
+    },
+    refetchQueries: () => {
+      if (refetchQueries && refetchQueries.onUpdate) {
+        return [{ query: refetchQueries.onUpdate }];
+      } else return [];
     },
   });
 

--- a/src/containers/Group/Group.test.tsx
+++ b/src/containers/Group/Group.test.tsx
@@ -6,13 +6,16 @@ import { MockedProvider } from '@apollo/client/testing';
 import { Group } from './Group';
 import { getGroupQuery, getGroupsQuery, getGroupUsersQuery } from '../../mocks/Group';
 import { getUsersQuery } from '../../mocks/User';
-import { getOrganizationQuery } from '../../mocks/Organization';
+import { getOrganizationLanguagesQuery, getOrganizationQuery } from '../../mocks/Organization';
 
 const mocks = [
   getUsersQuery,
   ...getOrganizationQuery,
   getGroupQuery,
+  getOrganizationLanguagesQuery,
+  getOrganizationLanguagesQuery,
   getGroupQuery, // if you refetch then you need to include same mock twice
+  getGroupUsersQuery,
   getGroupUsersQuery,
   getGroupsQuery,
 ];

--- a/src/containers/List/List.test.helper.ts
+++ b/src/containers/List/List.test.helper.ts
@@ -1,7 +1,7 @@
 import { GET_TAGS_COUNT, FILTER_TAGS, GET_TAGS } from '../../graphql/queries/Tag';
 import { GET_LANGUAGES } from '../../graphql/queries/List';
 import { DELETE_TAG } from '../../graphql/mutations/Tag';
-import { getOrganizationQuery } from '../../mocks/Organization';
+import { getOrganizationLanguagesQuery, getOrganizationQuery } from '../../mocks/Organization';
 
 export const defaultProps = {
   columnNames: ['label', 'description', 'keywords', 'actions'],
@@ -193,5 +193,6 @@ export const LIST_MOCKS = [
   search,
   searchCount,
   getTags,
-  ...getOrganizationQuery
+  ...getOrganizationQuery,
+  getOrganizationLanguagesQuery,
 ];

--- a/src/containers/OrganisationSettings/OrganisationSettings.test.helper.ts
+++ b/src/containers/OrganisationSettings/OrganisationSettings.test.helper.ts
@@ -1,12 +1,12 @@
 import { GET_AUTOMATIONS } from '../../graphql/queries/Automation';
 import { GET_LANGUAGES } from '../../graphql/queries/List';
-import { getOrganizationQuery } from '../../mocks/Organization';
+import { getOrganizationLanguagesQuery, getOrganizationQuery } from '../../mocks/Organization';
 
 export const LIST_ITEM_MOCKS = [
   {
     request: {
       query: GET_LANGUAGES,
-      variables: { opts: {order: 'ASC'} },
+      variables: { opts: { order: 'ASC' } },
     },
     result: {
       data: {
@@ -65,5 +65,6 @@ export const LIST_ITEM_MOCKS = [
       },
     },
   },
-  ...getOrganizationQuery
+  ...getOrganizationQuery,
+  getOrganizationLanguagesQuery,
 ];

--- a/src/containers/OrganisationSettings/OrganisationSettings.tsx
+++ b/src/containers/OrganisationSettings/OrganisationSettings.tsx
@@ -10,7 +10,7 @@ import { AutoComplete } from '../../components/UI/Form/AutoComplete/AutoComplete
 import { Input } from '../../components/UI/Form/Input/Input';
 import { FormLayout } from '../Form/FormLayout';
 import { GET_AUTOMATIONS } from '../../graphql/queries/Automation';
-import { GET_ORGANIZATION } from '../../graphql/queries/Organization';
+import { GET_ORGANIZATION, ORGANIZATION_LANGUAGES } from '../../graphql/queries/Organization';
 import {
   CREATE_ORGANIZATION,
   DELETE_ORGANIZATION,
@@ -111,7 +111,7 @@ export const OrganisationSettings: React.SFC<SettingsProps> = () => {
 
   const { data } = useQuery(GET_AUTOMATIONS);
   const { data: languages } = useQuery(GET_LANGUAGES, {
-    variables: { opts: {order: 'ASC'} },
+    variables: { opts: { order: 'ASC' } },
   });
   const [getOrg, { data: orgData }] = useLazyQuery<any>(GET_ORGANIZATION);
 
@@ -305,6 +305,7 @@ export const OrganisationSettings: React.SFC<SettingsProps> = () => {
       listItemName="Settings"
       dialogMessage={''}
       formFields={formFields}
+      refetchQueries={{ onUpdate: ORGANIZATION_LANGUAGES }}
       redirectionLink=""
       cancelLink="chat"
       linkParameter="id"

--- a/src/containers/OrganisationSettings/OrganisationSettings.tsx
+++ b/src/containers/OrganisationSettings/OrganisationSettings.tsx
@@ -10,7 +10,7 @@ import { AutoComplete } from '../../components/UI/Form/AutoComplete/AutoComplete
 import { Input } from '../../components/UI/Form/Input/Input';
 import { FormLayout } from '../Form/FormLayout';
 import { GET_AUTOMATIONS } from '../../graphql/queries/Automation';
-import { GET_ORGANIZATION, ORGANIZATION_LANGUAGES } from '../../graphql/queries/Organization';
+import { GET_ORGANIZATION, USER_LANGUAGES } from '../../graphql/queries/Organization';
 import {
   CREATE_ORGANIZATION,
   DELETE_ORGANIZATION,
@@ -305,7 +305,7 @@ export const OrganisationSettings: React.SFC<SettingsProps> = () => {
       listItemName="Settings"
       dialogMessage={''}
       formFields={formFields}
-      refetchQueries={{ onUpdate: ORGANIZATION_LANGUAGES }}
+      refetchQueries={{ onUpdate: USER_LANGUAGES }}
       redirectionLink=""
       cancelLink="chat"
       linkParameter="id"

--- a/src/containers/StaffManagement/StaffManagement.test.helper.tsx
+++ b/src/containers/StaffManagement/StaffManagement.test.helper.tsx
@@ -6,7 +6,7 @@ import {
 } from '../../graphql/queries/User';
 import { GET_LANGUAGES } from '../../graphql/queries/List';
 import { GET_GROUPS } from '../../graphql/queries/Group';
-import { getOrganizationQuery } from '../../mocks/Organization';
+import { getOrganizationLanguagesQuery, getOrganizationQuery } from '../../mocks/Organization';
 
 export const STAFF_MANAGEMENT_MOCKS = [
   {
@@ -126,5 +126,6 @@ export const STAFF_MANAGEMENT_MOCKS = [
       },
     },
   },
-  ...getOrganizationQuery
+  ...getOrganizationQuery,
+  getOrganizationLanguagesQuery,
 ];

--- a/src/containers/Template/Template.test.helper.ts
+++ b/src/containers/Template/Template.test.helper.ts
@@ -5,7 +5,7 @@ import {
   GET_TEMPLATE,
 } from '../../graphql/queries/Template';
 import { DELETE_TEMPLATE, CREATE_TEMPLATE } from '../../graphql/mutations/Template';
-import { getOrganizationQuery } from '../../mocks/Organization';
+import { getOrganizationLanguagesQuery, getOrganizationQuery } from '../../mocks/Organization';
 
 const count = {
   request: {
@@ -293,4 +293,5 @@ export const TEMPLATE_MOCKS = [
   filterByBody(''),
   speedSendValidation,
   ...getOrganizationQuery,
+  getOrganizationLanguagesQuery,
 ];

--- a/src/graphql/queries/Organization.ts
+++ b/src/graphql/queries/Organization.ts
@@ -35,7 +35,7 @@ export const GET_ORGANIZATION = gql`
   }
 `;
 
-export const ORGANIZATION_LANGUAGES = gql`
+export const USER_LANGUAGES = gql`
   query currentUserOrganisationLanguages {
     currentUser {
       user {

--- a/src/graphql/queries/Organization.ts
+++ b/src/graphql/queries/Organization.ts
@@ -7,10 +7,8 @@ export const GET_ORGANIZATION = gql`
         id
         name
         provider {
-          apiEndPoint
           id
           name
-          url
         }
         providerAppname
         providerPhone
@@ -31,6 +29,21 @@ export const GET_ORGANIZATION = gql`
         activeLanguages {
           id
           label
+        }
+      }
+    }
+  }
+`;
+
+export const ORGANIZATION_LANGUAGES = gql`
+  query currentUserOrganisationLanguages {
+    currentUser {
+      user {
+        organization {
+          activeLanguages {
+            id
+            label
+          }
         }
       }
     }

--- a/src/graphql/queries/Organization.ts
+++ b/src/graphql/queries/Organization.ts
@@ -44,6 +44,10 @@ export const ORGANIZATION_LANGUAGES = gql`
             id
             label
           }
+          defaultLanguage {
+            id
+            label
+          }
         }
       }
     }

--- a/src/mocks/Chat.tsx
+++ b/src/mocks/Chat.tsx
@@ -10,6 +10,7 @@ import { filterTagsQuery, getTagsQuery } from './Tag';
 import { contactGroupsQuery } from './Contact';
 import { CREATE_AND_SEND_MESSAGE_MUTATION, UPDATE_MESSAGE_TAGS } from '../graphql/mutations/Chat';
 import { SEARCH_QUERY_VARIABLES as queryVariables } from '../common/constants';
+import { getOrganizationLanguagesQuery } from './Organization';
 
 const getConversationQuery = (data: any) => {
   return {
@@ -220,6 +221,7 @@ export const CONVERSATION_MOCKS = [
   addMessageTagSubscription,
   deleteMessageTagSubscription,
   savedSearchQuery,
+  getOrganizationLanguagesQuery,
   conversationMessageQuery('2', 'Jane Doe', '919090909009'),
   conversationMessageQuery('3', 'Jane Monroe', '919090709009'),
 ];

--- a/src/mocks/Contact.tsx
+++ b/src/mocks/Contact.tsx
@@ -6,7 +6,7 @@ import {
 } from '../graphql/queries/Contact';
 import { getCurrentUserQuery } from './User';
 import { filterTagsQuery } from './Tag';
-import { getOrganizationQuery } from '../mocks/Organization';
+import { getOrganizationLanguagesQuery, getOrganizationQuery } from '../mocks/Organization';
 import { UPDATE_CONTACT } from '../graphql/mutations/Contact';
 
 export const contactGroupsQuery = {
@@ -93,7 +93,9 @@ export const getContactDetailsQuery = {
 export const LOGGED_IN_USER_MOCK = [
   getCurrentUserQuery,
   getContactDetailsQuery,
+  getOrganizationLanguagesQuery,
   filterTagsQuery,
+  getCurrentUserQuery,
   getContactQuery,
   getContactDetailsQuery,
   ...getOrganizationQuery,

--- a/src/mocks/Organization.tsx
+++ b/src/mocks/Organization.tsx
@@ -149,6 +149,10 @@ export const getOrganizationLanguagesQuery = {
                 label: 'English',
               },
             ],
+            defaultLanguage: {
+              id: '1',
+              label: 'English',
+            },
           },
         },
       },

--- a/src/mocks/Organization.tsx
+++ b/src/mocks/Organization.tsx
@@ -1,4 +1,4 @@
-import { GET_ORGANIZATION, ORGANIZATION_LANGUAGES } from '../graphql/queries/Organization';
+import { GET_ORGANIZATION, USER_LANGUAGES } from '../graphql/queries/Organization';
 
 export const getOrganizationQuery = [
   {
@@ -136,7 +136,7 @@ export const getOrganizationQuery = [
 
 export const getOrganizationLanguagesQuery = {
   request: {
-    query: ORGANIZATION_LANGUAGES,
+    query: USER_LANGUAGES,
   },
   result: {
     data: {

--- a/src/mocks/Organization.tsx
+++ b/src/mocks/Organization.tsx
@@ -1,4 +1,4 @@
-import { GET_ORGANIZATION } from '../graphql/queries/Organization';
+import { GET_ORGANIZATION, ORGANIZATION_LANGUAGES } from '../graphql/queries/Organization';
 
 export const getOrganizationQuery = [
   {
@@ -33,10 +33,8 @@ export const getOrganizationQuery = [
               startTime: '12:31:27',
             },
             provider: {
-              apiEndPoint: 'https://api.gupshup.io/sm/api/v1',
               id: '1',
               name: 'Gupshup',
-              url: 'https://gupshup.io/',
             },
             providerAppname: 'ADD_PROVIDER_API_KEY',
             providerPhone: '917834811114',
@@ -79,10 +77,8 @@ export const getOrganizationQuery = [
               startTime: '12:31:27',
             },
             provider: {
-              apiEndPoint: 'https://api.gupshup.io/sm/api/v1',
               id: '1',
               name: 'Gupshup',
-              url: 'https://gupshup.io/',
             },
             providerAppname: 'ADD_PROVIDER_API_KEY',
             providerPhone: '917834811114',
@@ -125,10 +121,8 @@ export const getOrganizationQuery = [
               startTime: '12:31:27',
             },
             provider: {
-              apiEndPoint: 'https://api.gupshup.io/sm/api/v1',
               id: '1',
               name: 'Gupshup',
-              url: 'https://gupshup.io/',
             },
             providerAppname: 'ADD_PROVIDER_API_KEY',
             providerPhone: '917834811114',
@@ -137,5 +131,27 @@ export const getOrganizationQuery = [
         },
       },
     },
-  }
+  },
 ];
+
+export const getOrganizationLanguagesQuery = {
+  request: {
+    query: ORGANIZATION_LANGUAGES,
+  },
+  result: {
+    data: {
+      currentUser: {
+        user: {
+          organization: {
+            activeLanguages: [
+              {
+                id: '1',
+                label: 'English',
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Summary

Fixes to get active languages for user

## Test Plan

Updated.

## Note
For resources like tags, speed-sends, templates, profile etc where we have language dropdown, the active languages should show up fine. However, when you change the language, save, go to a different page and then come back, it'll still show the old language from the cache. Upon refresh, it's working fine.

This is currently being worked on on a separate branch.