### PR TITLE
Chat input clickable

### DIFF
--- a/src/components/UI/Form/WhatsAppEditor/WhatsAppEditor.module.css
+++ b/src/components/UI/Form/WhatsAppEditor/WhatsAppEditor.module.css
@@ -10,21 +10,8 @@
 }
 
 .Editor :global(.public-DraftEditor-content) > div {
-  height: 40px;
-  overflow: auto;
-}
-
-.Editor :global(.public-DraftEditor-content) > div::-webkit-scrollbar {
-  width: 22px;
-}
-
-.Editor :global(.public-DraftEditor-content) > div::-webkit-scrollbar-thumb {
-  border-radius: 5px;
-  background: lightgray;
-  height: 30px;
-  border: 0.5em solid rgba(0, 0, 0, 0);
-  background-clip: padding-box;
-  -webkit-border-radius: 1em;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 /* TODO: Override emoji-mart-emoji font-size to make it medium. */

--- a/src/components/UI/Form/WhatsAppEditor/WhatsAppEditor.module.css
+++ b/src/components/UI/Form/WhatsAppEditor/WhatsAppEditor.module.css
@@ -9,6 +9,24 @@
   min-height: 40px;
 }
 
+.Editor :global(.public-DraftEditor-content) > div {
+  height: 40px;
+  overflow: auto;
+}
+
+.Editor :global(.public-DraftEditor-content) > div::-webkit-scrollbar {
+  width: 22px;
+}
+
+.Editor :global(.public-DraftEditor-content) > div::-webkit-scrollbar-thumb {
+  border-radius: 5px;
+  background: lightgray;
+  height: 30px;
+  border: 0.5em solid rgba(0, 0, 0, 0);
+  background-clip: padding-box;
+  -webkit-border-radius: 1em;
+}
+
 /* TODO: Override emoji-mart-emoji font-size to make it medium. */
 span.emoji-mart-emoji {
   font-size: medium;


### PR DESCRIPTION
## Summary

I made some updates in such a way that there's just one line in the chat input (like WhatsApp). Having a second line would have been confusing and two lines were not in alignment with send and emoji buttons.