### PR TITLE
Group member delete bug fixed

### DIFF
--- a/src/graphql/queries/Contact.ts
+++ b/src/graphql/queries/Contact.ts
@@ -70,6 +70,13 @@ export const GET_CONTACT = gql`
           id
           label
         }
+        groups {
+          id
+          label
+          users {
+            name
+          }
+        }
         status
         bspStatus
         settings


### PR DESCRIPTION
## Summary

The contact profile will not show the group after removal of the contact form the group.
