### PR TITLE
Added restriction checkbox for staff role

### DIFF
--- a/src/components/UI/Form/AutoComplete/AutoComplete.tsx
+++ b/src/components/UI/Form/AutoComplete/AutoComplete.tsx
@@ -173,7 +173,15 @@ export const AutoComplete: React.SFC<AutocompleteProps> = ({
         ) : null}
 
         {helpLink ? (
-          <div className={styles.HelpLink} onClick={()=>helpLink.handleClick()}>{helpLink.label}</div>
+          <div
+            className={styles.HelpLink}
+            onKeyDown={() => helpLink.handleClick()}
+            onClick={() => helpLink.handleClick()}
+            role="button"
+            tabIndex={0}
+          >
+            {helpLink.label}
+          </div>
         ) : null}
       </FormControl>
     </div>

--- a/src/components/UI/Form/AutoComplete/AutoComplete.tsx
+++ b/src/components/UI/Form/AutoComplete/AutoComplete.tsx
@@ -24,6 +24,7 @@ export interface AutocompleteProps {
   noOptionsText?: any;
   onChange?: any;
   asyncSearch?: boolean;
+  roleSelection?: any;
 }
 
 export const AutoComplete: React.SFC<AutocompleteProps> = ({
@@ -39,6 +40,7 @@ export const AutoComplete: React.SFC<AutocompleteProps> = ({
   disabled = false,
   getOptions,
   asyncValues,
+  roleSelection,
   onChange,
   asyncSearch = false,
   noOptionsText = 'No options available',
@@ -81,6 +83,9 @@ export const AutoComplete: React.SFC<AutocompleteProps> = ({
           options={optionValue}
           getOptionLabel={(option: any) => (option[optionLabel] ? option[optionLabel] : '')}
           onChange={(event, value: any) => {
+            if (roleSelection) {
+              roleSelection(value);
+            }
             if (asyncSearch) {
               const filterValues = asyncValues.value.filter(
                 (val: any) => val.id !== value[value.length - 1].id

--- a/src/containers/Form/FormLayout.tsx
+++ b/src/containers/Form/FormLayout.tsx
@@ -249,6 +249,7 @@ export const FormLayout: React.SFC<FormLayoutProps> = ({
       }
     });
 
+    console.log(payload);
     if (itemId) {
       updateItem({
         variables: {

--- a/src/containers/Form/FormLayout.tsx
+++ b/src/containers/Form/FormLayout.tsx
@@ -249,7 +249,6 @@ export const FormLayout: React.SFC<FormLayoutProps> = ({
       }
     });
 
-    console.log(payload);
     if (itemId) {
       updateItem({
         variables: {

--- a/src/containers/StaffManagement/StaffManagement.tsx
+++ b/src/containers/StaffManagement/StaffManagement.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import * as Yup from 'yup';
 import { useQuery } from '@apollo/client';
 
@@ -12,6 +12,7 @@ import { GET_GROUPS } from '../../graphql/queries/Group';
 import { ReactComponent as StaffManagementIcon } from '../../assets/images/icons/StaffManagement/Active.svg';
 import { isManagerRole } from '../../context/role';
 import { setVariables } from '../../common/constants';
+import { Checkbox } from '../../components/UI/Form/Checkbox/Checkbox';
 
 export interface StaffManagementProps {
   match: any;
@@ -31,15 +32,18 @@ const queries = {
 export const StaffManagement: React.SFC<StaffManagementProps> = ({ match }) => {
   const [name, setName] = useState('');
   const [phone, setPhone] = useState('');
-  const [roles, setRoles] = useState([]);
+  const [roles, setRoles] = useState<Array<any>>([]);
   const [groups, setGroups] = useState([]);
+  const [isRestricted, setIsRestricted] = useState(false);
+  const [staffRole, setStaffRole] = useState(false);
 
-  const states = { name, phone, roles, groups };
+  const states = { name, phone, roles, groups, isRestricted };
   const setStates = ({
     name: nameValue,
     phone: phoneValue,
     roles: rolesValue,
     groups: groupsValue,
+    isRestricted: isRestrictedValue,
   }: any) => {
     setName(nameValue);
     setPhone(phoneValue);
@@ -53,6 +57,7 @@ export const StaffManagement: React.SFC<StaffManagementProps> = ({ match }) => {
       setRoles(defaultRoles);
     }
     setGroups(groupsValue);
+    setIsRestricted(isRestrictedValue);
   };
 
   const { loading: loadingRoles, data: roleData } = useQuery(GET_USER_ROLES);
@@ -60,6 +65,12 @@ export const StaffManagement: React.SFC<StaffManagementProps> = ({ match }) => {
   const { loading, data } = useQuery(GET_GROUPS, {
     variables: setVariables(),
   });
+
+  useEffect(() => {
+    if (roles.map((role: any) => role.label).includes('Staff')) {
+      setStaffRole(true);
+    }
+  }, [roles]);
 
   if (loading || loadingRoles) return <Loading />;
 
@@ -85,7 +96,18 @@ export const StaffManagement: React.SFC<StaffManagementProps> = ({ match }) => {
     return options;
   };
 
-  const formFields = [
+  let formFields: any = [];
+
+  const handleRolesChange = (value: any) => {
+    const hasStaffRole = value.map((good: any) => good.label).includes('Staff');
+    if (hasStaffRole) {
+      setStaffRole(true);
+    } else {
+      setStaffRole(false);
+    }
+  };
+
+  formFields = [
     {
       component: Input,
       name: 'name',
@@ -104,6 +126,7 @@ export const StaffManagement: React.SFC<StaffManagementProps> = ({ match }) => {
       name: 'roles',
       placeholder: 'Roles',
       options: rolesList,
+      roleSelection: handleRolesChange,
       getOptions,
       optionLabel: 'label',
       textFieldProps: {
@@ -123,6 +146,17 @@ export const StaffManagement: React.SFC<StaffManagementProps> = ({ match }) => {
       },
     },
   ];
+
+  if (staffRole) {
+    formFields = [
+      ...formFields,
+      {
+        component: Checkbox,
+        name: 'isRestricted',
+        title: 'Can chat with group contacts only',
+      },
+    ];
+  }
 
   const FormSchema = Yup.object().shape({
     name: Yup.string().required('Name is required.'),

--- a/src/containers/StaffManagement/StaffManagement.tsx
+++ b/src/containers/StaffManagement/StaffManagement.tsx
@@ -39,7 +39,7 @@ export const StaffManagement: React.SFC<StaffManagementProps> = ({ match }) => {
   const [isRestricted, setIsRestricted] = useState(false);
   const [staffRole, setStaffRole] = useState(false);
   const [helpDialog, setHelpDialog] = useState(false);
-  
+
   let dialog;
 
   if (helpDialog) {
@@ -155,7 +155,7 @@ export const StaffManagement: React.SFC<StaffManagementProps> = ({ match }) => {
   const handleHelpClick = () => {
     setHelpDialog(true);
   };
- 
+
   formFields = [
     {
       component: Input,

--- a/src/graphql/mutations/User.ts
+++ b/src/graphql/mutations/User.ts
@@ -18,6 +18,7 @@ export const UPDATE_USER = gql`
         id
         name
         phone
+        isRestricted
         roles
         groups {
           id

--- a/src/graphql/queries/User.ts
+++ b/src/graphql/queries/User.ts
@@ -7,6 +7,7 @@ export const GET_USERS_QUERY = gql`
         id
         name
         phone
+        isRestricted
         roles
         groups {
           id


### PR DESCRIPTION
## Summary

If the user role will be staff then a checkbox will be added on the staff edit screen to restrict the access of the staff.

Targets one of the subfeatures in #717