### PR TITLE
Automation autosave when moving out of floweditor removed 

### DIFF
--- a/src/components/floweditor/FlowEditor.tsx
+++ b/src/components/floweditor/FlowEditor.tsx
@@ -228,6 +228,11 @@ export const FlowEditor = (props: FlowEditorProps) => {
           document.body.removeChild(files[node]);
         }
       });
+      // clearing all timeouts when component unmounts
+      const highestTimeoutId = setTimeout(() => {});
+      for (let timeoutId = 0; timeoutId < highestTimeoutId; timeoutId += 1) {
+        clearTimeout(timeoutId);
+      }
     };
   }, []);
 


### PR DESCRIPTION
## Summary

When the flow editor component unmounts it will stop all the repetitive autosave calls.
