### PR TITLE
Send OTP twice bug resolved

### DIFF
--- a/src/containers/Auth/Auth.module.css
+++ b/src/containers/Auth/Auth.module.css
@@ -212,3 +212,7 @@
 .OTPBox fieldset {
   border-color: #93a29b !important;
 }
+
+.SubmitAction {
+  display: none;
+}

--- a/src/containers/Auth/Auth.tsx
+++ b/src/containers/Auth/Auth.tsx
@@ -138,7 +138,6 @@ export const Auth: React.SFC<AuthProps> = (props) => {
                   const key = index;
                   return <Field className={styles.Form} key={key} {...fieldInfo} />;
                 })}
-
                 <div className={styles.Link}>
                   <Link to={`/${linkURL}`}>{linkText}</Link>
                 </div>
@@ -154,6 +153,10 @@ export const Auth: React.SFC<AuthProps> = (props) => {
                     {loading ? null : buttonText}
                   </Button>
                 </div>
+                {/* We neeed to add this submit button to enable form sumbitting when user hits enter
+                key. This is an workaround solution till the bug in formik or react is fixed. For
+                more info: https://github.com/formium/formik/issues/1418 */}
+                <input className={styles.SubmitAction} type="submit" />
               </Form>
               {displayErrorMessage}
               {staffInstructions}

--- a/src/containers/Auth/Auth.tsx
+++ b/src/containers/Auth/Auth.tsx
@@ -150,7 +150,6 @@ export const Auth: React.SFC<AuthProps> = (props) => {
                     className={styles.AuthButton}
                     data-testid="SubmitButton"
                     loading={loading}
-                    type="submit"
                   >
                     {loading ? null : buttonText}
                   </Button>


### PR DESCRIPTION
## Summary

Here is a reference to the solution: https://stackoverflow.com/questions/61557815/react-formik-onsubmit-async-called-twice#comment108889373_61557815


