### PR TITLE
Fixed notifications for adding to group and speed sends

### DIFF
--- a/src/containers/Chat/ChatMessages/AddToMessageTemplate/AddToMessageTemplate.tsx
+++ b/src/containers/Chat/ChatMessages/AddToMessageTemplate/AddToMessageTemplate.tsx
@@ -27,6 +27,9 @@ export const AddToMessageTemplate: React.SFC<AddToMessageTemplateProps> = ({
   const [required, setRequired] = useState(false);
 
   const [saveTemplate] = useMutation(SAVE_MESSAGE_TEMPLATE_MUTATION, {
+    onCompleted: () => {
+      setNotification(client, 'Message has been successfully added to speed sends.');
+    },
     refetchQueries: [
       {
         query: FILTER_TEMPLATES,
@@ -83,7 +86,6 @@ export const AddToMessageTemplate: React.SFC<AddToMessageTemplateProps> = ({
         },
       });
       changeDisplay(false);
-      setNotification(client, 'Message has been successfully added to speed sends.');
       setMessageTemplate(null);
     }
   };

--- a/src/containers/Chat/ChatMessages/ContactBar/ContactBar.tsx
+++ b/src/containers/Chat/ChatMessages/ContactBar/ContactBar.tsx
@@ -94,7 +94,28 @@ export const ContactBar: React.SFC<ContactBarProps> = (props) => {
   }, []);
 
   // mutation to update the contact groups
-  const [updateContactGroups] = useMutation(UPDATE_CONTACT_GROUPS);
+  const [updateContactGroups] = useMutation(UPDATE_CONTACT_GROUPS, {
+    onCompleted: (result: any) => {
+      const { numberDeleted, contactGroups } = result.updateContactGroups;
+      const numberAdded = contactGroups.length;
+      if (numberDeleted > 0 && numberAdded > 0) {
+        setNotification(
+          client,
+          `Added to ${numberDeleted} group${
+            numberDeleted === 1 ? '' : 's  and'
+          } removed from ${numberAdded} group${numberAdded === 1 ? '' : 's '}`
+        );
+      } else if (numberDeleted > 0) {
+        setNotification(
+          client,
+          `Removed from ${numberDeleted} group${numberDeleted === 1 ? '' : 's'}`
+        );
+      } else {
+        setNotification(client, `Added to ${numberAdded} group${numberAdded === 1 ? '' : 's'}`);
+      }
+    },
+    refetchQueries: [{ query: GET_CONTACT_GROUPS, variables: { id: contactId } }],
+  });
 
   const [blockContact] = useMutation(UPDATE_CONTACT, {
     onCompleted: () => {
@@ -170,12 +191,6 @@ export const ContactBar: React.SFC<ContactBarProps> = (props) => {
           },
         },
       });
-    }
-
-    if (finalSelectedGroups.length > 0) {
-      setNotification(client, 'Added to group succesfully');
-    } else if (finalRemovedGroups.length > 0) {
-      setNotification(client, 'Removed from group succesfully');
     }
 
     setShowGroupDialog(false);

--- a/src/containers/Chat/ChatMessages/ContactBar/ContactBar.tsx
+++ b/src/containers/Chat/ChatMessages/ContactBar/ContactBar.tsx
@@ -98,21 +98,15 @@ export const ContactBar: React.SFC<ContactBarProps> = (props) => {
     onCompleted: (result: any) => {
       const { numberDeleted, contactGroups } = result.updateContactGroups;
       const numberAdded = contactGroups.length;
+      let notification = `Added to ${numberAdded} group${numberAdded === 1 ? '' : 's'}`;
       if (numberDeleted > 0 && numberAdded > 0) {
-        setNotification(
-          client,
-          `Added to ${numberDeleted} group${
-            numberDeleted === 1 ? '' : 's  and'
-          } removed from ${numberAdded} group${numberAdded === 1 ? '' : 's '}`
-        );
+        notification = `Added to ${numberDeleted} group${
+          numberDeleted === 1 ? '' : 's  and'
+        } removed from ${numberAdded} group${numberAdded === 1 ? '' : 's '}`;
       } else if (numberDeleted > 0) {
-        setNotification(
-          client,
-          `Removed from ${numberDeleted} group${numberDeleted === 1 ? '' : 's'}`
-        );
-      } else {
-        setNotification(client, `Added to ${numberAdded} group${numberAdded === 1 ? '' : 's'}`);
+        notification = `Removed from ${numberDeleted} group${numberDeleted === 1 ? '' : 's'}`;
       }
+      setNotification(client, notification);
     },
     refetchQueries: [{ query: GET_CONTACT_GROUPS, variables: { id: contactId } }],
   });

--- a/src/graphql/mutations/Group.ts
+++ b/src/graphql/mutations/Group.ts
@@ -18,6 +18,7 @@ export const UPDATE_CONTACT_GROUPS = gql`
         id
         value
       }
+      numberDeleted
     }
   }
 `;


### PR DESCRIPTION

## Summary

- [x] After adding a contact to the group from the chat screen,
  - It should display the added group in groups under the contact.
  - It should display a successful message.
- [x]  After adding the speed send from the chat screen, the display of a successful message does not display.