### PR TITLE
Fixed icon size for search

### DIFF
--- a/src/components/UI/SearchBar/SearchBar.module.css
+++ b/src/components/UI/SearchBar/SearchBar.module.css
@@ -27,6 +27,7 @@
 
 .SearchIcon {
   margin-left: 8px;
+  width: 24px;
   vertical-align: middle;
 }
 


### PR DESCRIPTION

## Summary

On some screens, the search icon was larger than its actual size. So, added a fixed size for the icon