### PR TITLE
Search fixes

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -26,29 +26,29 @@ export const CONTACT_STATUS = [
   { id: 'FAILED', label: 'Failed' },
 ];
 
-// show conversation load more if count is greater than below
-export const SHOW_CONVERSATION_LOAD_MORE = 24;
+// default contact limit for search
+export const DEFAULT_CONTACT_LIMIT = 24;
 
-// show message load more if count is greater than below
-export const SHOW_MESSAGE_LOAD_MORE = 19;
+// default message limit for search
+export const DEFAULT_MESSAGE_LIMIT = 19;
 
 export const SEARCH_QUERY_VARIABLES = {
   contactOpts: {
-    limit: 25,
+    limit: DEFAULT_CONTACT_LIMIT,
   },
   filter: {},
   messageOpts: {
-    limit: 20,
+    limit: DEFAULT_MESSAGE_LIMIT,
   },
 };
 
 export const COLLECTION_SEARCH_QUERY_VARIABLES = {
   contactOpts: {
-    limit: 25,
+    limit: DEFAULT_CONTACT_LIMIT,
   },
   filter: { searchGroup: true },
   messageOpts: {
-    limit: 20,
+    limit: DEFAULT_MESSAGE_LIMIT,
   },
 };
 

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -27,10 +27,16 @@ export const CONTACT_STATUS = [
 ];
 
 // default contact limit for search
-export const DEFAULT_CONTACT_LIMIT = 24;
+export const DEFAULT_CONTACT_LIMIT = 25;
+
+// load more contact limit
+export const DEFAULT_CONTACT_LOADMORE_LIMIT = 10;
 
 // default message limit for search
-export const DEFAULT_MESSAGE_LIMIT = 19;
+export const DEFAULT_MESSAGE_LIMIT = 20;
+
+// load more message limit
+export const DEFAULT_MESSAGE_LOADMORE_LIMIT = 10;
 
 export const SEARCH_QUERY_VARIABLES = {
   contactOpts: {

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -26,6 +26,12 @@ export const CONTACT_STATUS = [
   { id: 'FAILED', label: 'Failed' },
 ];
 
+// show conversation load more if count is greater than below
+export const SHOW_CONVERSATION_LOAD_MORE = 24;
+
+// show message load more if count is greater than below
+export const SHOW_MESSAGE_LOAD_MORE = 19;
+
 export const SEARCH_QUERY_VARIABLES = {
   contactOpts: {
     limit: 25,

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -28,21 +28,21 @@ export const CONTACT_STATUS = [
 
 export const SEARCH_QUERY_VARIABLES = {
   contactOpts: {
-    limit: 50,
+    limit: 25,
   },
   filter: {},
   messageOpts: {
-    limit: 50,
+    limit: 20,
   },
 };
 
 export const COLLECTION_SEARCH_QUERY_VARIABLES = {
   contactOpts: {
-    limit: 50,
+    limit: 25,
   },
   filter: { searchGroup: true },
   messageOpts: {
-    limit: 50,
+    limit: 20,
   },
 };
 

--- a/src/containers/Chat/Chat.test.tsx
+++ b/src/containers/Chat/Chat.test.tsx
@@ -6,14 +6,15 @@ import { setUserSession } from '../../services/AuthService';
 
 import { ApolloClient, ApolloProvider, InMemoryCache } from '@apollo/client';
 import { SEARCH_QUERY } from '../../graphql/queries/Search';
+import { DEFAULT_CONTACT_LIMIT, DEFAULT_MESSAGE_LIMIT } from '../../common/constants';
 
 const cache = new InMemoryCache({ addTypename: false });
 cache.writeQuery({
   query: SEARCH_QUERY,
   variables: {
-    contactOpts: { limit: 25 },
+    contactOpts: { limit: DEFAULT_CONTACT_LIMIT },
     filter: {},
-    messageOpts: { limit: 20 },
+    messageOpts: { limit: DEFAULT_MESSAGE_LIMIT },
   },
   data: {
     search: [

--- a/src/containers/Chat/Chat.test.tsx
+++ b/src/containers/Chat/Chat.test.tsx
@@ -11,9 +11,9 @@ const cache = new InMemoryCache({ addTypename: false });
 cache.writeQuery({
   query: SEARCH_QUERY,
   variables: {
+    contactOpts: { limit: 25 },
     filter: {},
-    messageOpts: { limit: 50 },
-    contactOpts: { limit: 50 },
+    messageOpts: { limit: 20 },
   },
   data: {
     search: [

--- a/src/containers/Chat/ChatConversations/ChatConversations.test.helper.ts
+++ b/src/containers/Chat/ChatConversations/ChatConversations.test.helper.ts
@@ -68,22 +68,26 @@ const searchQuery = (
 };
 
 export const chatConversationsMocks = [
-  searchQuery({ limit: 50 }, 50, {}),
-  searchQuery({ limit: 50 }, 50, { term: 'a' }, false),
-  searchQuery({ limit: 50 }, 50, { term: '' }),
-  searchQuery({ limit: 5 }, 10, { includeTags: ['12'] }, false),
-  searchQuery({ limit: 50 }, 1, {}, false),
-  searchQuery({ limit: 50, offset: 0 }, 1, { id: '6' }, false),
+  searchQuery({ limit: 25 }, 20, {}),
+  searchQuery({ limit: 25 }, 20, { term: 'a' }, false),
+  searchQuery({ limit: 25 }, 20, { term: '' }),
+  searchQuery({ limit: 25 }, 20, { includeTags: ['12'] }, false),
+  searchQuery({ limit: 25 }, 1, {}, false),
+  searchQuery({ limit: 25, offset: 0 }, 1, { id: '6' }, false),
 ];
 
-export const searchMultiQuery = (term: string = '', limit: number = 50) => {
+export const searchMultiQuery = (
+  term: string = '',
+  contactLimit: number = 25,
+  messageLimit: number = 20
+) => {
   return {
     request: {
       query: SEARCH_MULTI_QUERY,
       variables: {
+        contactOpts: { order: 'DESC', contactLimit },
         searchFilter: { term },
-        messageOpts: { limit, order: 'ASC' },
-        contactOpts: { order: 'DESC', limit },
+        messageOpts: { messageLimit, order: 'ASC' },
       },
     },
     result: {
@@ -208,5 +212,5 @@ export const ChatConversationMocks = [
   searchOffset,
 ];
 
-export const searchQueryMock = searchQuery({ limit: 50 }, 50, { term: '' });
-export const searchQueryEmptyMock = searchQuery({ limit: 50 }, 50, {});
+export const searchQueryMock = searchQuery({ limit: 25 }, 20, { term: '' });
+export const searchQueryEmptyMock = searchQuery({ limit: 25 }, 20, {});

--- a/src/containers/Chat/ChatConversations/ChatConversations.test.helper.ts
+++ b/src/containers/Chat/ChatConversations/ChatConversations.test.helper.ts
@@ -1,5 +1,6 @@
 import { savedSearchQuery } from '../../../mocks/Chat';
 import { SEARCH_QUERY, SEARCH_MULTI_QUERY, SEARCH_OFFSET } from '../../../graphql/queries/Search';
+import { DEFAULT_CONTACT_LIMIT, DEFAULT_MESSAGE_LIMIT } from '../../../common/constants';
 
 const withResult = {
   data: {
@@ -68,18 +69,23 @@ const searchQuery = (
 };
 
 export const chatConversationsMocks = [
-  searchQuery({ limit: 25 }, 20, {}),
-  searchQuery({ limit: 25 }, 20, { term: 'a' }, false),
-  searchQuery({ limit: 25 }, 20, { term: '' }),
-  searchQuery({ limit: 25 }, 20, { includeTags: ['12'] }, false),
-  searchQuery({ limit: 25 }, 1, {}, false),
-  searchQuery({ limit: 25, offset: 0 }, 1, { id: '6' }, false),
+  searchQuery({ limit: DEFAULT_CONTACT_LIMIT }, DEFAULT_MESSAGE_LIMIT, {}),
+  searchQuery({ limit: DEFAULT_CONTACT_LIMIT }, DEFAULT_MESSAGE_LIMIT, { term: 'a' }, false),
+  searchQuery({ limit: DEFAULT_CONTACT_LIMIT }, DEFAULT_MESSAGE_LIMIT, { term: '' }),
+  searchQuery(
+    { limit: DEFAULT_CONTACT_LIMIT },
+    DEFAULT_MESSAGE_LIMIT,
+    { includeTags: ['12'] },
+    false
+  ),
+  searchQuery({ limit: DEFAULT_CONTACT_LIMIT }, 1, {}, false),
+  searchQuery({ limit: DEFAULT_CONTACT_LIMIT, offset: 0 }, 1, { id: '6' }, false),
 ];
 
 export const searchMultiQuery = (
   term: string = '',
-  contactLimit: number = 25,
-  messageLimit: number = 20
+  contactLimit: number = DEFAULT_CONTACT_LIMIT,
+  messageLimit: number = DEFAULT_MESSAGE_LIMIT
 ) => {
   return {
     request: {
@@ -212,5 +218,13 @@ export const ChatConversationMocks = [
   searchOffset,
 ];
 
-export const searchQueryMock = searchQuery({ limit: 25 }, 20, { term: '' });
-export const searchQueryEmptyMock = searchQuery({ limit: 25 }, 20, {});
+export const searchQueryMock = searchQuery(
+  { limit: DEFAULT_CONTACT_LIMIT },
+  DEFAULT_MESSAGE_LIMIT,
+  { term: '' }
+);
+export const searchQueryEmptyMock = searchQuery(
+  { limit: DEFAULT_CONTACT_LIMIT },
+  DEFAULT_MESSAGE_LIMIT,
+  {}
+);

--- a/src/containers/Chat/ChatConversations/ChatConversations.test.tsx
+++ b/src/containers/Chat/ChatConversations/ChatConversations.test.tsx
@@ -5,14 +5,15 @@ import ChatConversations from './ChatConversations';
 
 import { ApolloClient, ApolloProvider, InMemoryCache } from '@apollo/client';
 import { SEARCH_QUERY } from '../../../graphql/queries/Search';
+import { DEFAULT_CONTACT_LIMIT, DEFAULT_MESSAGE_LIMIT } from '../../../common/constants';
 
 const cache = new InMemoryCache({ addTypename: false });
 cache.writeQuery({
   query: SEARCH_QUERY,
   variables: {
+    contactOpts: { limit: DEFAULT_CONTACT_LIMIT },
     filter: {},
-    messageOpts: { limit: 50 },
-    contactOpts: { limit: 50 },
+    messageOpts: { limit: DEFAULT_MESSAGE_LIMIT },
   },
   data: {
     search: [

--- a/src/containers/Chat/ChatConversations/ChatConversations.tsx
+++ b/src/containers/Chat/ChatConversations/ChatConversations.tsx
@@ -243,6 +243,7 @@ export const ChatConversations: React.SFC<ChatConversationsProps> = (props) => {
           setSelectedContactId(i);
         }}
         savedSearchCriteria={savedSearchCriteria}
+        savedSearchCriteriaId={savedSearchCriteriaId}
       />
       {saveSearchButton}
       {dialogBox}

--- a/src/containers/Chat/ChatConversations/ConversationList/ConversationList.tsx
+++ b/src/containers/Chat/ChatConversations/ConversationList/ConversationList.tsx
@@ -448,7 +448,7 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
       {conversationList ? (
         <List className={styles.StyledList}>
           {conversationList}
-          {showLoadMore && conversations.length > 19 ? (
+          {showLoadMore && conversations.length > 24 ? (
             <div className={styles.LoadMore}>
               {showLoading ? (
                 <CircularProgress className={styles.Progress} />

--- a/src/containers/Chat/ChatConversations/ConversationList/ConversationList.tsx
+++ b/src/containers/Chat/ChatConversations/ConversationList/ConversationList.tsx
@@ -17,7 +17,8 @@ import { setErrorMessage } from '../../../../common/notification';
 import {
   COLLECTION_SEARCH_QUERY_VARIABLES,
   SEARCH_QUERY_VARIABLES,
-  SHOW_CONVERSATION_LOAD_MORE,
+  DEFAULT_CONTACT_LIMIT,
+  DEFAULT_MESSAGE_LIMIT,
 } from '../../../../common/constants';
 import { updateConversations } from '../../../../services/ChatService';
 import { showMessages } from '../../../../common/responsive';
@@ -44,7 +45,7 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
     selectedCollectionId,
   } = props;
   const client = useApolloClient();
-  const [loadingOffset, setLoadingOffset] = useState(25);
+  const [loadingOffset, setLoadingOffset] = useState(DEFAULT_CONTACT_LIMIT);
   const [showJumpToLatest, setShowJumpToLatest] = useState(false);
   const [showLoadMore, setShowLoadMore] = useState(true);
   const [showLoading, setShowLoading] = useState(false);
@@ -118,11 +119,11 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
 
     return {
       contactOpts: {
-        limit: 25,
+        limit: DEFAULT_CONTACT_LIMIT,
       },
       filter,
       messageOpts: {
-        limit: 20,
+        limit: DEFAULT_MESSAGE_LIMIT,
       },
     };
   };
@@ -130,14 +131,14 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
   const filterSearch = () => {
     return {
       contactOpts: {
+        limit: DEFAULT_CONTACT_LIMIT,
         order: 'DESC',
-        limit: 25,
       },
       searchFilter: {
         term: props.searchVal,
       },
       messageOpts: {
-        limit: 20,
+        limit: DEFAULT_MESSAGE_LIMIT,
         order: 'ASC',
       },
     };
@@ -160,7 +161,7 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
   useEffect(() => {
     let offsetValue = 0;
     if (offset.data) {
-      offsetValue = offset.data.offset - 25 <= 0 ? 0 : offset.data.offset - 10; // calculate offset
+      offsetValue = offset.data.offset - DEFAULT_CONTACT_LIMIT <= 0 ? 0 : offset.data.offset - 10; // calculate offset
     }
     if (offsetValue) {
       let loadMoreVariables;
@@ -173,7 +174,7 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
             id: selectedContactId,
           },
           messageOpts: {
-            limit: 20,
+            limit: DEFAULT_MESSAGE_LIMIT,
             offset: offsetValue,
           },
         };
@@ -187,7 +188,7 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
             searchGroup: true,
           },
           messageOpts: {
-            limit: 20,
+            limit: DEFAULT_MESSAGE_LIMIT,
             offset: offsetValue,
           },
         };
@@ -402,7 +403,7 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
       },
       filter: {},
       messageOpts: {
-        limit: 20,
+        limit: DEFAULT_MESSAGE_LIMIT,
       },
     };
 
@@ -452,7 +453,7 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
       {conversationList ? (
         <List className={styles.StyledList}>
           {conversationList}
-          {showLoadMore && conversations.length > SHOW_CONVERSATION_LOAD_MORE ? (
+          {showLoadMore && conversations.length > DEFAULT_CONTACT_LIMIT - 1 ? (
             <div className={styles.LoadMore}>
               {showLoading ? (
                 <CircularProgress className={styles.Progress} />

--- a/src/containers/Chat/ChatConversations/ConversationList/ConversationList.tsx
+++ b/src/containers/Chat/ChatConversations/ConversationList/ConversationList.tsx
@@ -41,7 +41,7 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
     selectedCollectionId,
   } = props;
   const client = useApolloClient();
-  const [loadingOffset, setLoadingOffset] = useState(50);
+  const [loadingOffset, setLoadingOffset] = useState(25);
   const [showJumpToLatest, setShowJumpToLatest] = useState(false);
   const [showLoadMore, setShowLoadMore] = useState(true);
   const [showLoading, setShowLoading] = useState(false);
@@ -114,12 +114,12 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
     }
 
     return {
+      contactOpts: {
+        limit: 25,
+      },
       filter,
       messageOpts: {
-        limit: 50,
-      },
-      contactOpts: {
-        limit: 50,
+        limit: 20,
       },
     };
   };
@@ -130,12 +130,12 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
         term: props.searchVal,
       },
       messageOpts: {
-        limit: 50,
+        limit: 20,
         order: 'ASC',
       },
       contactOpts: {
         order: 'DESC',
-        limit: 50,
+        limit: 25,
       },
     };
   };
@@ -170,7 +170,7 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
             id: selectedContactId,
           },
           messageOpts: {
-            limit: 50,
+            limit: 20,
             offset: offsetValue,
           },
         };
@@ -184,7 +184,7 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
             searchGroup: true,
           },
           messageOpts: {
-            limit: 50,
+            limit: 20,
             offset: offsetValue,
           },
         };
@@ -398,7 +398,7 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
       },
       filter: {},
       messageOpts: {
-        limit: 50,
+        limit: 20,
       },
     };
 
@@ -448,7 +448,7 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
       {conversationList ? (
         <List className={styles.StyledList}>
           {conversationList}
-          {showLoadMore && conversations.length > 49 ? (
+          {showLoadMore && conversations.length > 19 ? (
             <div className={styles.LoadMore}>
               {showLoading ? (
                 <CircularProgress className={styles.Progress} />

--- a/src/containers/Chat/ChatConversations/ConversationList/ConversationList.tsx
+++ b/src/containers/Chat/ChatConversations/ConversationList/ConversationList.tsx
@@ -19,6 +19,7 @@ import {
   SEARCH_QUERY_VARIABLES,
   DEFAULT_CONTACT_LIMIT,
   DEFAULT_MESSAGE_LIMIT,
+  DEFAULT_CONTACT_LOADMORE_LIMIT,
 } from '../../../../common/constants';
 import { updateConversations } from '../../../../services/ChatService';
 import { showMessages } from '../../../../common/responsive';
@@ -152,7 +153,7 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
         // save the conversation and update cache
         updateConversations(searchData, client, queryVariables);
 
-        setLoadingOffset(loadingOffset + 10);
+        setLoadingOffset(loadingOffset + DEFAULT_CONTACT_LOADMORE_LIMIT);
       }
     },
   });
@@ -161,7 +162,10 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
   useEffect(() => {
     let offsetValue = 0;
     if (offset.data) {
-      offsetValue = offset.data.offset - DEFAULT_CONTACT_LIMIT <= 0 ? 0 : offset.data.offset - 10; // calculate offset
+      offsetValue =
+        offset.data.offset - DEFAULT_CONTACT_LIMIT <= 0
+          ? 0
+          : offset.data.offset - DEFAULT_CONTACT_LOADMORE_LIMIT; // calculate offset
     }
     if (offsetValue) {
       let loadMoreVariables;
@@ -398,7 +402,7 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
   const loadMoreMessages = () => {
     const conversationLoadMoreVariables = {
       contactOpts: {
-        limit: 10,
+        limit: DEFAULT_CONTACT_LOADMORE_LIMIT,
         offset: loadingOffset,
       },
       filter: {},

--- a/src/containers/Chat/ChatConversations/ConversationList/ConversationList.tsx
+++ b/src/containers/Chat/ChatConversations/ConversationList/ConversationList.tsx
@@ -27,6 +27,7 @@ interface ConversationListProps {
   selectedContactId?: number;
   setSelectedContactId?: (i: number) => void;
   savedSearchCriteria?: string | null;
+  savedSearchCriteriaId?: number | null;
   searchParam?: any;
   searchMode: boolean;
   selectedCollectionId?: number;
@@ -39,6 +40,7 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
     searchVal,
     searchParam,
     savedSearchCriteria,
+    savedSearchCriteriaId,
     selectedCollectionId,
   } = props;
   const client = useApolloClient();
@@ -217,8 +219,9 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
       getFilterSearch({
         variables: filterSearch(),
       });
-    } else {
-      // This is used for filtering the searches, when you click on it
+    } else if (savedSearchCriteriaId) {
+      // This is used for filtering the searches, when you click on it, so only call it
+      // when user clicks and savedSearchCriteriaId is set.
       getFilterConvos({
         variables: filterVariables(),
       });

--- a/src/containers/Chat/ChatConversations/ConversationList/ConversationList.tsx
+++ b/src/containers/Chat/ChatConversations/ConversationList/ConversationList.tsx
@@ -17,6 +17,7 @@ import { setErrorMessage } from '../../../../common/notification';
 import {
   COLLECTION_SEARCH_QUERY_VARIABLES,
   SEARCH_QUERY_VARIABLES,
+  SHOW_CONVERSATION_LOAD_MORE,
 } from '../../../../common/constants';
 import { updateConversations } from '../../../../services/ChatService';
 import { showMessages } from '../../../../common/responsive';
@@ -126,16 +127,16 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
 
   const filterSearch = () => {
     return {
+      contactOpts: {
+        order: 'DESC',
+        limit: 25,
+      },
       searchFilter: {
         term: props.searchVal,
       },
       messageOpts: {
         limit: 20,
         order: 'ASC',
-      },
-      contactOpts: {
-        order: 'DESC',
-        limit: 25,
       },
     };
   };
@@ -448,7 +449,7 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
       {conversationList ? (
         <List className={styles.StyledList}>
           {conversationList}
-          {showLoadMore && conversations.length > 24 ? (
+          {showLoadMore && conversations.length > SHOW_CONVERSATION_LOAD_MORE ? (
             <div className={styles.LoadMore}>
               {showLoading ? (
                 <CircularProgress className={styles.Progress} />

--- a/src/containers/Chat/ChatMessages/ChatMessages.test.tsx
+++ b/src/containers/Chat/ChatMessages/ChatMessages.test.tsx
@@ -5,14 +5,15 @@ import { ChatMessages } from './ChatMessages';
 import { fireEvent, waitFor } from '@testing-library/dom';
 import { MemoryRouter } from 'react-router';
 import { SEARCH_QUERY } from '../../../graphql/queries/Search';
+import { DEFAULT_CONTACT_LIMIT, DEFAULT_MESSAGE_LIMIT } from '../../../common/constants';
 
 const cache = new InMemoryCache({ addTypename: false });
 export const searchQuery = {
   query: SEARCH_QUERY,
   variables: {
     filter: {},
-    contactOpts: { limit: 25 },
-    messageOpts: { limit: 20 },
+    contactOpts: { limit: DEFAULT_CONTACT_LIMIT },
+    messageOpts: { limit: DEFAULT_MESSAGE_LIMIT },
   },
   data: {
     search: [
@@ -63,8 +64,8 @@ cache.writeQuery({
   query: SEARCH_QUERY,
   variables: {
     filter: { searchGroup: true },
-    contactOpts: { limit: 25 },
-    messageOpts: { limit: 20 },
+    contactOpts: { limit: DEFAULT_CONTACT_LIMIT },
+    messageOpts: { limit: DEFAULT_MESSAGE_LIMIT },
   },
   data: {
     search: [

--- a/src/containers/Chat/ChatMessages/ChatMessages.test.tsx
+++ b/src/containers/Chat/ChatMessages/ChatMessages.test.tsx
@@ -11,8 +11,8 @@ export const searchQuery = {
   query: SEARCH_QUERY,
   variables: {
     filter: {},
-    messageOpts: { limit: 50 },
-    contactOpts: { limit: 50 },
+    contactOpts: { limit: 25 },
+    messageOpts: { limit: 20 },
   },
   data: {
     search: [
@@ -63,8 +63,8 @@ cache.writeQuery({
   query: SEARCH_QUERY,
   variables: {
     filter: { searchGroup: true },
-    messageOpts: { limit: 50 },
-    contactOpts: { limit: 50 },
+    contactOpts: { limit: 25 },
+    messageOpts: { limit: 20 },
   },
   data: {
     search: [

--- a/src/containers/Chat/ChatMessages/ChatMessages.tsx
+++ b/src/containers/Chat/ChatMessages/ChatMessages.tsx
@@ -17,6 +17,7 @@ import {
   COLLECTION_SEARCH_QUERY_VARIABLES,
   DEFAULT_MESSAGE_LIMIT,
   DEFAULT_CONTACT_LIMIT,
+  DEFAULT_MESSAGE_LOADMORE_LIMIT,
 } from '../../../common/constants';
 import { SEARCH_QUERY } from '../../../graphql/queries/Search';
 import {
@@ -392,7 +393,7 @@ export const ChatMessages: React.SFC<ChatMessagesProps> = ({
     const variables: any = {
       contactOpts: { limit: 1 },
       filter: { id: contactId?.toString() },
-      messageOpts: { limit: DEFAULT_MESSAGE_LIMIT, offset: messageOffset },
+      messageOpts: { limit: DEFAULT_MESSAGE_LOADMORE_LIMIT, offset: messageOffset },
     };
 
     if (collectionId) {
@@ -402,7 +403,7 @@ export const ChatMessages: React.SFC<ChatMessagesProps> = ({
       variables: {
         filter: { id: contactId?.toString() },
         contactOpts: { limit: 1 },
-        messageOpts: { limit: 20, offset: messageOffset },
+        messageOpts: { limit: DEFAULT_MESSAGE_LIMIT, offset: messageOffset },
       },
     });
     const messageContainer = document.querySelector('.messageContainer');

--- a/src/containers/Chat/ChatMessages/ChatMessages.tsx
+++ b/src/containers/Chat/ChatMessages/ChatMessages.tsx
@@ -15,7 +15,8 @@ import {
   SEARCH_QUERY_VARIABLES,
   setVariables,
   COLLECTION_SEARCH_QUERY_VARIABLES,
-  SHOW_MESSAGE_LOAD_MORE,
+  DEFAULT_MESSAGE_LIMIT,
+  DEFAULT_CONTACT_LIMIT,
 } from '../../../common/constants';
 import { SEARCH_QUERY } from '../../../graphql/queries/Search';
 import {
@@ -50,7 +51,7 @@ export const ChatMessages: React.SFC<ChatMessagesProps> = ({
   const [showDropdown, setShowDropdown] = useState<any>(null);
   const [reducedHeight, setReducedHeight] = useState(0);
   const [lastScrollHeight, setLastScrollHeight] = useState(0);
-  const [messageOffset, setMessageOffset] = useState(20);
+  const [messageOffset, setMessageOffset] = useState(DEFAULT_MESSAGE_LIMIT);
   const [showLoadMore, setShowLoadMore] = useState(true);
 
   useEffect(() => {
@@ -131,7 +132,7 @@ export const ChatMessages: React.SFC<ChatMessagesProps> = ({
         if (searchData.search[0].messages.length === 0) {
           setShowLoadMore(false);
         } else {
-          setMessageOffset(messageOffset + 20);
+          setMessageOffset(messageOffset + DEFAULT_MESSAGE_LIMIT);
         }
       }
     },
@@ -262,8 +263,8 @@ export const ChatMessages: React.SFC<ChatMessagesProps> = ({
         getSearchQuery({
           variables: {
             filter: { id: contactId },
-            contactOpts: { limit: 25 },
-            messageOpts: { limit: 20, offset: 0 },
+            contactOpts: { limit: DEFAULT_CONTACT_LIMIT },
+            messageOpts: { limit: DEFAULT_MESSAGE_LIMIT, offset: 0 },
           },
         });
       }
@@ -287,8 +288,8 @@ export const ChatMessages: React.SFC<ChatMessagesProps> = ({
         getSearchQuery({
           variables: {
             filter: { id: collectionId, searchGroup: true },
-            contactOpts: { limit: 25 },
-            messageOpts: { limit: 20, offset: 0 },
+            contactOpts: { limit: DEFAULT_CONTACT_LIMIT },
+            messageOpts: { limit: DEFAULT_MESSAGE_LIMIT, offset: 0 },
           },
         });
       }
@@ -391,7 +392,7 @@ export const ChatMessages: React.SFC<ChatMessagesProps> = ({
     const variables: any = {
       contactOpts: { limit: 1 },
       filter: { id: contactId?.toString() },
-      messageOpts: { limit: 20, offset: messageOffset },
+      messageOpts: { limit: DEFAULT_MESSAGE_LIMIT, offset: messageOffset },
     };
 
     if (collectionId) {
@@ -420,7 +421,7 @@ export const ChatMessages: React.SFC<ChatMessagesProps> = ({
         maxWidth={false}
         data-testid="messageContainer"
       >
-        {showLoadMore && conversationInfo.messages.length > SHOW_MESSAGE_LOAD_MORE ? (
+        {showLoadMore && conversationInfo.messages.length > DEFAULT_MESSAGE_LIMIT - 1 ? (
           <div className={styles.LoadMore}>
             {(called && loading) || conversationLoad ? (
               <CircularProgress className={styles.Loading} />

--- a/src/containers/Chat/ChatMessages/ChatMessages.tsx
+++ b/src/containers/Chat/ChatMessages/ChatMessages.tsx
@@ -15,6 +15,7 @@ import {
   SEARCH_QUERY_VARIABLES,
   setVariables,
   COLLECTION_SEARCH_QUERY_VARIABLES,
+  SHOW_MESSAGE_LOAD_MORE,
 } from '../../../common/constants';
 import { SEARCH_QUERY } from '../../../graphql/queries/Search';
 import {
@@ -419,7 +420,7 @@ export const ChatMessages: React.SFC<ChatMessagesProps> = ({
         maxWidth={false}
         data-testid="messageContainer"
       >
-        {showLoadMore && conversationInfo.messages.length > 19 ? (
+        {showLoadMore && conversationInfo.messages.length > SHOW_MESSAGE_LOAD_MORE ? (
           <div className={styles.LoadMore}>
             {(called && loading) || conversationLoad ? (
               <CircularProgress className={styles.Loading} />

--- a/src/containers/Chat/ChatMessages/ChatMessages.tsx
+++ b/src/containers/Chat/ChatMessages/ChatMessages.tsx
@@ -49,7 +49,7 @@ export const ChatMessages: React.SFC<ChatMessagesProps> = ({
   const [showDropdown, setShowDropdown] = useState<any>(null);
   const [reducedHeight, setReducedHeight] = useState(0);
   const [lastScrollHeight, setLastScrollHeight] = useState(0);
-  const [messageOffset, setMessageOffset] = useState(50);
+  const [messageOffset, setMessageOffset] = useState(20);
   const [showLoadMore, setShowLoadMore] = useState(true);
 
   useEffect(() => {
@@ -130,7 +130,7 @@ export const ChatMessages: React.SFC<ChatMessagesProps> = ({
         if (searchData.search[0].messages.length === 0) {
           setShowLoadMore(false);
         } else {
-          setMessageOffset(messageOffset + 50);
+          setMessageOffset(messageOffset + 20);
         }
       }
     },
@@ -261,8 +261,8 @@ export const ChatMessages: React.SFC<ChatMessagesProps> = ({
         getSearchQuery({
           variables: {
             filter: { id: contactId },
-            messageOpts: { limit: 200, offset: 0 },
-            contactOpts: { limit: 50 },
+            contactOpts: { limit: 25 },
+            messageOpts: { limit: 20, offset: 0 },
           },
         });
       }
@@ -286,8 +286,8 @@ export const ChatMessages: React.SFC<ChatMessagesProps> = ({
         getSearchQuery({
           variables: {
             filter: { id: collectionId, searchGroup: true },
-            messageOpts: { limit: 50, offset: 0 },
-            contactOpts: { limit: 50 },
+            contactOpts: { limit: 25 },
+            messageOpts: { limit: 20, offset: 0 },
           },
         });
       }
@@ -388,9 +388,9 @@ export const ChatMessages: React.SFC<ChatMessagesProps> = ({
 
   const loadMoreMessages = () => {
     const variables: any = {
-      filter: { id: contactId?.toString() },
-      messageOpts: { limit: 50, offset: messageOffset },
       contactOpts: { limit: 1 },
+      filter: { id: contactId?.toString() },
+      messageOpts: { limit: 20, offset: messageOffset },
     };
 
     if (collectionId) {
@@ -399,8 +399,8 @@ export const ChatMessages: React.SFC<ChatMessagesProps> = ({
     getSearchQuery({
       variables: {
         filter: { id: contactId?.toString() },
-        messageOpts: { limit: 200, offset: messageOffset },
         contactOpts: { limit: 1 },
+        messageOpts: { limit: 20, offset: messageOffset },
       },
     });
     const messageContainer = document.querySelector('.messageContainer');
@@ -419,7 +419,7 @@ export const ChatMessages: React.SFC<ChatMessagesProps> = ({
         maxWidth={false}
         data-testid="messageContainer"
       >
-        {showLoadMore && conversationInfo.messages.length > 49 ? (
+        {showLoadMore && conversationInfo.messages.length > 19 ? (
           <div className={styles.LoadMore}>
             {(called && loading) || conversationLoad ? (
               <CircularProgress className={styles.Loading} />

--- a/src/containers/Chat/ChatSubscription/ChatSubscription.tsx
+++ b/src/containers/Chat/ChatSubscription/ChatSubscription.tsx
@@ -129,11 +129,11 @@ export const ChatSubscription: React.SFC<ChatSubscriptionProps> = ({
         getContactQuery({
           variables: {
             contactOpts: {
-              limit: 50,
+              limit: 25,
             },
             filter: { id: contactId },
             messageOpts: {
-              limit: 50,
+              limit: 20,
             },
           },
         });

--- a/src/containers/Chat/ChatSubscription/ChatSubscription.tsx
+++ b/src/containers/Chat/ChatSubscription/ChatSubscription.tsx
@@ -3,6 +3,8 @@ import { useApolloClient, useLazyQuery } from '@apollo/client';
 
 import {
   COLLECTION_SEARCH_QUERY_VARIABLES,
+  DEFAULT_CONTACT_LIMIT,
+  DEFAULT_MESSAGE_LIMIT,
   SEARCH_QUERY_VARIABLES,
 } from '../../../common/constants';
 import { SEARCH_QUERY } from '../../../graphql/queries/Search';
@@ -129,11 +131,11 @@ export const ChatSubscription: React.SFC<ChatSubscriptionProps> = ({
         getContactQuery({
           variables: {
             contactOpts: {
-              limit: 25,
+              limit: DEFAULT_CONTACT_LIMIT,
             },
             filter: { id: contactId },
             messageOpts: {
-              limit: 20,
+              limit: DEFAULT_MESSAGE_LIMIT,
             },
           },
         });

--- a/src/containers/Chat/CollectionConversations/CollectionConversations.test.tsx
+++ b/src/containers/Chat/CollectionConversations/CollectionConversations.test.tsx
@@ -4,14 +4,15 @@ import { render, cleanup, waitFor } from '@testing-library/react';
 import CollectionConversations from './CollectionConversations';
 import { ApolloClient, ApolloProvider, InMemoryCache } from '@apollo/client';
 import { SEARCH_QUERY } from '../../../graphql/queries/Search';
+import { DEFAULT_CONTACT_LIMIT, DEFAULT_MESSAGE_LIMIT } from '../../../common/constants';
 
 const cache = new InMemoryCache({ addTypename: false });
 cache.writeQuery({
   query: SEARCH_QUERY,
   variables: {
-    contactOpts: { limit: 25 },
+    contactOpts: { limit: DEFAULT_CONTACT_LIMIT },
     filter: { searchGroup: true },
-    messageOpts: { limit: 20 },
+    messageOpts: { limit: DEFAULT_MESSAGE_LIMIT },
   },
   data: {
     search: [

--- a/src/containers/Chat/CollectionConversations/CollectionConversations.test.tsx
+++ b/src/containers/Chat/CollectionConversations/CollectionConversations.test.tsx
@@ -9,9 +9,9 @@ const cache = new InMemoryCache({ addTypename: false });
 cache.writeQuery({
   query: SEARCH_QUERY,
   variables: {
+    contactOpts: { limit: 25 },
     filter: { searchGroup: true },
-    messageOpts: { limit: 50 },
-    contactOpts: { limit: 50 },
+    messageOpts: { limit: 20 },
   },
   data: {
     search: [

--- a/src/containers/SavedSearch/SavedSearchToolbar/SavedSearchToolbar.tsx
+++ b/src/containers/SavedSearch/SavedSearchToolbar/SavedSearchToolbar.tsx
@@ -130,7 +130,7 @@ export const SavedSearchToolbar: React.SFC<SavedSearchToolbarProps> = (props) =>
         aria-hidden="true"
       >
         <div className={labelClass.join(' ')}>{savedSearch.shortcode}</div>
-        <div className={countClass.join(' ')}>{savedSearch.count}</div>
+        <div className={countClass.join(' ')}>{savedSearch.count ? savedSearch.count : 0}</div>
       </div>
     );
   });
@@ -154,7 +154,7 @@ export const SavedSearchToolbar: React.SFC<SavedSearchToolbarProps> = (props) =>
                   aria-hidden="true"
                 >
                   <span className={styles.Label}>{search.shortcode}</span>
-                  <span className={styles.Count}>{search.count}</span>
+                  <span className={styles.Count}>{search.count ? search.count : 0}</span>
                 </div>
               );
             })}

--- a/src/containers/Search/Search.tsx
+++ b/src/containers/Search/Search.tsx
@@ -123,9 +123,9 @@ export const Search: React.SFC<SearchProps> = ({ match, type, search, ...props }
 
   const restoreSearch = () => {
     const args = {
-      messageOpts: {
+      contactOpts: {
         offset: 0,
-        limit: 10,
+        limit: 25,
       },
       filter: {
         term: props.searchParam.term,
@@ -139,7 +139,7 @@ export const Search: React.SFC<SearchProps> = ({ match, type, search, ...props }
           ? props.searchParam.includeUsers.map((option: any) => option.id)
           : [],
       },
-      contactOpts: {
+      messageOpts: {
         offset: 0,
         limit: 20,
       },
@@ -274,9 +274,9 @@ export const Search: React.SFC<SearchProps> = ({ match, type, search, ...props }
     if (search) search(payload);
 
     const args = {
-      messageOpts: {
+      contactOpts: {
         offset: 0,
-        limit: 10,
+        limit: 25,
       },
       filter: {
         term: payload.term,
@@ -288,7 +288,7 @@ export const Search: React.SFC<SearchProps> = ({ match, type, search, ...props }
           ? payload.includeUsers.map((option: any) => option.id)
           : [],
       },
-      contactOpts: {
+      messageOpts: {
         offset: 0,
         limit: 20,
       },

--- a/src/containers/Search/Search.tsx
+++ b/src/containers/Search/Search.tsx
@@ -17,7 +17,7 @@ import { GET_USERS } from '../../graphql/queries/User';
 import { AutoComplete } from '../../components/UI/Form/AutoComplete/AutoComplete';
 import { Calendar } from '../../components/UI/Form/Calendar/Calendar';
 import Loading from '../../components/UI/Layout/Loading/Loading';
-import { setVariables } from '../../common/constants';
+import { DEFAULT_CONTACT_LIMIT, DEFAULT_MESSAGE_LIMIT, setVariables } from '../../common/constants';
 import { getObject } from '../../common/utils';
 
 export interface SearchProps {
@@ -125,7 +125,7 @@ export const Search: React.SFC<SearchProps> = ({ match, type, search, ...props }
     const args = {
       contactOpts: {
         offset: 0,
-        limit: 25,
+        limit: DEFAULT_CONTACT_LIMIT,
       },
       filter: {
         term: props.searchParam.term,
@@ -141,7 +141,7 @@ export const Search: React.SFC<SearchProps> = ({ match, type, search, ...props }
       },
       messageOpts: {
         offset: 0,
-        limit: 20,
+        limit: DEFAULT_MESSAGE_LIMIT,
       },
     };
 
@@ -276,7 +276,7 @@ export const Search: React.SFC<SearchProps> = ({ match, type, search, ...props }
     const args = {
       contactOpts: {
         offset: 0,
-        limit: 25,
+        limit: DEFAULT_CONTACT_LIMIT,
       },
       filter: {
         term: payload.term,
@@ -290,7 +290,7 @@ export const Search: React.SFC<SearchProps> = ({ match, type, search, ...props }
       },
       messageOpts: {
         offset: 0,
-        limit: 20,
+        limit: DEFAULT_MESSAGE_LIMIT,
       },
     };
 

--- a/src/graphql/queries/Search.ts
+++ b/src/graphql/queries/Search.ts
@@ -53,7 +53,6 @@ export const SAVED_SEARCH_QUERY = gql`
       shortcode
       label
       args
-      count
     }
   }
 `;

--- a/src/mocks/Chat.tsx
+++ b/src/mocks/Chat.tsx
@@ -30,8 +30,8 @@ const conversationMessageQuery = (
   contactId: any,
   contactName: string,
   contactNumber: string,
-  contactLimit: number = 50,
-  messageLimit: object = { limit: 50 }
+  contactLimit: number = 25,
+  messageLimit: object = { limit: 20 }
 ) => ({
   request: {
     query: SEARCH_QUERY,
@@ -90,8 +90,8 @@ const conversationMessageQuery = (
 const conversationCollectionQuery = (
   collectionId: any,
   collectionName: string,
-  contactLimit: number = 50,
-  messageLimit: object = { limit: 50 }
+  contactLimit: number = 25,
+  messageLimit: object = { limit: 20 }
 ) => ({
   request: {
     query: SEARCH_QUERY,
@@ -346,14 +346,18 @@ export const conversationQuery = getConversationQuery({
   ],
 });
 
-export const searchMultiQuery = (term: string = '', limit: number = 50) => {
+export const searchMultiQuery = (
+  term: string = '',
+  contactLimit: number = 25,
+  messageLimit: number = 20
+) => {
   return {
     request: {
       query: SEARCH_MULTI_QUERY,
       variables: {
         searchFilter: { term: term },
-        messageOpts: { limit: limit, order: 'ASC' },
-        contactOpts: { order: 'DESC', limit: limit },
+        messageOpts: { limit: contactLimit, order: 'ASC' },
+        contactOpts: { order: 'DESC', limit: messageLimit },
       },
     },
     result: {
@@ -459,9 +463,9 @@ export const CONVERSATION_MOCKS = [
   deleteMessageTagSubscription,
   savedSearchQuery,
   getOrganizationLanguagesQuery,
-  conversationMessageQuery('2', 'Jane Doe', '919090909009', 50, { limit: 50 }),
-  conversationMessageQuery('3', 'Jane Monroe', '919090709009', 50, { limit: 50 }),
-  conversationMessageQuery('2', 'Jane Doe', '919090909009', 1, { limit: 50, offset: 0 }),
+  conversationMessageQuery('2', 'Jane Doe', '919090909009', 25, { limit: 20 }),
+  conversationMessageQuery('3', 'Jane Monroe', '919090709009', 25, { limit: 20 }),
+  conversationMessageQuery('2', 'Jane Doe', '919090909009', 1, { limit: 20, offset: 0 }),
   conversationCollectionQuery('2', 'Default collection'),
 ];
 
@@ -674,7 +678,7 @@ const searchQueryResult = {
 export const searchQuerywithFilter = {
   request: {
     query: SEARCH_QUERY,
-    variables: { contactOpts: { limit: 50 }, filter: { id: '2' }, messageOpts: { limit: 50 } },
+    variables: { contactOpts: { limit: 25 }, filter: { id: '2' }, messageOpts: { limit: 20 } },
   },
   result: searchQueryResult,
 };
@@ -683,9 +687,9 @@ export const searchQuerywithFilterOffset = {
   request: {
     query: SEARCH_QUERY,
     variables: {
-      contactOpts: { limit: 50 },
+      contactOpts: { limit: 25 },
       filter: { id: '2' },
-      messageOpts: { limit: 50, offset: 50 },
+      messageOpts: { limit: 20, offset: 20 },
     },
   },
   result: searchQueryResult,

--- a/src/mocks/Chat.tsx
+++ b/src/mocks/Chat.tsx
@@ -11,7 +11,11 @@ import { addMessageTagSubscription, deleteMessageTagSubscription } from './Tag';
 import { filterTagsQuery, getTagsQuery } from './Tag';
 import { contactCollectionsQuery } from './Contact';
 import { CREATE_AND_SEND_MESSAGE_MUTATION, UPDATE_MESSAGE_TAGS } from '../graphql/mutations/Chat';
-import { SEARCH_QUERY_VARIABLES as queryVariables } from '../common/constants';
+import {
+  DEFAULT_CONTACT_LIMIT,
+  DEFAULT_MESSAGE_LIMIT,
+  SEARCH_QUERY_VARIABLES as queryVariables,
+} from '../common/constants';
 import { getOrganizationLanguagesQuery } from './Organization';
 
 const getConversationQuery = (data: any) => {
@@ -30,8 +34,8 @@ const conversationMessageQuery = (
   contactId: any,
   contactName: string,
   contactNumber: string,
-  contactLimit: number = 25,
-  messageLimit: object = { limit: 20 }
+  contactLimit: number = DEFAULT_CONTACT_LIMIT,
+  messageLimit: object = { limit: DEFAULT_MESSAGE_LIMIT }
 ) => ({
   request: {
     query: SEARCH_QUERY,
@@ -90,8 +94,8 @@ const conversationMessageQuery = (
 const conversationCollectionQuery = (
   collectionId: any,
   collectionName: string,
-  contactLimit: number = 25,
-  messageLimit: object = { limit: 20 }
+  contactLimit: number = DEFAULT_CONTACT_LIMIT,
+  messageLimit: object = { limit: DEFAULT_MESSAGE_LIMIT }
 ) => ({
   request: {
     query: SEARCH_QUERY,
@@ -348,8 +352,8 @@ export const conversationQuery = getConversationQuery({
 
 export const searchMultiQuery = (
   term: string = '',
-  contactLimit: number = 25,
-  messageLimit: number = 20
+  contactLimit: number = DEFAULT_CONTACT_LIMIT,
+  messageLimit: number = DEFAULT_MESSAGE_LIMIT
 ) => {
   return {
     request: {
@@ -463,9 +467,16 @@ export const CONVERSATION_MOCKS = [
   deleteMessageTagSubscription,
   savedSearchQuery,
   getOrganizationLanguagesQuery,
-  conversationMessageQuery('2', 'Jane Doe', '919090909009', 25, { limit: 20 }),
-  conversationMessageQuery('3', 'Jane Monroe', '919090709009', 25, { limit: 20 }),
-  conversationMessageQuery('2', 'Jane Doe', '919090909009', 1, { limit: 20, offset: 0 }),
+  conversationMessageQuery('2', 'Jane Doe', '919090909009', DEFAULT_CONTACT_LIMIT, {
+    limit: DEFAULT_MESSAGE_LIMIT,
+  }),
+  conversationMessageQuery('3', 'Jane Monroe', '919090709009', DEFAULT_CONTACT_LIMIT, {
+    limit: DEFAULT_MESSAGE_LIMIT,
+  }),
+  conversationMessageQuery('2', 'Jane Doe', '919090909009', 1, {
+    limit: DEFAULT_MESSAGE_LIMIT,
+    offset: 0,
+  }),
   conversationCollectionQuery('2', 'Default collection'),
 ];
 
@@ -678,7 +689,11 @@ const searchQueryResult = {
 export const searchQuerywithFilter = {
   request: {
     query: SEARCH_QUERY,
-    variables: { contactOpts: { limit: 25 }, filter: { id: '2' }, messageOpts: { limit: 20 } },
+    variables: {
+      contactOpts: { limit: DEFAULT_CONTACT_LIMIT },
+      filter: { id: '2' },
+      messageOpts: { limit: DEFAULT_MESSAGE_LIMIT },
+    },
   },
   result: searchQueryResult,
 };
@@ -687,9 +702,9 @@ export const searchQuerywithFilterOffset = {
   request: {
     query: SEARCH_QUERY,
     variables: {
-      contactOpts: { limit: 25 },
+      contactOpts: { limit: DEFAULT_CONTACT_LIMIT },
       filter: { id: '2' },
-      messageOpts: { limit: 20, offset: 20 },
+      messageOpts: { limit: DEFAULT_MESSAGE_LIMIT, offset: DEFAULT_MESSAGE_LIMIT },
     },
   },
   result: searchQueryResult,

--- a/src/mocks/Search.tsx
+++ b/src/mocks/Search.tsx
@@ -65,11 +65,9 @@ export const getSearchesQuery = [
       data: {
         savedSearches: [
           {
-            count: 4,
             args:
               '{"messageOpts":{"offset":0,"limit":10},"filter":{"term":"","includeTags":["10"]},"contactOpts":{"offset":0,"limit":20}}',
             id: '8',
-            isReserved: false,
             label: 'Test search',
             shortcode: 'Save Search',
           },
@@ -83,11 +81,9 @@ export const getSearchesQuery = [
       data: {
         savedSearches: [
           {
-            count: 4,
             args:
               '{"messageOpts":{"offset":0,"limit":10},"filter":{"term":"","includeTags":["10"]},"contactOpts":{"offset":0,"limit":20}}',
             id: '8',
-            isReserved: false,
             label: 'Test search',
             shortcode: 'Save Search',
           },
@@ -110,7 +106,6 @@ export const getSearch = {
         savedSearch: {
           args:
             '{"messageOpts":{"offset":0,"limit":10},"filter":{"term":"","includeTags":["10"]},"contactOpts":{"offset":0,"limit":20}}',
-          count: 0,
           id: '1',
           label: 'Test search',
           shortcode: 'Save Search collection',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1631,6 +1631,8 @@
   dependencies:
     react "^16.8.6"
     react-dom "^16.8.6"
+    react-icons "4.1.0"
+    react-notifications "1.7.2"
 
 "@pmmmwh/react-refresh-webpack-plugin@0.4.2":
   version "0.4.2"


### PR DESCRIPTION
## Summary

* Set the default contact to 25 and messages to 20 for search queries
* Remove unnecessary search call on page load
* Code optimization and clean up
* Removed count from savedsearch query. Update the count only using the subscription. (backend might add new api later this week or so)

## Test Plan

* Included in the PR
