### PR TITLE
fix the errors with yarn setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "cy:run": "cypress run",
     "eject": "react-scripts eject",
     "format": "prettier \"**/*.{ts,tsx,css,graphql}\" --write",
-    "floweditor": "cp -r node_modules/@nyaruka/flow-editor/build/static public && cp -r node_modules/@nyaruka/flow-editor/build/sitestatic public"
+    "floweditor": "cp -r node_modules/@nyaruka/flow-editor/build/static public && rm -rf public/sitestatic && cp -r node_modules/@nyaruka/flow-editor/build/sitestatic public"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
## Summary

`yarn setup` results in the following error.

`cp: cannot overwrite directory public/sitestatic/@fortawesome/fontawesome-free with non-directory node_modules/@nyaruka/flow-editor/build/sitestatic/@fortawesome/fontawesome-free`

## Test Plan

* Nit needed
