### PR TITLE
Updated margins for saveSearchToolBar, removed top margin for search on

### DIFF
--- a/src/containers/Chat/Chat.module.css
+++ b/src/containers/Chat/Chat.module.css
@@ -54,6 +54,7 @@
   margin: 4px 0px 5px 0px !important;
   color: #93a29b;
   cursor: pointer;
+  line-height: 1 !important;
 }
 
 .SelectedTab {

--- a/src/containers/Chat/ChatConversations/ChatConversations.module.css
+++ b/src/containers/Chat/ChatConversations/ChatConversations.module.css
@@ -57,3 +57,7 @@
 .CancelOutlined {
   background-color: white !important;
 }
+
+.SavedSearchTopMargin {
+  margin-top: 0px !important;
+}

--- a/src/containers/Chat/ChatConversations/ChatConversations.tsx
+++ b/src/containers/Chat/ChatConversations/ChatConversations.tsx
@@ -228,6 +228,7 @@ export const ChatConversations: React.SFC<ChatConversationsProps> = (props) => {
         handleClick={handleClick}
         endAdornment
         searchMode={enableSearchMode}
+        className={styles.SavedSearchTopMargin}
       />
       <ConversationList
         searchVal={searchVal}

--- a/src/containers/Chat/ChatConversations/ConversationList/ConversationList.module.css
+++ b/src/containers/Chat/ChatConversations/ConversationList/ConversationList.module.css
@@ -56,7 +56,7 @@
   background-color: #073f24;
   font-weight: 500;
   padding: 1px 8px;
-  margin: 0 auto;
+  margin: 20px auto 0px auto;
   border-radius: 0 0 12px 12px;
   color: #edf6f2;
   cursor: pointer;

--- a/src/containers/Chat/ChatConversations/ConversationList/ConversationList.module.css
+++ b/src/containers/Chat/ChatConversations/ConversationList/ConversationList.module.css
@@ -1,11 +1,17 @@
-.ListingContainer {
-  height: calc(100% - 100px);
+.ChatListingContainer {
+  height: calc(100% - 124px);
   overflow-y: auto;
   padding: 0px !important;
 }
 
 .CollectionListingContainer {
   height: 100%;
+  overflow-y: auto;
+  padding: 0px !important;
+}
+
+.SaveSearchListingContainer {
+  height: calc(100% - 96px);
   overflow-y: auto;
   padding: 0px !important;
 }
@@ -56,7 +62,7 @@
   background-color: #073f24;
   font-weight: 500;
   padding: 1px 8px;
-  margin: 20px auto 0px auto;
+  margin: 0 auto;
   border-radius: 0 0 12px 12px;
   color: #edf6f2;
   cursor: pointer;
@@ -68,7 +74,7 @@
 
 .ScrollToTopContacts {
   composes: ScrollButton;
-  top: 88px;
+  top: 110px;
 }
 
 .ScrollToTopCollections {

--- a/src/containers/Chat/ChatConversations/ConversationList/ConversationList.tsx
+++ b/src/containers/Chat/ChatConversations/ConversationList/ConversationList.tsx
@@ -87,7 +87,7 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
         }
       });
     }
-  }, []);
+  });
 
   // reset offset value on saved search changes
   useEffect(() => {
@@ -479,9 +479,13 @@ export const ConversationList: React.SFC<ConversationListProps> = (props) => {
     </div>
   );
 
-  const entityStyle = selectedContactId
-    ? styles.ListingContainer
-    : styles.CollectionListingContainer;
+  const entityStyles: any = {
+    contact: styles.ChatListingContainer,
+    collection: styles.CollectionListingContainer,
+    savedSearch: styles.SaveSearchListingContainer,
+  };
+
+  const entityStyle = entityStyles[entityType];
 
   return (
     <Container className={`${entityStyle} contactsContainer`} disableGutters>

--- a/src/containers/Chat/ChatMessages/ContactBar/ContactBar.module.css
+++ b/src/containers/Chat/ChatMessages/ContactBar/ContactBar.module.css
@@ -229,7 +229,7 @@
 .ContactInfoWrapper {
   display: flex;
   width: 100%;
-  align-items: baseline;
+  align-items: flex-end;
   justify-content: space-between;
 }
 

--- a/src/containers/SavedSearch/SavedSearchToolbar/SavedSearchToolbar.module.css
+++ b/src/containers/SavedSearch/SavedSearchToolbar/SavedSearchToolbar.module.css
@@ -1,6 +1,6 @@
 .SavedSearchToolbar {
   font-family: 'heebo';
-  padding: 24px 6px;
+  padding: 16px 6px;
   display: flex;
 }
 


### PR DESCRIPTION
chat conversations, align contents for contact-bar, adjusted margin for
go-to-top action bar

As discussed updated design

- Adjusted padding for saved-search-tool-bar with 16px, before it was 24px
- Removed top margin for searchbar for chat-conversations, adjusted go-to-top button margin for same
- Adjusted line-height for toolbar titles
- Aligned content for contact-info-wrapper
