### PR TITLE
Template buttons

### DIFF
--- a/src/common/RichEditor.tsx
+++ b/src/common/RichEditor.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import reactStringReplace from 'react-string-replace';
 import { convertToRaw, convertFromRaw } from 'draft-js';
+import CallIcon from '@material-ui/icons/Call';
+import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 
 const MarkDownConvertor = require('markdown-draft-js');
 
@@ -160,11 +162,13 @@ export const WhatsAppTemplateButton = (text: string) => {
           value: null,
           type: 'call-to-action',
           tooltip: 'Currently not supported',
+          icon: <CallIcon />,
         };
         if (link) {
           const [url] = link;
           callToActionButton.value = url;
           callToActionButton.tooltip = '';
+          callToActionButton.icon = <OpenInNewIcon />;
         }
         return callToActionButton;
       }

--- a/src/common/RichEditor.tsx
+++ b/src/common/RichEditor.tsx
@@ -155,9 +155,16 @@ export const WhatsAppTemplateButton = (text: string) => {
         const [key, value]: any = btn.split(',');
         // Checking if given value is valid link
         const [link] = [...value.matchAll(regexForLink)];
-        const callToActionButton: any = { title: key.trim(), value: null, type: 'call-to-action' };
+        const callToActionButton: any = {
+          title: key.trim(),
+          value: null,
+          type: 'call-to-action',
+          tooltip: 'Currently not supported',
+        };
         if (link) {
-          callToActionButton.value = link;
+          const [url] = link;
+          callToActionButton.value = url;
+          callToActionButton.tooltip = '';
         }
         return callToActionButton;
       }

--- a/src/common/RichEditor.tsx
+++ b/src/common/RichEditor.tsx
@@ -5,6 +5,7 @@ import { convertToRaw, convertFromRaw } from 'draft-js';
 const MarkDownConvertor = require('markdown-draft-js');
 
 // Indicates how to replace different parts of the text from WhatsApp to HTML.
+const regexForLink = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,4}\b([-a-zA-Z0-9@:%_+.~#?&/=]*)/gi;
 export const TextReplacements: any = [
   {
     bold: {
@@ -92,7 +93,6 @@ export const WhatsAppToJsx = (text: any) => {
   // regex for checking whatsapp formatting for both bold and italic
   const complexFormatting = [/(_\*.*\*_)/, /(\*_.*_\*)/];
   // regex for checking links in the message
-  const regexForLink = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._+~#=]{2,256}\.[a-z]{2,4}\b([-a-zA-Z0-9@:%_+.~#?&/=]*)/gi;
 
   if (typeof text === 'string') {
     // search for all the links in the message
@@ -129,4 +129,44 @@ export const WhatsAppToJsx = (text: any) => {
   });
 
   return modifiedText;
+};
+
+export const WhatsAppTemplateButton = (text: string) => {
+  // Checking if template consists of buttons or not because they are separated with `|`
+  const isTemplateButtonsPresent = text.indexOf('|');
+  const result: any = { body: text, buttons: null };
+  if (isTemplateButtonsPresent > 0) {
+    const templateStr = text.split('|');
+    const templateButtons = templateStr.map((val: string, index: number) => {
+      /**
+       * templateStr 0th element is template message
+       * otherwise slice from 1 to last value
+       * For removing `[]` brackets
+       */
+      if (index === 0) return val.trim();
+      return val.trim().slice(1, -1);
+    });
+    const [messageBody, ...buttons] = templateButtons;
+
+    // Checking if template type is call to action or quick reply
+
+    const btnWithKeyValues = buttons.map((btn: string) => {
+      if (btn.indexOf(',') > 0) {
+        const [key, value]: any = btn.split(',');
+        // Checking if given value is valid link
+        const [link] = [...value.matchAll(regexForLink)];
+        const callToActionButton: any = { title: key.trim(), value: null, type: 'call-to-action' };
+        if (link) {
+          callToActionButton.value = link;
+        }
+        return callToActionButton;
+      }
+      return { title: btn, value: btn, type: 'quick-reply' };
+    });
+
+    result.body = messageBody;
+    result.buttons = btnWithKeyValues;
+  }
+
+  return result;
 };

--- a/src/common/RichEditor.tsx
+++ b/src/common/RichEditor.tsx
@@ -134,9 +134,12 @@ export const WhatsAppToJsx = (text: any) => {
 };
 
 export const WhatsAppTemplateButton = (text: string) => {
+  const result: any = { body: text, buttons: null };
+
+  // Returning early if text is null
+  if (!text) return result;
   // Checking if template consists of buttons or not because they are separated with `|`
   const isTemplateButtonsPresent = text.indexOf('|');
-  const result: any = { body: text, buttons: null };
   if (isTemplateButtonsPresent > 0) {
     const templateStr = text.split('|');
     const templateButtons = templateStr.map((val: string, index: number) => {

--- a/src/components/simulator/Simulator.module.css
+++ b/src/components/simulator/Simulator.module.css
@@ -27,6 +27,8 @@
   margin-right: 24px;
   color: #333;
   background: white;
+  width: 200px;
+  margin-top: 4px;
 }
 
 .SendMessage {
@@ -273,4 +275,8 @@
 .CrossIcon {
   margin-left: 15px;
   color: grey;
+}
+
+.TemplateButtons {
+  width: 200px;
 }

--- a/src/components/simulator/Simulator.tsx
+++ b/src/components/simulator/Simulator.tsx
@@ -132,8 +132,8 @@ export const Simulator: React.FC<SimulatorProps> = ({
   ) => {
     const { body, buttons } = WhatsAppTemplateButton(text);
     return (
-      <>
-        <div className={getStyleForDirection(direction)} key={index}>
+      <div key={index}>
+        <div className={getStyleForDirection(direction)}>
           <ChatMessageType
             type={type}
             media={media}
@@ -151,9 +151,10 @@ export const Simulator: React.FC<SimulatorProps> = ({
           <TemplateButtons
             template={buttons}
             callbackTemplateButtonClick={(value: string) => setReply(value)}
+            isSimulator
           />
         </div>
-      </>
+      </div>
     );
   };
 

--- a/src/components/simulator/Simulator.tsx
+++ b/src/components/simulator/Simulator.tsx
@@ -132,23 +132,28 @@ export const Simulator: React.FC<SimulatorProps> = ({
   ) => {
     const { body, buttons } = WhatsAppTemplateButton(text);
     return (
-      <div className={getStyleForDirection(direction)} key={index}>
-        <ChatMessageType
-          type={type}
-          media={media}
-          body={body}
-          location={location}
-          isSimulatedMessage={isSimulatedMessage}
-        />
-        <TemplateButtons
-          template={buttons}
-          callbackTemplateButtonClick={(value: string) => setReply(value)}
-        />
-        <span className={direction === 'received' ? styles.TimeSent : styles.TimeReceived}>
-          {moment(insertedAt).format(TIME_FORMAT)}
-        </span>
-        {direction === 'send' ? <DoneAllIcon /> : null}
-      </div>
+      <>
+        <div className={getStyleForDirection(direction)} key={index}>
+          <ChatMessageType
+            type={type}
+            media={media}
+            body={body}
+            location={location}
+            isSimulatedMessage={isSimulatedMessage}
+          />
+
+          <span className={direction === 'received' ? styles.TimeSent : styles.TimeReceived}>
+            {moment(insertedAt).format(TIME_FORMAT)}
+          </span>
+          {direction === 'send' ? <DoneAllIcon /> : null}
+        </div>
+        <div className={styles.TemplateButtons}>
+          <TemplateButtons
+            template={buttons}
+            callbackTemplateButtonClick={(value: string) => setReply(value)}
+          />
+        </div>
+      </>
     );
   };
 

--- a/src/containers/Chat/ChatMessages/ChatMessage/ChatMessage.module.css
+++ b/src/containers/Chat/ChatMessages/ChatMessage/ChatMessage.module.css
@@ -237,3 +237,7 @@
   color: #93a29b;
   line-height: 14px;
 }
+
+.TemplateButtonOnError {
+  margin-left: 42px;
+}

--- a/src/containers/Chat/ChatMessages/ChatMessage/ChatMessage.test.tsx
+++ b/src/containers/Chat/ChatMessages/ChatMessage/ChatMessage.test.tsx
@@ -58,7 +58,7 @@ const Props = (link: any) => {
     media: { url: 'http://glific.com' },
     errors: '{}',
     contextMessage: {
-      body: 'All good',
+      body: '*All good* https://www.google.com',
       contextId: 1,
       messageNumber: 10,
       errors: '{}',
@@ -91,14 +91,12 @@ describe('<ChatMessage />', () => {
 
   test('it should render the message content correctly', () => {
     const { getByTestId } = render(chatMessageText);
-    expect(getByTestId('content').textContent).toContain(
-      'Hello there! visit https://www.google.com'
-    );
+    expect(getByTestId('content').textContent).toContain('All good');
   });
 
   test('it should apply the correct styling', () => {
     const { getByTestId } = render(chatMessageText);
-    expect(getByTestId('content').innerHTML.includes('<b>Hello there!</b>')).toBe(true);
+    expect(getByTestId('content').innerHTML.includes('<b>All good</b>')).toBe(true);
   });
 
   test('it should render the message date  correctly', () => {
@@ -136,8 +134,8 @@ describe('<ChatMessage />', () => {
   });
 
   test('it should detect a link in message', async () => {
-    const { getByTestId } = render(chatMessageText);
-    expect(getByTestId('messageLink').getAttribute('href')).toBe('https://www.google.com');
+    const { getAllByTestId } = render(chatMessageText);
+    expect(getAllByTestId('messageLink')[0].getAttribute('href')).toBe('https://www.google.com');
   });
 
   const chatMessageVideo = chatMessage('VIDEO');

--- a/src/containers/Chat/ChatMessages/ChatMessage/ChatMessage.test.tsx
+++ b/src/containers/Chat/ChatMessages/ChatMessage/ChatMessage.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, within, fireEvent, waitFor } from '@testing-library/react';
+import { render, within, fireEvent, waitFor, screen, prettyDOM } from '@testing-library/react';
 import moment from 'moment';
 
 import ChatMessage from './ChatMessage';
@@ -75,6 +75,7 @@ const Props = (link: any) => {
       },
     },
     jumpToMessage: Function,
+    focus: true,
   };
 };
 
@@ -174,6 +175,88 @@ describe('<ChatMessage />', () => {
     const { getByTestId } = render(chatMessageDoc);
     await waitFor(() => {
       fireEvent.click(getByTestId('reply-message'));
+    });
+  });
+
+  const props = Props('TEXT');
+  test('it should render error with payload', async () => {
+    props.errors = '{"payload": {"payload": {"reason": "Something went wrong"}}} ';
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <ChatMessage {...props} />
+      </MockedProvider>
+    );
+    const errors = screen.getAllByTestId('tooltip');
+    expect(errors[0]).toHaveTextContent('Warning.svg');
+  });
+
+  const imageProps = Props('IMAGE');
+  test('it should render error with message', () => {
+    imageProps.media = {
+      url:
+        'https://i.picsum.photos/id/674/200/300.jpg?hmac=kS3VQkm7AuZdYJGUABZGmnNj_3KtZ6Twgb5Qb9ITssY',
+      caption: '\n',
+    };
+    props.errors = '{"message": ["Something went wrong"]}';
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <ChatMessage {...imageProps} />
+      </MockedProvider>
+    );
+  });
+
+  test('it should render error with error message', () => {
+    props.errors = '{"error": "Something went wrong"}';
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <ChatMessage {...props} />
+      </MockedProvider>
+    );
+
+    const errors = screen.getAllByTestId('tooltip');
+    expect(errors[0]).toHaveTextContent('Warning.svg');
+  });
+
+  const receivedProps = {
+    id: '93',
+    body: null,
+    insertedAt: '2021-05-25T14:09:43.623251Z',
+    messageNumber: 2,
+    receiver: {
+      id: '4',
+    },
+    sender: {
+      id: '1',
+    },
+    location: null,
+    tags: [],
+    type: 'IMAGE',
+    media: {
+      url:
+        'https://i.picsum.photos/id/1/200/300.jpg?hmac=jH5bDkLr6Tgy3oAg5khKCHeunZMHq0ehBZr6vGifPLY',
+      caption: '\n',
+    },
+    errors: '{}',
+    contextMessage: null,
+    contactId: '4',
+    popup: true,
+    focus: true,
+    showMessage: true,
+  };
+
+  test('it should render with image', async () => {
+    render(
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <ChatMessage {...receivedProps} />
+      </MockedProvider>
+    );
+    const messageMenu = screen.getByTestId('messageOptions');
+
+    await waitFor(() => {});
+
+    expect(messageMenu).toBeInTheDocument();
+    await waitFor(() => {
+      fireEvent.mouseDown(messageMenu);
     });
   });
 });

--- a/src/containers/Chat/ChatMessages/ChatMessage/ChatMessage.test.tsx
+++ b/src/containers/Chat/ChatMessages/ChatMessage/ChatMessage.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, within, fireEvent, waitFor, screen, prettyDOM } from '@testing-library/react';
+import { render, within, fireEvent, waitFor, screen } from '@testing-library/react';
 import moment from 'moment';
 
 import ChatMessage from './ChatMessage';
@@ -33,7 +33,7 @@ const mocks = [
 ];
 
 const insertedAt = '2020-06-19T18:44:02Z';
-const Props = (link: any) => {
+const Props: any = (link: any) => {
   return {
     id: 1,
     body: '*Hello there!* visit https://www.google.com',
@@ -92,12 +92,14 @@ describe('<ChatMessage />', () => {
 
   test('it should render the message content correctly', () => {
     const { getByTestId } = render(chatMessageText);
-    expect(getByTestId('content').textContent).toContain('All good');
+    expect(getByTestId('content').textContent).toContain(
+      'Hello there! visit https://www.google.com'
+    );
   });
 
   test('it should apply the correct styling', () => {
     const { getByTestId } = render(chatMessageText);
-    expect(getByTestId('content').innerHTML.includes('<b>All good</b>')).toBe(true);
+    expect(getByTestId('content').innerHTML.includes('<b>Hello there!</b>')).toBe(true);
   });
 
   test('it should render the message date  correctly', () => {
@@ -145,6 +147,14 @@ describe('<ChatMessage />', () => {
     const { getAllByTestId } = render(chatMessageVideo);
     fireEvent.click(getAllByTestId('popup')[0]);
     expect(getAllByTestId('downloadMedia')[0]).toBeVisible();
+
+    // For download video
+    const download = getAllByTestId('downloadMedia')[0];
+    expect(download).toBeVisible();
+
+    await waitFor(() => {
+      fireEvent.click(download);
+    });
   });
 
   const chatMessageAudio = chatMessage('AUDIO');
@@ -153,6 +163,14 @@ describe('<ChatMessage />', () => {
     const { getAllByTestId } = render(chatMessageAudio);
     fireEvent.click(getAllByTestId('popup')[0]);
     expect(getAllByTestId('downloadMedia')[0]).toBeVisible();
+
+    // For download audio
+    const download = getAllByTestId('downloadMedia')[0];
+    expect(download).toBeVisible();
+
+    await waitFor(() => {
+      fireEvent.click(download);
+    });
   });
 
   const chatMessageImage = chatMessage('IMAGE');
@@ -161,14 +179,37 @@ describe('<ChatMessage />', () => {
     const { getAllByTestId } = render(chatMessageImage);
     fireEvent.click(getAllByTestId('popup')[0]);
     expect(getAllByTestId('downloadMedia')[0]).toBeVisible();
+
+    // For download image
+    const download = getAllByTestId('downloadMedia')[0];
+    expect(download).toBeVisible();
+
+    await waitFor(() => {
+      fireEvent.click(download);
+    });
   });
 
   const chatMessageDoc = chatMessage('DOCUMENT');
 
   test('it should show the download media option when clicked on down arrow and message type is document', async () => {
-    const { getAllByTestId } = render(chatMessageDoc);
+    const { getAllByTestId, getAllByText } = render(chatMessageDoc);
     fireEvent.click(getAllByTestId('popup')[0]);
-    expect(getAllByTestId('downloadMedia')[0]).toBeVisible();
+
+    // for speedsend
+    const speedSend = getAllByText('Add to speed sends');
+    expect(speedSend[0]).toBeInTheDocument();
+
+    await waitFor(() => {
+      fireEvent.click(speedSend[0]);
+    });
+
+    // For download document
+    const download = getAllByTestId('downloadMedia')[0];
+    expect(download).toBeVisible();
+
+    await waitFor(() => {
+      fireEvent.click(download);
+    });
   });
 
   test('it should click on replied message', async () => {
@@ -186,18 +227,19 @@ describe('<ChatMessage />', () => {
         <ChatMessage {...props} />
       </MockedProvider>
     );
+
     const errors = screen.getAllByTestId('tooltip');
     expect(errors[0]).toHaveTextContent('Warning.svg');
   });
 
-  const imageProps = Props('IMAGE');
+  const imageProps = Props('DOCUMENT');
   test('it should render error with message', () => {
     imageProps.media = {
-      url:
-        'https://i.picsum.photos/id/674/200/300.jpg?hmac=kS3VQkm7AuZdYJGUABZGmnNj_3KtZ6Twgb5Qb9ITssY',
-      caption: '\n',
+      url: 'https://file-examples-com.github.io/uploads/2017/10/file-sample_150kB.pdf',
+      caption: 'test',
     };
-    props.errors = '{"message": ["Something went wrong"]}';
+    imageProps.errors = '{"message": ["Something went wrong"]}';
+
     render(
       <MockedProvider mocks={mocks} addTypename={false}>
         <ChatMessage {...imageProps} />

--- a/src/containers/Chat/ChatMessages/ChatMessage/ChatMessage.tsx
+++ b/src/containers/Chat/ChatMessages/ChatMessage/ChatMessage.tsx
@@ -256,8 +256,7 @@ export const ChatMessage: React.SFC<ChatMessageProps> = (props) => {
     </Tooltip>
   ) : null;
 
-  const message = contextMessage ? contextMessage.body : body;
-  const { body: bodyText, buttons: templateButtons } = WhatsAppTemplateButton(message);
+  const { body: bodyText, buttons: templateButtons } = WhatsAppTemplateButton(body);
 
   return (
     <div
@@ -283,7 +282,7 @@ export const ChatMessage: React.SFC<ChatMessageProps> = (props) => {
                   <ChatMessageType
                     type={contextMessage.type}
                     media={contextMessage.media}
-                    body={bodyText}
+                    body={contextMessage.body}
                     insertedAt={contextMessage.insertedAt}
                     location={contextMessage.location}
                   />

--- a/src/containers/Chat/ChatMessages/ChatMessage/ChatMessage.tsx
+++ b/src/containers/Chat/ChatMessages/ChatMessage/ChatMessage.tsx
@@ -13,10 +13,11 @@ import { ReactComponent as WarningIcon } from '../../../../assets/images/icons/W
 import { ReactComponent as MessageIcon } from '../../../../assets/images/icons/Dropdown.svg';
 import { ReactComponent as CloseIcon } from '../../../../assets/images/icons/Close.svg';
 import { AddToMessageTemplate } from '../AddToMessageTemplate/AddToMessageTemplate';
+import { TemplateButtons } from '../TemplateButtons/TemplateButtons';
 import { DATE_FORMAT, TIME_FORMAT } from '../../../../common/constants';
 import { UPDATE_MESSAGE_TAGS } from '../../../../graphql/mutations/Chat';
 import { setNotification } from '../../../../common/notification';
-import { WhatsAppToJsx } from '../../../../common/RichEditor';
+import { WhatsAppToJsx, WhatsAppTemplateButton } from '../../../../common/RichEditor';
 import { ChatMessageType } from './ChatMessageType/ChatMessageType';
 import { Tooltip } from '../../../../components/UI/Tooltip/Tooltip';
 import { parseTextMethod } from '../../../../common/utils';
@@ -255,6 +256,9 @@ export const ChatMessage: React.SFC<ChatMessageProps> = (props) => {
     </Tooltip>
   ) : null;
 
+  const message = contextMessage ? contextMessage.body : body;
+  const { body: bodyText, buttons: templateButtons } = WhatsAppTemplateButton(message);
+
   return (
     <div
       className={additionalClass}
@@ -279,7 +283,7 @@ export const ChatMessage: React.SFC<ChatMessageProps> = (props) => {
                   <ChatMessageType
                     type={contextMessage.type}
                     media={contextMessage.media}
-                    body={contextMessage.body}
+                    body={bodyText}
                     insertedAt={contextMessage.insertedAt}
                     location={contextMessage.location}
                   />
@@ -299,12 +303,12 @@ export const ChatMessage: React.SFC<ChatMessageProps> = (props) => {
           } ${type === 'STICKER' ? styles.StickerBackground : ''}`}
         >
           <Tooltip title={tooltipTitle} placement={isSender ? 'right' : 'left'}>
-            <div className={styles.Content} data-testid="content">
-              <div>
+            <div>
+              <div className={styles.Content} data-testid="content">
                 <ChatMessageType
                   type={type}
                   media={media}
-                  body={body}
+                  body={bodyText}
                   insertedAt={insertedAt}
                   location={location}
                 />
@@ -369,6 +373,9 @@ export const ChatMessage: React.SFC<ChatMessageProps> = (props) => {
       {saveTemplateMessage}
 
       <div className={messageDetails}>
+        <div className={`${messageErrorStatus && styles.TemplateButtonOnError}`}>
+          <TemplateButtons template={templateButtons} />
+        </div>
         {date}
         {displayTag ? (
           <div className={`${styles.TagContainer} ${tagContainer}`}>{displayTag}</div>

--- a/src/containers/Chat/ChatMessages/ChatMessages.test.tsx
+++ b/src/containers/Chat/ChatMessages/ChatMessages.test.tsx
@@ -251,12 +251,12 @@ it('should have an emoji picker', async () => {
   });
 });
 
-it('should contain the mock message', async () => {
-  const { getByText } = render(chatMessages);
-  await waitFor(() => {
-    expect(getByText('Hey there whats up?')).toBeInTheDocument();
-  });
-});
+// it('should contain the mock message', async () => {
+//   const { getByText } = render(chatMessages);
+//   await waitFor(() => {
+//     expect(getByText('Hey there whats up?')).toBeInTheDocument();
+//   });
+// });
 
 test('click on assign tag should open a dialog box with already assigned tags', async () => {
   const { getByTestId } = render(chatMessages);

--- a/src/containers/Chat/ChatMessages/ChatMessages.test.tsx
+++ b/src/containers/Chat/ChatMessages/ChatMessages.test.tsx
@@ -251,12 +251,12 @@ it('should have an emoji picker', async () => {
   });
 });
 
-// it('should contain the mock message', async () => {
-//   const { getByText } = render(chatMessages);
-//   await waitFor(() => {
-//     expect(getByText('Hey there whats up?')).toBeInTheDocument();
-//   });
-// });
+it('should contain the mock message', async () => {
+  const { getByText } = render(chatMessages);
+  await waitFor(() => {
+    expect(getByText('Hey there whats up?')).toBeInTheDocument();
+  });
+});
 
 test('click on assign tag should open a dialog box with already assigned tags', async () => {
   const { getByTestId } = render(chatMessages);

--- a/src/containers/Chat/ChatMessages/TemplateButtons/TemplateButtons.module.css
+++ b/src/containers/Chat/ChatMessages/TemplateButtons/TemplateButtons.module.css
@@ -1,0 +1,14 @@
+.TemplateButtonContainer {
+  display: flex;
+  flex-wrap: wrap;
+  max-width: 404px;
+}
+
+.TemplateButton {
+  background-color: #cacaca !important;
+  width: 100%;
+  color: #ffffff !important;
+  border-radius: 10px !important;
+  margin: 2px 0px 1px 0px !important;
+  padding: 10px 0px !important;
+}

--- a/src/containers/Chat/ChatMessages/TemplateButtons/TemplateButtons.module.css
+++ b/src/containers/Chat/ChatMessages/TemplateButtons/TemplateButtons.module.css
@@ -6,12 +6,25 @@
 }
 
 .TemplateButton {
-  background-color: #cacaca !important;
   width: 100%;
-  color: #ffffff !important;
   border-radius: 10px !important;
   margin: 2px 0px 1px 0px !important;
   padding: 12px 0px !important;
   font-size: 16px;
   line-height: 1.25 !important;
+}
+
+.Simulator {
+  background-color: #ffffff !important;
+  color: #1690cf !important;
+}
+
+.Chat {
+  background-color: #eaedec !important;
+  color: #119656 !important;
+}
+
+.TemplateButton:disabled {
+  color: #9a9e9f !important;
+  pointer-events: none !important;
 }

--- a/src/containers/Chat/ChatMessages/TemplateButtons/TemplateButtons.module.css
+++ b/src/containers/Chat/ChatMessages/TemplateButtons/TemplateButtons.module.css
@@ -11,5 +11,7 @@
   color: #ffffff !important;
   border-radius: 10px !important;
   margin: 2px 0px 1px 0px !important;
-  padding: 10px 0px !important;
+  padding: 12px 0px !important;
+  font-size: 16px;
+  line-height: 1.25 !important;
 }

--- a/src/containers/Chat/ChatMessages/TemplateButtons/TemplateButtons.module.css
+++ b/src/containers/Chat/ChatMessages/TemplateButtons/TemplateButtons.module.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-wrap: wrap;
   max-width: 404px;
+  margin: 4px 0px;
 }
 
 .TemplateButton {

--- a/src/containers/Chat/ChatMessages/TemplateButtons/TemplateButtons.test.tsx
+++ b/src/containers/Chat/ChatMessages/TemplateButtons/TemplateButtons.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { TemplateButtons } from './TemplateButtons';
+
+const props: any = {
+  template: [
+    {
+      title: 'Click here',
+      value: 'www.google.com',
+      tooltip: 'Currently not supported',
+      type: 'call-to-action',
+    },
+    {
+      title: 'Contact us',
+      value: null,
+      tooltip: 'Currently not supported',
+      type: 'call-to-action',
+    },
+  ],
+};
+window.open = jest.fn();
+
+test('renders components successfully with call-to-action buttons', () => {
+  render(<TemplateButtons {...props} />);
+  expect(screen.getByText(/Contact us/i)).toBeInTheDocument();
+  expect(screen.getByText(/Click here/i)).toBeInTheDocument();
+});
+
+test('renders components successfully with callback event', () => {
+  render(<TemplateButtons {...props} />);
+  const button = screen.getByText(/Click here/i);
+  expect(button).toBeInTheDocument();
+
+  fireEvent.click(button);
+  expect(window.open).toHaveBeenCalledTimes(1);
+  expect(window.open).toHaveBeenCalledWith('www.google.com', '_blank');
+});
+
+test('renders components with quick reply buttons', () => {
+  props.template = [
+    {
+      title: 'Yes',
+      value: 'Yes',
+      tooltip: null,
+      type: 'quick-reply',
+    },
+  ];
+  props.callbackTemplateButtonClick = jest.fn();
+
+  render(<TemplateButtons {...props} />);
+  const button = screen.getByText('Yes');
+  expect(button).toBeInTheDocument();
+
+  fireEvent.click(button);
+
+  expect(props.callbackTemplateButtonClick).toHaveBeenCalledTimes(1);
+});

--- a/src/containers/Chat/ChatMessages/TemplateButtons/TemplateButtons.test.tsx
+++ b/src/containers/Chat/ChatMessages/TemplateButtons/TemplateButtons.test.tsx
@@ -5,15 +5,17 @@ const props: any = {
   template: [
     {
       title: 'Click here',
-      value: 'www.google.com',
+      value: 'http://www.google.com',
       tooltip: 'Currently not supported',
       type: 'call-to-action',
+      icon: <span></span>,
     },
     {
       title: 'Contact us',
       value: null,
       tooltip: 'Currently not supported',
       type: 'call-to-action',
+      icon: <span></span>,
     },
   ],
 };
@@ -26,13 +28,14 @@ test('renders components successfully with call-to-action buttons', () => {
 });
 
 test('renders components successfully with callback event', () => {
+  props.isSimulator = true;
   render(<TemplateButtons {...props} />);
   const button = screen.getByText(/Click here/i);
   expect(button).toBeInTheDocument();
 
   fireEvent.click(button);
   expect(window.open).toHaveBeenCalledTimes(1);
-  expect(window.open).toHaveBeenCalledWith('www.google.com', '_blank');
+  expect(window.open).toHaveBeenCalledWith('http://www.google.com', '_blank');
 });
 
 test('renders components with quick reply buttons', () => {
@@ -42,8 +45,10 @@ test('renders components with quick reply buttons', () => {
       value: 'Yes',
       tooltip: null,
       type: 'quick-reply',
+      icon: <span></span>,
     },
   ];
+  props.isSimulator = true;
   props.callbackTemplateButtonClick = jest.fn();
 
   render(<TemplateButtons {...props} />);

--- a/src/containers/Chat/ChatMessages/TemplateButtons/TemplateButtons.tsx
+++ b/src/containers/Chat/ChatMessages/TemplateButtons/TemplateButtons.tsx
@@ -6,7 +6,7 @@ import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 import styles from './TemplateButtons.module.css';
 
 interface TemplateButtonProps {
-  template: Array<string>;
+  template: Array<any>;
   callbackTemplateButtonClick?: any;
 }
 

--- a/src/containers/Chat/ChatMessages/TemplateButtons/TemplateButtons.tsx
+++ b/src/containers/Chat/ChatMessages/TemplateButtons/TemplateButtons.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Button } from '@material-ui/core';
+
+import styles from './TemplateButtons.module.css';
+
+interface TemplateButtonProps {
+  template: Array<string>;
+  callbackTemplateButtonClick?: any;
+}
+
+export const TemplateButtons: React.SFC<TemplateButtonProps> = ({
+  template,
+  callbackTemplateButtonClick = () => null,
+}) => {
+  const handleButtonClick = (type: string, value: string) => {
+    if (type === 'call-to-action') {
+      if (value) window.open(value, '_blank');
+    } else {
+      callbackTemplateButtonClick(value);
+    }
+  };
+
+  return (
+    <div className={styles.TemplateButtonContainer}>
+      {template?.map(({ title, value, type }: any) => (
+        <Button
+          className={styles.TemplateButton}
+          key={value}
+          onClick={() => handleButtonClick(type, value)}
+        >
+          {title}
+        </Button>
+      ))}
+    </div>
+  );
+};
+
+export default TemplateButtons;

--- a/src/containers/Chat/ChatMessages/TemplateButtons/TemplateButtons.tsx
+++ b/src/containers/Chat/ChatMessages/TemplateButtons/TemplateButtons.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { Button } from '@material-ui/core';
+import CallIcon from '@material-ui/icons/Call';
+import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 
 import styles from './TemplateButtons.module.css';
 
@@ -20,13 +22,22 @@ export const TemplateButtons: React.SFC<TemplateButtonProps> = ({
     }
   };
 
+  const startIcon = (type: string, value: string) => {
+    if (type === 'call-to-action') {
+      return value ? <OpenInNewIcon /> : <CallIcon />;
+    }
+    return null;
+  };
+
   return (
     <div className={styles.TemplateButtonContainer}>
-      {template?.map(({ title, value, type }: any) => (
+      {template?.map(({ title, value, type, tooltip }: any) => (
         <Button
+          key={title}
+          title={tooltip}
           className={styles.TemplateButton}
-          key={value}
           onClick={() => handleButtonClick(type, value)}
+          startIcon={startIcon(type, value)}
         >
           {title}
         </Button>

--- a/src/containers/Chat/ChatMessages/TemplateButtons/TemplateButtons.tsx
+++ b/src/containers/Chat/ChatMessages/TemplateButtons/TemplateButtons.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import { Button } from '@material-ui/core';
-import CallIcon from '@material-ui/icons/Call';
-import OpenInNewIcon from '@material-ui/icons/OpenInNew';
 
 import styles from './TemplateButtons.module.css';
 
 interface TemplateButtonProps {
   template: Array<any>;
   callbackTemplateButtonClick?: any;
+  isSimulator?: any;
 }
 
 export const TemplateButtons: React.SFC<TemplateButtonProps> = ({
   template,
-  callbackTemplateButtonClick = () => null,
+  callbackTemplateButtonClick,
+  isSimulator = false,
 }) => {
   const handleButtonClick = (type: string, value: string) => {
     if (type === 'call-to-action') {
@@ -22,22 +22,16 @@ export const TemplateButtons: React.SFC<TemplateButtonProps> = ({
     }
   };
 
-  const startIcon = (type: string, value: string) => {
-    if (type === 'call-to-action') {
-      return value ? <OpenInNewIcon /> : <CallIcon />;
-    }
-    return null;
-  };
-
   return (
     <div className={styles.TemplateButtonContainer}>
-      {template?.map(({ title, value, type, tooltip }: any) => (
+      {template?.map(({ title, value, type, tooltip, icon }): any => (
         <Button
           key={title}
           title={tooltip}
-          className={styles.TemplateButton}
+          className={`${styles.TemplateButton} ${isSimulator ? styles.Simulator : styles.Chat}`}
           onClick={() => handleButtonClick(type, value)}
-          startIcon={startIcon(type, value)}
+          startIcon={icon}
+          disabled={!isSimulator}
         >
           {title}
         </Button>

--- a/src/containers/WalletBalance/WalletBalance.tsx
+++ b/src/containers/WalletBalance/WalletBalance.tsx
@@ -80,7 +80,7 @@ export const WalletBalance: React.FC<WalletBalanceProps> = ({ fullOpen }) => {
   });
 
   const updateBalanceValue = (balance: any) => {
-    if (balance && balance !== null) {
+    if (balance) {
       setDisplayBalance(balance);
     }
   };


### PR DESCRIPTION
Completed tasks: 
- Added support for template buttons
- For call-to-action with URL type will redirect to new screen
- For call-to-action with contact type does nothing
- For quick-reply buttons replies with appropriate text
- Fixed CSS issue for messages with errors for `ChatMessage.tsx`

Pending
- Add icons for template buttons of type call-to-action
- Fix simulator CSS for buttons, currently buttons are inside message