### PR TITLE
Suspense fallback loading fix

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,7 +61,7 @@ const App = () => {
       <ApolloProvider client={gqlClient(history)}>
         <ErrorHandler />
         <ClearCacheProvider duration={CLEAR_CACHE_DURATION}>
-          <Suspense fallback={Loading}>{routes}</Suspense>
+          <Suspense fallback={<Loading />}>{routes}</Suspense>
         </ClearCacheProvider>
       </ApolloProvider>
     </SessionContext.Provider>


### PR DESCRIPTION
## Summary

When we switch between screens we get a white canvas with nothing on it. This PR adds a loading fallback on the screen when switching between pages.
