### PR TITLE
Now buttons will be added/removed, fixed bug when adding | symbol to

### DIFF
--- a/src/common/RichEditor.tsx
+++ b/src/common/RichEditor.tsx
@@ -139,20 +139,21 @@ export const WhatsAppTemplateButton = (text: string) => {
 
   // Returning early if text is null
   if (!text) return result;
-  // Checking if template consists of buttons or not because they are separated with `|`
-  const isTemplateButtonsPresent = text.indexOf('|');
+  /**
+   * Regular expression to check if there is buttons present in message
+   * `search` will return first index of given pattern or it will return -1 if not found
+   */
+  const exp = /(\|\s\[)|(\|\[)/;
+  const isTemplateButtonsPresent = text.search(exp);
+
   if (isTemplateButtonsPresent > 0) {
-    const templateStr = text.split('|');
-    const templateButtons = templateStr.map((val: string, index: number) => {
-      /**
-       * templateStr 0th element is template message
-       * otherwise slice from 1 to last value
-       * For removing `[]` brackets
-       */
-      if (index === 0) return val.trim();
-      return val.trim().slice(1, -1);
-    });
-    const [messageBody, ...buttons] = templateButtons;
+    const messageBody = text.substr(0, isTemplateButtonsPresent);
+    const buttonsStr = text.substr(isTemplateButtonsPresent);
+    const templateStr = buttonsStr.split('|');
+
+    const buttons = templateStr
+      .map((val: string) => val && val.trim().slice(1, -1))
+      .filter((a) => a);
 
     // Checking if template type is call to action or quick reply
 

--- a/src/containers/Template/Form/HSM/HSM.tsx
+++ b/src/containers/Template/Form/HSM/HSM.tsx
@@ -75,7 +75,13 @@ export const HSM: React.SFC<HSMProps> = ({ match }) => {
 
   const getTemplate = (text: string) => {
     const { body } = sampleMessages;
-    const areButtonsPresent = body.indexOf('|');
+    /**
+     * Regular expression to check if message contains given pattern
+     * If pattern is present search will return first index of given pattern
+     * otherwise it will return -1
+     */
+    const exp = /(\|\s\[)|(\|\[)/;
+    const areButtonsPresent = body.search(exp);
     if (areButtonsPresent > -1) {
       const buttons = body.substr(areButtonsPresent);
       return text + buttons;

--- a/src/containers/Template/Form/Template.tsx
+++ b/src/containers/Template/Form/Template.tsx
@@ -26,12 +26,9 @@ import { validateMedia } from '../../../common/utils';
 
 const regexForShortcode = /^[a-z0-9_]+$/g;
 
-const validateExample = (value: any) => value.indexOf('|') === -1;
-
 const HSMValidation = {
   example: Yup.string()
     .transform((current, original) => original.getCurrentContent().getPlainText())
-    .test('Do not allow Pipe symbol', 'Symbol | is not allowed', validateExample)
     .required('Example is required.'),
   category: Yup.object().nullable().required('Category is required.'),
   shortcode: Yup.string()

--- a/src/containers/Template/Form/Template.tsx
+++ b/src/containers/Template/Form/Template.tsx
@@ -26,9 +26,12 @@ import { validateMedia } from '../../../common/utils';
 
 const regexForShortcode = /^[a-z0-9_]+$/g;
 
+const validateExample = (value: any) => value.indexOf('|') === -1;
+
 const HSMValidation = {
   example: Yup.string()
     .transform((current, original) => original.getCurrentContent().getPlainText())
+    .test('Do not allow Pipe symbol', 'Symbol | is not allowed', validateExample)
     .required('Example is required.'),
   category: Yup.object().nullable().required('Category is required.'),
   shortcode: Yup.string()
@@ -538,7 +541,8 @@ const Template: React.SFC<TemplateProps> = (props) => {
   }, [templateType]);
 
   const getTemplateAndButton = (text: string) => {
-    const areButtonsPresent = text.indexOf('|');
+    const exp = /(\|\s\[)|(\|\[)/;
+    const areButtonsPresent = text.search(exp);
 
     let message: any = text;
     let buttons: any = null;
@@ -550,6 +554,14 @@ const Template: React.SFC<TemplateProps> = (props) => {
 
     return { message, buttons };
   };
+
+  // Removing buttons when checkbox is checked or unchecked
+  useEffect(() => {
+    if (getExample) {
+      const { message }: any = getTemplateAndButton(convertToWhatsApp(getExample));
+      onExampleChange(message || '');
+    }
+  }, [isAddButtonChecked]);
 
   // Converting buttons to template and vice-versa to show realtime update on simulator
   useEffect(() => {


### PR DESCRIPTION
- Now you can add/remove template buttons on the HSM screen
- Now if `|` operator is present, an appropriate validation error will be shown
- Now parsing buttons with regular expression which check if appropriate button format is present or not


closes #1492 