### PR TITLE
proper error handling for calendar and time picker

### DIFF
--- a/src/components/UI/Form/Calendar/Calendar.tsx
+++ b/src/components/UI/Form/Calendar/Calendar.tsx
@@ -42,7 +42,7 @@ export const Calendar: React.SFC<CalendarProps> = ({
     <MuiPickersUtilsProvider utils={DateFnsUtils}>
       <Grid className={styles.Calendar}>
         <KeyboardDatePicker
-          error={hasError ? errorText : ''}
+          error={hasError}
           autoOk
           variant={variant}
           inputVariant={inputVariant}

--- a/src/components/UI/Form/TimePicker/TimePicker.tsx
+++ b/src/components/UI/Form/TimePicker/TimePicker.tsx
@@ -42,7 +42,7 @@ export const TimePicker: React.SFC<TimePickerProps> = ({
     <MuiPickersUtilsProvider utils={DateFnsUtils}>
       <Grid className={styles.TimePicker}>
         <KeyboardTimePicker
-          error={hasError ? errorText : ''}
+          error={hasError}
           autoOk
           variant={variant}
           inputVariant={inputVariant}


### PR DESCRIPTION

## Summary

* Followup PR for handling calendar and timepicker errors. `error` prop should be boolean instead of a string.
## Test Plan

* Not needed
