### PR TITLE
Enable split by contact field

### DIFF
--- a/src/components/floweditor/FlowEditor.tsx
+++ b/src/components/floweditor/FlowEditor.tsx
@@ -104,7 +104,6 @@ const setConfig = (uuid: any) => ({
     'start_session',
     'open_ticket',
     'transfer_airtime',
-    'split_by_contact_field',
     'split_by_random',
     'split_by_scheme',
   ],


### PR DESCRIPTION
- We already enabled this functionality in the backend. 
- So now wanted to enable this action on the frontend so that I can assign this to the team for testing and documentation. 