### PR TITLE
Lets not make a global change for checkbox background

### DIFF
--- a/src/config/theme.tsx
+++ b/src/config/theme.tsx
@@ -68,25 +68,6 @@ const theme = createTheme({
       label: { color: '#073f24' },
     },
 
-    MuiIconButton: {
-      root: {
-        '& .MuiIconButton-label': {
-          position: 'relative',
-          zIndex: 0,
-        },
-        '& .MuiIconButton-label:after': {
-          content: '""',
-          left: 4,
-          top: 4,
-          height: 15,
-          width: 15,
-          position: 'absolute',
-          backgroundColor: 'white',
-          zIndex: -1,
-        },
-      },
-    },
-
     MuiListItem: {
       root: {
         color: '073F24',

--- a/src/containers/Organization/Registration/Registration.module.css
+++ b/src/containers/Organization/Registration/Registration.module.css
@@ -34,3 +34,19 @@
   font-size: 14px;
   font-weight: 400 !important;
 }
+
+.Wrapper :global(.MuiIconButton-label) {
+  position: relative;
+  z-index: 0;
+}
+
+.Wrapper :global(.MuiIconButton-label:after) {
+  content: '';
+  left: 4px;
+  top: 4px;
+  height: 15px;
+  width: 15px;
+  position: absolute;
+  background-color: white;
+  z-index: -1;
+}


### PR DESCRIPTION


## Summary

Lets not make a global change for checkbox background as it is affecting other areas. 

We can extend the checkbox on organization registration page to use in other places where white background is needed.
