### PR TITLE
Dialogbox error description centered

### DIFF
--- a/src/components/UI/DialogBox/DialogBox.module.css
+++ b/src/components/UI/DialogBox/DialogBox.module.css
@@ -40,6 +40,9 @@
   color: #073f24;
   padding-top: 24px !important;
   padding-bottom: 8px !important;
+  justify-content: center !important;
+  display: flex !important;
+  flex-direction: column !important;
 }
 
 .DialogTitle h2 {
@@ -49,13 +52,13 @@
 .DialogTitleCenter {
   composes: DialogTitle;
   text-align: center;
-  max-width: 395px;
+  max-width: 100%;
 }
 
 .DialogTitleLeft {
   composes: DialogTitle;
   text-align: left;
-  max-width: 395px;
+  max-width: 100%;
 }
 
 .DialogContentCenter {


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/glific/glific-frontend) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Please ensure coding standard and conventions are followed. You can find the details at https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing

-->

## Summary

As discussed in meeting and in the following issue https://github.com/glific/glific-frontend/issues/2164, I have centred the error title `An Error Has Occured!`. The fixes has been implemented into the file `src/components/UI/DialogBox/DialogBox.module.css` 

## Test Plan

I have extended the error message to be able to set the CSS accurately. The current behaviour can be seen here

_Error with long message_
<img width="794" alt="CleanShot 2022-10-17 at 02 32 45@2x" src="https://user-images.githubusercontent.com/71540402/196105108-6c372267-528c-4029-8ec4-8e18dc6b55e0.png">
_Error with short message_
<img width="688" alt="CleanShot 2022-10-17 at 02 34 06@2x" src="https://user-images.githubusercontent.com/71540402/196105260-01e40f41-897e-463e-8861-5ad2704bf8f1.png">

