### PR TITLE
Fixed floweditor issue with nodes moving to right

### DIFF
--- a/src/components/floweditor/FlowEditor.module.css
+++ b/src/components/floweditor/FlowEditor.module.css
@@ -45,6 +45,7 @@
 .FlowContainer {
   position: relative;
   height: 100vh;
+  overflow: auto;
 }
 
 .ButtonContainer {


### PR DESCRIPTION

## Summary

Fixes #2192 but creates issue when opening the revisions dialog https://github.com/glific/glific-frontend/issues/2057. 
Since this looks more critical. Adding this fix now and see if both can be fixed.

Fixed floweditor issue with nodes moving to right.
