### PR TITLE
Collection contact filter based on name or phone

### DIFF
--- a/src/containers/Collection/CollectionContact/CollectionContactList/CollectionContactList.tsx
+++ b/src/containers/Collection/CollectionContact/CollectionContactList/CollectionContactList.tsx
@@ -74,7 +74,7 @@ export const CollectionContactList = ({ title }: CollectionContactListProps) => 
       title={title}
       listItem="contacts"
       listItemName="contact"
-      searchParameter={['name']}
+      searchParameter={['term']}
       filters={{ includeGroups: collectionId }}
       button={{ show: false, label: '' }}
       pageLink="contact"


### PR DESCRIPTION
Target issue: https://github.com/glific/glific-frontend/issues/2376

1. Changed the filter parameter to **term** from **name** in the contact collection list screen's search. It filters the contacts based on name or phone.