### PR TITLE
Added Error message for when the account doesn't exist.

### DIFF
--- a/src/containers/Auth/ResetPassword/ResetPasswordPhone.test.tsx
+++ b/src/containers/Auth/ResetPassword/ResetPasswordPhone.test.tsx
@@ -56,7 +56,7 @@ describe('<ResetPasswordPhone />', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('AuthContainer')).toHaveTextContent(
-        errorMessage?.response?.data?.error?.message
+        errorMessage.response.data.error.message
       );
     });
   });

--- a/src/containers/Auth/ResetPassword/ResetPasswordPhone.test.tsx
+++ b/src/containers/Auth/ResetPassword/ResetPasswordPhone.test.tsx
@@ -36,11 +36,17 @@ describe('<ResetPasswordPhone />', () => {
 
   test('test the form submission with incorrect phone', async () => {
     // set the mock
-    const errorMessage = 'Cannot send the otp to 919978776554';
-    mockedAxios.post.mockImplementation(() => Promise.reject(new Error(errorMessage)));
+    const errorMessage = {
+      response: {
+        data: {
+          error: {
+            message: 'Account with phone number 919425010449 does not exist',
+          },
+        },
+      },
+    };
+    mockedAxios.post.mockImplementation(() => Promise.reject(errorMessage));
     const { container } = render(wrapper);
-
-    // enter the phone
     const phone = container.querySelector('input[type="tel"]') as HTMLInputElement;
     fireEvent.change(phone, { target: { value: '+919978776554' } });
 
@@ -49,9 +55,8 @@ describe('<ResetPasswordPhone />', () => {
     UserEvent.click(continueButton);
 
     await waitFor(() => {
-      const authContainer = screen.getByTestId('AuthContainer');
-      expect(authContainer).toHaveTextContent(
-        'We are unable to generate an OTP, kindly contact your technical team.'
+      expect(screen.getByTestId('AuthContainer')).toHaveTextContent(
+        errorMessage?.response?.data?.error?.message
       );
     });
   });

--- a/src/containers/Auth/ResetPassword/ResetPasswordPhone.tsx
+++ b/src/containers/Auth/ResetPassword/ResetPasswordPhone.tsx
@@ -26,8 +26,8 @@ export const ResetPasswordPhone = () => {
         setValues(data);
         setRedirect(true);
       })
-      .catch(() => {
-        setAuthError(t('We are unable to generate an OTP, kindly contact your technical team.'));
+      .catch((error) => {
+        setAuthError(error?.response?.data?.error?.message)
       });
   };
 

--- a/src/containers/Auth/ResetPassword/ResetPasswordPhone.tsx
+++ b/src/containers/Auth/ResetPassword/ResetPasswordPhone.tsx
@@ -27,11 +27,12 @@ export const ResetPasswordPhone = () => {
         setRedirect(true);
       })
       .catch((error) => {
-        if (error?.response?.data?.error?.message) {
-          setAuthError(error?.response?.data?.error?.message);
-        } else {
-          setAuthError('We are unable to generate an OTP, kindly contact your technical team.');
-        }
+       let errorMsg = error?.response?.data?.error?.message
+       if (!errorMsg) {
+          errorMsg="We are unable to generate an OTP, kindly contact your technical team."
+        } 
+       setAuthError(errorMsg);
+       
       });
   };
 

--- a/src/containers/Auth/ResetPassword/ResetPasswordPhone.tsx
+++ b/src/containers/Auth/ResetPassword/ResetPasswordPhone.tsx
@@ -27,7 +27,7 @@ export const ResetPasswordPhone = () => {
         setRedirect(true);
       })
       .catch((error) => {
-        if (error?.response?.status === 400) {
+        if (error?.response?.data?.error?.message) {
           setAuthError(error?.response?.data?.error?.message);
         } else {
           setAuthError('We are unable to generate an OTP, kindly contact your technical team.');

--- a/src/containers/Auth/ResetPassword/ResetPasswordPhone.tsx
+++ b/src/containers/Auth/ResetPassword/ResetPasswordPhone.tsx
@@ -29,7 +29,7 @@ export const ResetPasswordPhone = () => {
       .catch((error) => {
         if (error?.response?.status === 400) {
           setAuthError(error?.response?.data?.error?.message);
-        } else if (error?.response?.status === 500) {
+        } else {
           setAuthError('We are unable to generate an OTP, kindly contact your technical team.');
         }
       });

--- a/src/containers/Auth/ResetPassword/ResetPasswordPhone.tsx
+++ b/src/containers/Auth/ResetPassword/ResetPasswordPhone.tsx
@@ -27,7 +27,11 @@ export const ResetPasswordPhone = () => {
         setRedirect(true);
       })
       .catch((error) => {
-        setAuthError(error?.response?.data?.error?.message)
+        if (error?.response?.status === 400) {
+          setAuthError(error?.response?.data?.error?.message);
+        } else if (error?.response?.status === 500) {
+          setAuthError('We are unable to generate an OTP, kindly contact your technical team.');
+        }
       });
   };
 


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/glific/glific-frontend) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Please ensure coding standard and conventions are followed. You can find the details at https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing

-->

## Summary
If someone tries to reset their password using `forgot password`, but their account doesn't exist, they will see a clear message that says, "Account with phone number 91**** does not exist"
fixes #2620 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
