### PR TITLE
Fix: Added not rated for templates which have unknown quality

### DIFF
--- a/src/containers/Template/List/Template.tsx
+++ b/src/containers/Template/List/Template.tsx
@@ -41,7 +41,7 @@ import { RaiseToGupShup } from './RaiseToGupshupDialog/RaiseToGupShup';
 const getLabel = (label: string, quality?: string) => (
   <div className={styles.LabelContainer}>
     <div className={styles.LabelText}>{label}</div>
-    <div className={styles.Quality}>{quality || 'Not Rated'}</div>
+    <div className={styles.Quality}>{quality && quality !== 'UNKNOWN' ? quality : 'Not Rated'}</div>
   </div>
 );
 


### PR DESCRIPTION
if a template is not rated it returns UNKNOWN, so replaced that with Not Rated

<img width="754" alt="Screenshot 2024-07-22 at 7 39 48 PM" src="https://github.com/user-attachments/assets/66483e50-fd71-4091-a45f-8e17ddb3212a">
