### PR TITLE
Fix: Interactive templates taking a lot of time to load in the floweditor

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@emoji-mart/react": "^1.1.1",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
-    "@glific/flow-editor": "^1.26.3-14",
+    "@glific/flow-editor": "^1.26.3-15",
     "@lexical/react": "^0.17.1",
     "@mui/icons-material": "^6.1.1",
     "@mui/material": "^6.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -652,10 +652,10 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz#81fd50d11e2c32b2d6241470e3185b70c7b30699"
   integrity sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==
 
-"@glific/flow-editor@^1.26.3-14":
-  version "1.26.3-14"
-  resolved "https://registry.yarnpkg.com/@glific/flow-editor/-/flow-editor-1.26.3-14.tgz#39583fae301398b6176e7b73cd1197d66f0734a7"
-  integrity sha512-hRcNrflCGTLQeDDcIvQ2Cnu3lOYdd5zeMZX2d0XGbVzk/z9Fbx7yTrH2pgSjXd2A2XgKWw9hs0gB2QtEbanCDA==
+"@glific/flow-editor@^1.26.3-15":
+  version "1.26.3-15"
+  resolved "https://registry.yarnpkg.com/@glific/flow-editor/-/flow-editor-1.26.3-15.tgz#7f281213fb3348703343a43d8d72fb0a8f3203a6"
+  integrity sha512-bCDjpodnCr32ZLOgq36HvveSUXL5NibEjJ2qwnvIBeyROipHvTLFlS4zpyU7JIB+rK6SDXlgVLcWmSveNK228w==
   dependencies:
     react "^16.8.6"
     react-dom "^16.8.6"


### PR DESCRIPTION
On getting translations from the list api it takes a lot of time to load, so now changed it to call the /interactive=-template api for translations