### PR TITLE
HSM: Fixed Language dropdown #3188

### DIFF
--- a/src/containers/HSM/HSM.tsx
+++ b/src/containers/HSM/HSM.tsx
@@ -156,11 +156,10 @@ export const HSM = () => {
   };
 
   const getLanguageId = (value: any) => {
-    let result: any;
-    const selected = languageOptions.find((option: any) => option.label === value?.label);
-    result = selected;
-
-    if (result) setLanguageId(result);
+    if (value.label) {
+      const selected = languageOptions.find((option: any) => option.label === value.label);
+      setLanguageId(selected);
+    }
   };
 
   // Creating payload for button template

--- a/src/containers/HSM/HSM.tsx
+++ b/src/containers/HSM/HSM.tsx
@@ -156,12 +156,12 @@ export const HSM = () => {
   };
 
   const getLanguageId = (value: any) => {
-    if (value.label) {
-      const selected = languageOptions.find((option: any) => option.label === value.label);
-      setLanguageId(selected);
-    } else {
+    if (!value.label) {
       return;
     }
+
+    const selected = languageOptions.find((option: any) => option.label === value.label);
+    setLanguageId(selected);
   };
 
   // Creating payload for button template

--- a/src/containers/HSM/HSM.tsx
+++ b/src/containers/HSM/HSM.tsx
@@ -159,6 +159,8 @@ export const HSM = () => {
     if (value.label) {
       const selected = languageOptions.find((option: any) => option.label === value.label);
       setLanguageId(selected);
+    } else {
+      return;
     }
   };
 

--- a/src/containers/HSM/HSM.tsx
+++ b/src/containers/HSM/HSM.tsx
@@ -157,7 +157,7 @@ export const HSM = () => {
 
   const getLanguageId = (value: any) => {
     let result: any;
-    const selected = languageOptions.find((option: any) => option.label === value);
+    const selected = languageOptions.find((option: any) => option.label === value?.label);
     result = selected;
 
     if (result) setLanguageId(result);


### PR DESCRIPTION
When creating a hsm template language dropdown is not working as expected.

Steps to reproduce:
1. Go to create hsm page
2. Select language from dropdown
3. Type in any other field
4. The language selected changes into the previous one