### PR TITLE
HSM: Update toast message for HSM sync to reflect queued status

### DIFF
--- a/src/containers/HSM/HSMList/HSMList.tsx
+++ b/src/containers/HSM/HSMList/HSMList.tsx
@@ -109,7 +109,7 @@ export const HSMList = () => {
       if (data.errors) {
         setNotification(t('Sorry, failed to sync HSM updates.'), 'warning');
       } else {
-        setNotification(t('HSM queued for sync, Check notifications for updates.'), 'success');
+        setNotification(t('HSM queued for sync. Check notifications for updates.'), 'success');
       }
       setSyncTemplateLoad(false);
     },

--- a/src/containers/HSM/HSMList/HSMList.tsx
+++ b/src/containers/HSM/HSMList/HSMList.tsx
@@ -109,7 +109,7 @@ export const HSMList = () => {
       if (data.errors) {
         setNotification(t('Sorry, failed to sync HSM updates.'), 'warning');
       } else {
-        setNotification(t('HSMs updated successfully.'), 'success');
+        setNotification(t('HSM queued for sync, Check notifications for updates.'), 'success');
       }
       setSyncTemplateLoad(false);
     },

--- a/src/i18n/en/en.json
+++ b/src/i18n/en/en.json
@@ -441,7 +441,7 @@
   "Translate": "Translate",
   "back": "back",
   "Sorry, failed to sync HSM updates.": "Sorry, failed to sync HSM updates.",
-  "HSMs updated successfully.": "HSMs updated successfully.",
+  "HSM queued for sync, Check notifications for updates.": "HSM queued for sync, Check notifications for updates.",
   "Preview": "Preview",
   "An error occured while translating flows.": "An error occured while translating flows.",
   "Export with auto translate": "Export with auto translate",

--- a/src/i18n/en/en.json
+++ b/src/i18n/en/en.json
@@ -441,7 +441,7 @@
   "Translate": "Translate",
   "back": "back",
   "Sorry, failed to sync HSM updates.": "Sorry, failed to sync HSM updates.",
-  "HSM queued for sync, Check notifications for updates.": "HSM queued for sync, Check notifications for updates.",
+  "HSM queued for sync. Check notifications for updates.": "HSM queued for sync. Check notifications for updates.",
   "Preview": "Preview",
   "An error occured while translating flows.": "An error occured while translating flows.",
   "Export with auto translate": "Export with auto translate",


### PR DESCRIPTION
Issue #3316


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the notification message after syncing HSM templates to inform users that the sync is queued and to check notifications for updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->