### PR TITLE
Remove checkout of package-updates branch in Cypress setup

### DIFF
--- a/.github/workflows/cypress-testing.yml
+++ b/.github/workflows/cypress-testing.yml
@@ -96,7 +96,6 @@ jobs:
           git clone https://github.com/glific/cypress-testing.git
           echo done. go to dir.
           cd cypress-testing
-          git checkout package-updates
           cd ..
           cp -r cypress-testing/cypress cypress
           yarn add cypress@13.6.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow to streamline repository setup by removing an unnecessary branch checkout step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->