### PR TITLE
update node version constraint to <23

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "engines": {
-    "node": ">=20.0.0 <25"
+    "node": ">=20.0.0 <23"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the supported Node.js version range to allow versions 20.x and 22.x only, excluding versions 23 and above.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->