### PR TITLE
Trim leading spaces from media URL

### DIFF
--- a/src/containers/HSM/HSM.test.tsx
+++ b/src/containers/HSM/HSM.test.tsx
@@ -33,7 +33,6 @@ vi.mock('lexical-beautiful-mentions', async (importOriginal) => {
   };
 });
 
-// Add this spy before your tests
 const validateMediaSpy = vi.spyOn(utilsModule, 'validateMedia');
 
 describe('Edit mode', () => {

--- a/src/containers/HSM/HSM.test.tsx
+++ b/src/containers/HSM/HSM.test.tsx
@@ -335,4 +335,35 @@ describe('Add mode', () => {
     const callToActionRadio = screen.getByRole('radio', { name: 'Call to actions' }) as HTMLInputElement;
     expect(callToActionRadio.checked).toBe(false);
   });
+
+  test('attachment URL is trimmed before validation', async () => {
+    render(template);
+
+    await waitFor(() => {
+      expect(screen.getByText('Add a new HSM Template')).toBeInTheDocument();
+    });
+
+    // Select attachment type (e.g., IMAGE)
+    const autocompletes = screen.getAllByTestId('autocomplete-element');
+    autocompletes[2].focus();
+    fireEvent.keyDown(autocompletes[2], { key: 'ArrowDown' });
+    fireEvent.click(screen.getByText('IMAGE'), { key: 'Enter' });
+
+    // Enter attachment URL with spaces
+    const inputs = screen.getAllByRole('textbox');
+    fireEvent.change(inputs[3], { target: { value: '   https://example.com/image.jpg   ' } });
+
+    await waitFor(() => {
+      // The input value should still have spaces, but validation should use the trimmed value.
+      expect(inputs[3]).toHaveValue('   https://example.com/image.jpg   ');
+    });
+
+    // Optionally, trigger blur to invoke validation
+    fireEvent.blur(inputs[3]);
+
+    // There should be no validation error for a valid trimmed URL
+    await waitFor(() => {
+      expect(screen.queryByText('Attachment URL is required.')).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/containers/HSM/HSM.tsx
+++ b/src/containers/HSM/HSM.tsx
@@ -324,9 +324,7 @@ export const HSM = () => {
 
 const validateURL = (value: string) => {
   if (value && type) {
-    // const trimmedValue = value.trim(); 
     setValidatingURL(true);
-
     validateMedia(value, type.id, false).then((response: any) => {
       if (!response.data.is_valid) {
         setIsUrlValid(response.data.message);
@@ -590,10 +588,6 @@ const validateURL = (value: string) => {
       inputProp: {
         onBlur: (event: any) => {
           setAttachmentURL(event.target.value.trim());
-        },
-        onChange: (event: any) => {
-          clearTimeout(timer);
-          timer = setTimeout(() => setAttachmentURL(event.target.value.trim()), 1000);
         },
       },
     },

--- a/src/containers/HSM/HSM.tsx
+++ b/src/containers/HSM/HSM.tsx
@@ -322,19 +322,19 @@ export const HSM = () => {
     return payloadCopy;
   };
 
-const validateURL = (value: string) => {
-  if (value && type) {
-    setValidatingURL(true);
-    validateMedia(value, type.id, false).then((response: any) => {
-      if (!response.data.is_valid) {
-        setIsUrlValid(response.data.message);
-      } else {
-        setIsUrlValid('');
-      }
-      setValidatingURL(false);
-    });
-  }
-};
+  const validateURL = (value: string) => {
+    if (value && type) {
+      setValidatingURL(true);
+      validateMedia(value, type.id, false).then((response: any) => {
+        if (!response.data.is_valid) {
+          setIsUrlValid(response.data.message);
+        } else {
+          setIsUrlValid('');
+        }
+        setValidatingURL(false);
+      });
+    }
+  };
 
   const addTemplateButtons = (addFromTemplate: boolean = true) => {
     let buttons: any = [];

--- a/src/containers/HSM/HSM.tsx
+++ b/src/containers/HSM/HSM.tsx
@@ -324,10 +324,10 @@ export const HSM = () => {
 
 const validateURL = (value: string) => {
   if (value && type) {
-    const trimmedValue = value.trim(); 
+    // const trimmedValue = value.trim(); 
     setValidatingURL(true);
 
-    validateMedia(trimmedValue, type.id, false).then((response: any) => {
+    validateMedia(value, type.id, false).then((response: any) => {
       if (!response.data.is_valid) {
         setIsUrlValid(response.data.message);
       } else {
@@ -589,11 +589,11 @@ const validateURL = (value: string) => {
       ),
       inputProp: {
         onBlur: (event: any) => {
-          setAttachmentURL(event.target.value);
+          setAttachmentURL(event.target.value.trim());
         },
         onChange: (event: any) => {
           clearTimeout(timer);
-          timer = setTimeout(() => setAttachmentURL(event.target.value), 1000);
+          timer = setTimeout(() => setAttachmentURL(event.target.value.trim()), 1000);
         },
       },
     },

--- a/src/containers/HSM/HSM.tsx
+++ b/src/containers/HSM/HSM.tsx
@@ -322,20 +322,21 @@ export const HSM = () => {
     return payloadCopy;
   };
 
-  const validateURL = (value: string) => {
-    const trimmedValue = value.trim();
-    if (trimmedValue && type) {
-      setValidatingURL(true);
-      validateMedia(trimmedValue, type.id, false).then((response: any) => {
-        if (!response.data.is_valid) {
-          setIsUrlValid(response.data.message);
-        } else {
-          setIsUrlValid('');
-        }
-        setValidatingURL(false);
-      });
-    }
-  };
+const validateURL = (value: string) => {
+  if (value && type) {
+    const trimmedValue = value.trim(); 
+    setValidatingURL(true);
+
+    validateMedia(trimmedValue, type.id, false).then((response: any) => {
+      if (!response.data.is_valid) {
+        setIsUrlValid(response.data.message);
+      } else {
+        setIsUrlValid('');
+      }
+      setValidatingURL(false);
+    });
+  }
+};
 
   const addTemplateButtons = (addFromTemplate: boolean = true) => {
     let buttons: any = [];

--- a/src/containers/HSM/HSM.tsx
+++ b/src/containers/HSM/HSM.tsx
@@ -323,9 +323,10 @@ export const HSM = () => {
   };
 
   const validateURL = (value: string) => {
-    if (value && type) {
+    const trimmedValue = value.trim();
+    if (trimmedValue && type) {
       setValidatingURL(true);
-      validateMedia(value, type.id, false).then((response: any) => {
+      validateMedia(trimmedValue, type.id, false).then((response: any) => {
         if (!response.data.is_valid) {
           setIsUrlValid(response.data.message);
         } else {

--- a/src/containers/InteractiveMessage/InteractiveMessage.tsx
+++ b/src/containers/InteractiveMessage/InteractiveMessage.tsx
@@ -799,10 +799,7 @@ export const InteractiveMessage = () => {
       validate: () => !dynamicMedia && isUrlValid,
       inputProp: {
         onBlur: (event: any) => {
-          setAttachmentURL(event.target.value);
-        },
-        onChange: (event: any) => {
-          setAttachmentURL(event.target.value);
+          setAttachmentURL(event.target.value.trim());
         },
       },
       helperText:

--- a/src/containers/SpeedSend/SpeedSend.test.tsx
+++ b/src/containers/SpeedSend/SpeedSend.test.tsx
@@ -119,12 +119,11 @@ describe('test creating a speed send', () => {
 
     fireEvent.click(screen.getByText('IMAGE'), { key: 'Enter' });
 
-    fireEvent.blur(inputs[2], {
-      target: {
-        value: 'invalid media',
-      },
+    fireEvent.change(inputs[2], {
+      target: { value: 'invalid media' },
     });
 
+    fireEvent.blur(inputs[2]);
     await waitFor(() => {
       expect(validateMediaSpy).toHaveBeenCalled();
       expect(screen.getByText('Validating URL')).toBeInTheDocument();

--- a/src/containers/SpeedSend/SpeedSend.test.tsx
+++ b/src/containers/SpeedSend/SpeedSend.test.tsx
@@ -82,21 +82,20 @@ describe('test creating a speed send', () => {
     });
 
     const inputs = screen.getAllByRole('textbox');
-
     const autocompletes = screen.getAllByTestId('autocomplete-element');
     autocompletes[0].focus();
     fireEvent.keyDown(autocompletes[0], { key: 'ArrowDown' });
 
     fireEvent.click(screen.getByText('IMAGE'), { key: 'Enter' });
 
-    fireEvent.change(inputs[2], {
+    fireEvent.blur(inputs[2], {
       target: {
         value: 'https://www.buildquickbots.com/whatsapp/media/sample/jpg/sample02.jpg',
       },
     });
 
     await waitFor(() => {
-      expect(validateMediaSpy).toHaveBeenCalled();
+      expect(validateMediaSpy).toHaveBeenCalledTimes(1);
       expect(screen.getByText('Validating URL')).toBeInTheDocument();
     });
   });
@@ -120,7 +119,7 @@ describe('test creating a speed send', () => {
 
     fireEvent.click(screen.getByText('IMAGE'), { key: 'Enter' });
 
-    fireEvent.change(inputs[2], {
+    fireEvent.blur(inputs[2], {
       target: {
         value: 'invalid media',
       },

--- a/src/containers/SpeedSend/SpeedSend.tsx
+++ b/src/containers/SpeedSend/SpeedSend.tsx
@@ -409,7 +409,7 @@ export const SpeedSend = () => {
         'Please provide a sample attachment for approval purpose. You may send a similar but different attachment when sending the HSM to users.'
       ),
       inputProp: {
-        onblur: (event: any) => {
+        onBlur: (event: any) => {
           setAttachmentURL(event.target.value.trim());
         },
       },

--- a/src/containers/SpeedSend/SpeedSend.tsx
+++ b/src/containers/SpeedSend/SpeedSend.tsx
@@ -409,8 +409,8 @@ export const SpeedSend = () => {
         'Please provide a sample attachment for approval purpose. You may send a similar but different attachment when sending the HSM to users.'
       ),
       inputProp: {
-        onChange: (event: any) => {
-          setAttachmentURL(event.target.value);
+        onblur: (event: any) => {
+          setAttachmentURL(event.target.value.trim());
         },
       },
     },


### PR DESCRIPTION

 **Summary**

This PR ensures that leading and trailing whitespace in media URLs are trimmed before validation. Previously, users encountered an “Invalid media URL” error when pasting URLs with accidental spaces — even though the URLs were otherwise correct. This led to unnecessary confusion and validation failures.


**Motivation**

While creating templates, users often paste media URLs that may unintentionally include a leading or trailing space. Since the backend validation treats such URLs as invalid, it results in a poor user experience. By trimming the URL before calling validateMedia, we eliminate this friction and improve form reliability.


**Changes Made**
- Trimmed the media URL using value.trim() before passing it to the validateMedia function.
- Ensured no changes to other validation logic or UI.

**Test Plan**

- Pasted a URL with leading/trailing spaces → It now passes validation if the actual URL is valid.
- Pasted a completely invalid URL → Still fails as expected.
- Confirmed that trimming doesn't affect already valid URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved URL handling by trimming whitespace from attachment URLs before validation.
  - Enhanced form validation to prevent errors when URLs contain leading or trailing spaces.
  - Updated attachment URL input behavior to validate and save trimmed values only on input blur, reducing unnecessary state updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->