### PR TITLE
Adding clues

### DIFF
--- a/src/containers/Profile/Contact/ContactProfile.module.css
+++ b/src/containers/Profile/Contact/ContactProfile.module.css
@@ -77,7 +77,7 @@
   color: #717971;
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 10px; 
 }
 
 .SelectedProfile {
@@ -86,4 +86,10 @@
 
 .ProfileHeaderElements {
   padding: 10px;
+}
+
+.ProfileLabel {
+  color: #666;
+  font-size: 0.85rem;
+  margin-left: 2px; 
 }

--- a/src/containers/Profile/Contact/ContactProfile.module.css
+++ b/src/containers/Profile/Contact/ContactProfile.module.css
@@ -88,8 +88,26 @@
   padding: 10px;
 }
 
-.ProfileLabel {
-  color: #666;
-  font-size: 0.85rem;
-  margin-left: 2px; 
+.ProfileTags {
+  display: inline-flex;
+  gap: 4px;
+  margin-left: 6px;
+}
+
+.Pill {
+  font-size: 0.7rem;
+  padding: 2px 6px;
+  border-radius: 12px;
+  font-weight: 500;
+  text-transform: lowercase;
+}
+
+.Default {
+  background-color: #e0e0e0;
+  color: #4b4b4b;
+}
+
+.Active {
+  background-color: #e4f5ea;
+  color: #256029;
 }

--- a/src/containers/Profile/Contact/ContactProfile.module.css
+++ b/src/containers/Profile/Contact/ContactProfile.module.css
@@ -77,7 +77,7 @@
   color: #717971;
   display: flex;
   align-items: center;
-  gap: 10px; 
+  gap: 10px;
 }
 
 .SelectedProfile {
@@ -99,7 +99,6 @@
   padding: 2px 6px;
   border-radius: 12px;
   font-weight: 500;
-  text-transform: lowercase;
 }
 
 .Default {

--- a/src/containers/Profile/Contact/ContactProfile.test.tsx
+++ b/src/containers/Profile/Contact/ContactProfile.test.tsx
@@ -85,23 +85,30 @@ describe('contact profile with multiple profiles', () => {
     });
   });
 
-test('should render all profiles and show correct status cues', async () => {
-  render(wrapper);
+  test('should render all profiles and show correct status cues', async () => {
+    render(wrapper);
 
-  await waitFor(() => {
-    expect(screen.getByText('Contact Profile')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Contact Profile')).toBeInTheDocument();
+    });
+
+    const profileHeaders = await screen.findAllByTestId('profileHeader');
+
+    // Assert 3 profiles rendered
+    expect(profileHeaders).toHaveLength(3);
+
+    // Check profile names and label cues according to new implementation
+    // Update the expected text below to match your new UI cues
+    expect(profileHeaders[0]).toHaveTextContent('profile name 1'); // Add new cues if any
+    expect(profileHeaders[0]).toHaveTextContent('DEFAULT');
+    expect(profileHeaders[0]).toHaveTextContent('ACTIVE');
+
+    expect(profileHeaders[1]).toHaveTextContent('profile name 2');
+    expect(profileHeaders[1]).toHaveTextContent('ACTIVE');
+    expect(profileHeaders[1]).not.toHaveTextContent('DEFAULT');
+
+    expect(profileHeaders[2]).toHaveTextContent('profile name 3');
+    expect(profileHeaders[2]).not.toHaveTextContent('DEFAULT');
+    expect(profileHeaders[2]).not.toHaveTextContent('ACTIVE');
   });
-
-  const profileHeaders = await screen.findAllByTestId('profileHeader');
-
-  // Assert 3 profiles rendered
-  expect(profileHeaders).toHaveLength(3);
-
-  // Check profile names and label cues
-  console.log('the data', profileHeaders[0]);
-  expect(profileHeaders[0]).toHaveTextContent('profile name 1 [Default][Active]');
-  expect(profileHeaders[1]).toHaveTextContent('profile name 2 [Active]');
-  expect(profileHeaders[2]).toHaveTextContent('profile name 3');
-});
-
 });

--- a/src/containers/Profile/Contact/ContactProfile.test.tsx
+++ b/src/containers/Profile/Contact/ContactProfile.test.tsx
@@ -85,21 +85,23 @@ describe('contact profile with multiple profiles', () => {
     });
   });
 
-  test('should only show active profiles in profile list', async () => {
-    render(wrapper);
+test('should render all profiles and show correct status cues', async () => {
+  render(wrapper);
 
-    await waitFor(() => {
-      expect(screen.getByText('Contact Profile')).toBeInTheDocument();
-    });
-
-    await waitFor(() => {
-      const profileHeaders = screen.getAllByTestId('profileHeader');
-
-      // Should render exactly 2 active profiles
-      expect(profileHeaders).toHaveLength(2);
-
-      expect(profileHeaders[0]).toHaveTextContent('profile name 1');
-      expect(profileHeaders[1]).toHaveTextContent('profile name 2');
-    });
+  await waitFor(() => {
+    expect(screen.getByText('Contact Profile')).toBeInTheDocument();
   });
+
+  const profileHeaders = await screen.findAllByTestId('profileHeader');
+
+  // Assert 3 profiles rendered
+  expect(profileHeaders).toHaveLength(3);
+
+  // Check profile names and label cues
+  console.log('the data', profileHeaders[0]);
+  expect(profileHeaders[0]).toHaveTextContent('profile name 1 [Default][Active]');
+  expect(profileHeaders[1]).toHaveTextContent('profile name 2 [Active]');
+  expect(profileHeaders[2]).toHaveTextContent('profile name 3');
+});
+
 });

--- a/src/containers/Profile/Contact/ContactProfile.tsx
+++ b/src/containers/Profile/Contact/ContactProfile.tsx
@@ -28,12 +28,10 @@ export const ContactProfile = () => {
     variables: {
       filter: {
         contactId: params.id,
-        is_active: true
       }
     },
     fetchPolicy: 'network-only',
   });
-
   useEffect(() => {
     if (data) {
       setSelectedProfileId(data.contact.contact.activeProfile?.id);
@@ -101,51 +99,57 @@ export const ContactProfile = () => {
 
   const drawer = (
     <div className={styles.Drawer}>
-      {profileHeaders.map(({ id, name }) => {
+      {profileHeaders.map((profile: any) => {
+        const { id, name, is_active, is_default } = profile;
         const showProfileSelected = id === selectedProfileId || id === 'noProfile';
 
-        return (
-          <React.Fragment key={id}>
+      return (
+        <React.Fragment key={id}>
+          <div
+            data-testid="profileHeader"
+            className={styles.ProfileHeader}
+            onClick={() => {
+              setSelectedProfileId(`${id}`);
+              setShowProfileSection('profile');
+            }}
+          >
             <div
-              data-testid="profileHeader"
-              className={styles.ProfileHeader}
-              onClick={() => {
-                setSelectedProfileId(`${id}`);
-                setShowProfileSection('profile');
-              }}
+              className={
+                showProfileSelected
+                  ? `${styles.ProfileHeaderTitle} ${styles.SelectedProfile}`
+                  : styles.ProfileHeaderTitle
+              }
             >
-              <div
-                className={
-                  showProfileSelected
-                    ? `${styles.ProfileHeaderTitle} ${styles.SelectedProfile}`
-                    : styles.ProfileHeaderTitle
-                }
-              >
-                <AvatarDisplay name={name} />
-                {name}
-              </div>
-              {showProfileSelected ? <ExpandIcon /> : <CollapseIcon />}
+              <AvatarDisplay name={name} />
+                <span>
+                 {name}
+                 {(is_default || is_active) && ' '}
+                 {is_default && <span className={styles.ProfileLabel}>[Default]</span>}
+                 {is_active && <span className={styles.ProfileLabel}>[Active]</span>}
+                </span>
+
             </div>
-            <Collapse in={showProfileSelected}>
-              <div className={styles.ProfileHeaderElements}>
-                {list.map((data: any, index: number) => {
-                  return (
-                    <div
-                      key={index}
-                      onClick={() => setShowProfileSection(data.section)}
-                      className={`${styles.Tab} ${showProfileSection === data.section ? styles.ActiveTab : ''}`}
-                    >
-                      {data.name}
-                    </div>
-                  );
-                })}
-              </div>
-            </Collapse>
-          </React.Fragment>
-        );
-      })}
-    </div>
-  );
+            {showProfileSelected ? <ExpandIcon /> : <CollapseIcon />}
+          </div>
+          <Collapse in={showProfileSelected}>
+            <div className={styles.ProfileHeaderElements}>
+              {list.map((data: any, index: number) => (
+                <div
+                  key={index}
+                  onClick={() => setShowProfileSection(data.section)}
+                  className={`${styles.Tab} ${showProfileSection === data.section ? styles.ActiveTab : ''}`}
+                >
+                  {data.name}
+                </div>
+              ))}
+            </div>
+          </Collapse>
+        </React.Fragment>
+      );
+    })}
+   </div>
+);
+
 
   let profileBodyContent;
   if (showProfileSection === 'profile') {

--- a/src/containers/Profile/Contact/ContactProfile.tsx
+++ b/src/containers/Profile/Contact/ContactProfile.tsx
@@ -28,7 +28,7 @@ export const ContactProfile = () => {
     variables: {
       filter: {
         contactId: params.id,
-      }
+      },
     },
     fetchPolicy: 'network-only',
   });
@@ -103,57 +103,54 @@ export const ContactProfile = () => {
         const { id, name, is_active, is_default } = profile;
         const showProfileSelected = id === selectedProfileId || id === 'noProfile';
 
-      return (
-        <React.Fragment key={id}>
-          <div
-            data-testid="profileHeader"
-            className={styles.ProfileHeader}
-            onClick={() => {
-              setSelectedProfileId(`${id}`);
-              setShowProfileSection('profile');
-            }}
-          >
+        return (
+          <React.Fragment key={id}>
             <div
-              className={
-                showProfileSelected
-                  ? `${styles.ProfileHeaderTitle} ${styles.SelectedProfile}`
-                  : styles.ProfileHeaderTitle
-              }
+              data-testid="profileHeader"
+              className={styles.ProfileHeader}
+              onClick={() => {
+                setSelectedProfileId(`${id}`);
+                setShowProfileSection('profile');
+              }}
             >
-              <AvatarDisplay name={name} />
-<span>
-  {name}
-  {(is_default || is_active) && (
-    <span className={styles.ProfileTags}>
-      {is_default && <span className={styles.Pill + ' ' + styles.Default}>default</span>}
-      {is_active && <span className={styles.Pill + ' ' + styles.Active}>active</span>}
-    </span>
-  )}
-</span>
-
-
+              <div
+                className={
+                  showProfileSelected
+                    ? `${styles.ProfileHeaderTitle} ${styles.SelectedProfile}`
+                    : styles.ProfileHeaderTitle
+                }
+              >
+                <AvatarDisplay name={name} />
+                <span>
+                  {name}
+                  {(is_default || is_active) && (
+                    <span className={styles.ProfileTags}>
+                      {is_default && <span className={styles.Pill + ' ' + styles.Default}>DEFAULT</span>}
+                      {is_active && <span className={styles.Pill + ' ' + styles.Active}>ACTIVE</span>}
+                    </span>
+                  )}
+                </span>
+              </div>
+              {showProfileSelected ? <ExpandIcon /> : <CollapseIcon />}
             </div>
-            {showProfileSelected ? <ExpandIcon /> : <CollapseIcon />}
-          </div>
-          <Collapse in={showProfileSelected}>
-            <div className={styles.ProfileHeaderElements}>
-              {list.map((data: any, index: number) => (
-                <div
-                  key={index}
-                  onClick={() => setShowProfileSection(data.section)}
-                  className={`${styles.Tab} ${showProfileSection === data.section ? styles.ActiveTab : ''}`}
-                >
-                  {data.name}
-                </div>
-              ))}
-            </div>
-          </Collapse>
-        </React.Fragment>
-      );
-    })}
-   </div>
-);
-
+            <Collapse in={showProfileSelected}>
+              <div className={styles.ProfileHeaderElements}>
+                {list.map((data: any, index: number) => (
+                  <div
+                    key={index}
+                    onClick={() => setShowProfileSection(data.section)}
+                    className={`${styles.Tab} ${showProfileSection === data.section ? styles.ActiveTab : ''}`}
+                  >
+                    {data.name}
+                  </div>
+                ))}
+              </div>
+            </Collapse>
+          </React.Fragment>
+        );
+      })}
+    </div>
+  );
 
   let profileBodyContent;
   if (showProfileSection === 'profile') {

--- a/src/containers/Profile/Contact/ContactProfile.tsx
+++ b/src/containers/Profile/Contact/ContactProfile.tsx
@@ -121,12 +121,16 @@ export const ContactProfile = () => {
               }
             >
               <AvatarDisplay name={name} />
-                <span>
-                 {name}
-                 {(is_default || is_active) && ' '}
-                 {is_default && <span className={styles.ProfileLabel}>[Default]</span>}
-                 {is_active && <span className={styles.ProfileLabel}>[Active]</span>}
-                </span>
+<span>
+  {name}
+  {(is_default || is_active) && (
+    <span className={styles.ProfileTags}>
+      {is_default && <span className={styles.Pill + ' ' + styles.Default}>default</span>}
+      {is_active && <span className={styles.Pill + ' ' + styles.Active}>active</span>}
+    </span>
+  )}
+</span>
+
 
             </div>
             {showProfileSelected ? <ExpandIcon /> : <CollapseIcon />}

--- a/src/mocks/Contact.tsx
+++ b/src/mocks/Contact.tsx
@@ -116,38 +116,38 @@ export const getMultipleProfiles = {
     variables: {
       filter: {
         contactId: '2',
-        is_active: true
       },
     },
   },
-  result: {
+    result: {
     data: {
       profiles: [
         {
-          fields:
-            '{"role":{"value":"Student","type":"string","label":"role","inserted_at":"2024-09-08T12:13:37.192507Z"},"name":{"value":"profile name 1","type":"string","label":"Name","inserted_at":"2024-09-08T12:13:37.151339Z"},"age_group":{"value":"19 or above","type":"string","label":"Age Group","inserted_at":"2024-09-08T12:12:45.907810Z"}}',
           id: '2',
-          language: {
-            id: '1',
-          },
           name: 'profile name 1',
-          type: 'Student',
           is_default: true,
           is_active: true,
+          fields: '{}',
+          language: { id: '1' },
+          type: 'Student',
         },
         {
-          __typename: 'Profile',
-          fields:
-            '{"role":{"value":"Parent","type":"string","label":"role","inserted_at":"2024-09-08T12:14:25.625321Z"},"name":{"value":"profile name 2","type":"string","label":"Name","inserted_at":"2024-09-08T12:14:25.619652Z"}}',
           id: '3',
-          language: {
-            __typename: 'Language',
-            id: '1',
-          },
           name: 'profile name 2',
-          type: 'Parent',
           is_default: false,
           is_active: true,
+          fields: '{}',
+          language: { id: '1' },
+          type: 'Parent',
+        },
+        {
+          id: '4',
+          name: 'profile name 3',
+          is_default: false,
+          is_active: false,
+          fields: '{}',
+          language: { id: '1' },
+          type: 'Alumni',
         },
       ],
     },


### PR DESCRIPTION
 **Summary**

This PR adds visual cues to distinguish between the default and active profiles in the contact's profile listing view. The cues are now clearly shown next to each relevant profile, improving clarity and user experience when managing multiple profiles for a contact.

**Motivation**

Previously, users were unable to differentiate between a contact’s default and active profiles, which led to confusion and potential mismanagement during actions like editing or sending messages. By introducing explicit cues for both profile types, this change:

- Enhances visual feedback and usability.
- Reduces the cognitive load for users working with multiple profiles.
- Makes the profile selection and interaction more intuitive and error-free.