### PR TITLE
Rename 'Assistants' to 'AI Assistants' in side menu

### DIFF
--- a/src/config/menu.ts
+++ b/src/config/menu.ts
@@ -181,7 +181,7 @@ const menus = (): Menu[] => [
     roles: managerLevel,
   },
   {
-    title: 'Assistants',
+    title: 'AI Assistants',
     path: '/assistants',
     icon: 'assistant',
     type: 'sideDrawer',


### PR DESCRIPTION
closes #3386 