### PR TITLE
fixed css in the lexical editor

### DIFF
--- a/src/components/UI/Form/EmojiInput/Editor.module.css
+++ b/src/components/UI/Form/EmojiInput/Editor.module.css
@@ -8,7 +8,6 @@
 
 .Editor {
   position: relative;
-
   height: 10rem;
   position: relative;
   padding: 1rem;
@@ -61,16 +60,13 @@
 }
 
 .disabled {
+  composes: Editor;
   position: relative;
-  border: 2px solid rgba(0, 0, 0, 0.23);
-  border-radius: 12px;
   height: 10rem;
   position: relative;
   padding: 1rem;
   position: relative;
   display: block;
-  border-bottom-left-radius: 10px;
-  border-bottom-right-radius: 10px;
   color: rgba(0, 0, 0, 0.38);
 }
 
@@ -189,4 +185,8 @@
 
 .FormatingOptions span:hover {
   background-color: #eee;
+}
+
+.DisablePicker {
+  pointer-events: none;
 }

--- a/src/components/UI/Form/EmojiInput/Editor.tsx
+++ b/src/components/UI/Form/EmojiInput/Editor.tsx
@@ -217,7 +217,7 @@ export const Editor = ({ disabled = false, ...props }: EditorProps) => {
             items={suggestions}
           />
           <OnChangePlugin onChange={handleChange} />
-          {picker}
+          <span className={disabled && styles.DisablePicker}>{picker}</span>
         </div>
       </div>
       {form && form.errors[field.name] && form.touched[field.name] ? (


### PR DESCRIPTION
closes #3415 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual consistency and disabled state styling for the emoji input editor.
  * Enhanced formatting for hover effects.

* **Bug Fixes**
  * Picker is now visually and interactively disabled when the editor is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->