### PR TITLE
Add email field to my account page

### DIFF
--- a/.github/workflows/cypress-testing.yml
+++ b/.github/workflows/cypress-testing.yml
@@ -65,7 +65,6 @@ jobs:
           git clone https://github.com/glific/glific.git
           echo done. go to dir.
           cd glific
-          git checkout feat/quick_onboarding
           echo done. start dev.secret.exs config
           cd priv
           mkdir cert

--- a/.github/workflows/cypress-testing.yml
+++ b/.github/workflows/cypress-testing.yml
@@ -65,6 +65,7 @@ jobs:
           git clone https://github.com/glific/glific.git
           echo done. go to dir.
           cd glific
+          git checkout feat/quick_onboarding
           echo done. start dev.secret.exs config
           cd priv
           mkdir cert

--- a/src/containers/MyAccount/MyAccount.tsx
+++ b/src/containers/MyAccount/MyAccount.tsx
@@ -157,6 +157,7 @@ export const MyAccount = () => {
       component: Input,
       name: 'email',
       label: t('Email'),
+      disabled: true,
     },
   ];
 

--- a/src/containers/MyAccount/MyAccount.tsx
+++ b/src/containers/MyAccount/MyAccount.tsx
@@ -157,7 +157,6 @@ export const MyAccount = () => {
       component: Input,
       name: 'email',
       label: t('Email'),
-      disabled: true,
     },
   ];
 

--- a/src/containers/MyAccount/MyAccount.tsx
+++ b/src/containers/MyAccount/MyAccount.tsx
@@ -71,6 +71,7 @@ export const MyAccount = () => {
 
   const userName = userData.currentUser.user.contact.name;
   const userPhone = userData.currentUser.user.contact.phone;
+  const userEmail = userData.currentUser.user.email;
 
   // filter languages that support localization
   const languageOptions = organizationData.currentUser.user.organization.activeLanguages
@@ -152,10 +153,16 @@ export const MyAccount = () => {
       label: t('Phone number'),
       disabled: true,
     },
+    {
+      component: Input,
+      name: 'email',
+      label: t('Email'),
+      disabled: true,
+    },
   ];
 
   const userForm = (
-    <Formik initialValues={{ name: userName, phone: userPhone }} onSubmit={() => {}}>
+    <Formik initialValues={{ name: userName, phone: userPhone, email: userEmail }} onSubmit={() => {}}>
       <Form>
         {userformFields.map((field) => (
           <div className={styles.UserField} key={field.name}>

--- a/src/graphql/queries/User.ts
+++ b/src/graphql/queries/User.ts
@@ -69,6 +69,7 @@ export const GET_CURRENT_USER = gql`
         id
         name
         phone
+        email
         accessRoles {
           id
           label

--- a/src/i18n/en/en.json
+++ b/src/i18n/en/en.json
@@ -81,6 +81,7 @@
   "No messages.": "No messages.",
   "Jump to latest": "Jump to latest",
   "Error :(": "Error :(",
+  "Email": "Email",
   "Contact blocked successfully.": "Contact blocked successfully.",
   "Flow started successfully.": "Flow started successfully.",
   "Your flow will start in a couple of minutes.": "Your flow will start in a couple of minutes.",


### PR DESCRIPTION
## Summary
 Target issue - https://github.com/glific/glific-frontend/issues/3426
Use the backend branch feat/quick_onboarding to test this PR.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * My Account now displays the user’s email address as a read-only field alongside name and phone.
  * Form initialization updated to include email for a consistent profile overview.

* Localization
  * Added English translation for the Email label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->