### PR TITLE
Added asterics in certificates page and corrected info on resolution

### DIFF
--- a/src/containers/Certificates/Certificate.tsx
+++ b/src/containers/Certificates/Certificate.tsx
@@ -54,7 +54,7 @@ const Certificate = () => {
       component: Input,
       name: 'title',
       type: 'text',
-      label: t('Title'),
+      label: `${t('Title')}*`,
     },
     {
       component: Input,
@@ -68,7 +68,7 @@ const Certificate = () => {
       component: Input,
       name: 'url',
       type: 'text',
-      label: t('URL'),
+      label: `${t('URL')}*`,
       helperText: (
         <span className={styles.HelperText}>
           <>
@@ -79,7 +79,8 @@ const Certificate = () => {
             <br />
             For best results:
             <ul>
-              <li>Landscape certificates – Use a resolution of 2550 x 3300 px.</li>
+              <li>Landscape certificates – Use a resolution of 3300 x 2550 px.</li>
+              <li> Portrait certificates– Use resolution of 816 x 1056 px.</li>
               <li> Badges – Use a square format, minimum 600 x 600 px.</li>
             </ul>
           </>


### PR DESCRIPTION
target issue https://github.com/glific/glific-frontend/issues/3463

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Style
  * Added asterisks to the Title and URL labels to clearly indicate required fields, improving form clarity.

* Documentation
  * Updated certificate image resolution guidance: corrected landscape recommendation to 3300 × 2550 px and added portrait guidance (816 × 1056 px).
  * Refreshed help text to better guide users when preparing certificate assets; no changes to validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->