### PR TITLE
Quick Onboarding: Replaced Default “NA” Text with “To be updated” inside Gupshup tab in setting

### DIFF
--- a/src/containers/SettingList/Providers/Providers.tsx
+++ b/src/containers/SettingList/Providers/Providers.tsx
@@ -50,6 +50,9 @@ export const Providers = () => {
   const setCredential = (item: any) => {
     const keysObj = JSON.parse(item.keys);
     const secretsObj = JSON.parse(item.secrets);
+    if (type === 'gupshup' && secretsObj.app_id && secretsObj.app_id !== 'NA') {
+      setIsDisabled(true);
+    }
     if (type === 'gupshup' && secretsObj.app_id === 'NA') {
       secretsObj.app_id = 'To be updated';
       secretsObj.app_name = 'To be updated';
@@ -63,15 +66,6 @@ export const Providers = () => {
       states[key] = fields[key];
     });
     states.isActive = item.isActive;
-
-    if (
-      type === 'gupshup' &&
-      secretsObj.app_id &&
-      secretsObj.app_id !== 'NA' &&
-      secretsObj.app_id !== 'To be updated'
-    ) {
-      setIsDisabled(true);
-    }
 
     setStateValues(states);
   };


### PR DESCRIPTION
## Summary

Target issue - https://github.com/glific/glific-frontend/issues/3503

## Test Plan

1-In the backend go to the branch quick_onboarding
2-On iex -run 
``` 
credential = Repo.get_by(Glific.Partners.Credential, %{organization_id: 1, provider_id: 1})

 credential
|> Ecto.Changeset.change(secrets: Map.merge(credential.secrets || %{}, %{"api_key" => "NA", "app_id" => "NA", "app_name" => "NA"}))
|> Glific.Repo.update()
```

