### PR TITLE
Replace hamburger menu with collapsible side arrow icon when it open

### DIFF
--- a/src/components/UI/Layout/Navigation/SideDrawer/SideDrawer.tsx
+++ b/src/components/UI/Layout/Navigation/SideDrawer/SideDrawer.tsx
@@ -1,6 +1,7 @@
 import { useContext, useState } from 'react';
 import { Drawer, Toolbar, Typography, IconButton } from '@mui/material';
 import MenuIcon from '@mui/icons-material/Menu';
+import ArrowBackIosNewIcon from '@mui/icons-material/ArrowBackIosNew';
 import { SideDrawerContext, ProviderContext } from 'context/session';
 import { GUPSHUP_ENTERPRISE_SHORTCODE } from 'common/constants';
 import GlificLogo from 'assets/images/logo/Logo.svg';
@@ -27,7 +28,7 @@ export const SideDrawer = () => {
             </Typography>
 
             <IconButton onClick={() => setDrawerOpen(false)} data-testid="drawer-button">
-              <MenuIcon />
+              <ArrowBackIosNewIcon fontSize="small" />
             </IconButton>
           </div>
         ) : (

--- a/src/components/UI/Layout/Navigation/SideMenus/SideMenus.module.css
+++ b/src/components/UI/Layout/Navigation/SideMenus/SideMenus.module.css
@@ -31,7 +31,6 @@
 
 .ClosedItem {
   width: unset !important;
-  margin: 0px 10px !important;
 }
 
 .SelectedText {


### PR DESCRIPTION
Target issue: https://github.com/glific/glific-frontend/issues/3523


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Calendar and TimePicker now include a dedicated picker button to open selectors.
  - Lists support external default sorting; Trigger List defaults to Updated (desc).
  - Captcha auto-verifies and updates forms via onTokenUpdate.

- Improvements
  - Multiple form labels now show required indicators (*), updated helper texts, and clearer copy across Assistants, Certificates, Collections, Flows, Interactive Messages, HSM, Sheet Integration, and Triggers.
  - Side drawer shows a back icon when open; side menu layout refined.
  - Notification links open in a new window; severity filter order updated.
  - Registration and My Account remove email/consent; Organization phone made read-only.
  - Ticket text wraps better; safer payload handling.
  - Updated Terms of Use link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->