### PR TITLE
HSM: Deduped the hsm shortcodes for Autocomplete

### DIFF
--- a/src/containers/HSM/HSM.tsx
+++ b/src/containers/HSM/HSM.tsx
@@ -127,12 +127,12 @@ export const HSM = () => {
 
   const shortCodeOptions: any = [];
   if (shortCodes?.sessionTemplates) {
-    const seen = new Set<string>();
+    const visitedShortCodes = new Set<string>();
     shortCodes.sessionTemplates.forEach((value: any, index: number) => {
-      const code = (value?.shortcode || '').toString();
-      if (!code || seen.has(code)) return;
-      seen.add(code);
-      shortCodeOptions.push({ label: code, id: index });
+      const shortCode = (value?.shortcode || '').toString();
+      if (!shortCode || visitedShortCodes.has(shortCode)) return;
+      visitedShortCodes.add(shortCode);
+      shortCodeOptions.push({ label: shortCode, id: index });
     });
   }
 


### PR DESCRIPTION
Target issue https://github.com/glific/glific-frontend/issues/3596

If autocomplete component has duplicate elements, its acting weird by showing the duplicates in the dropdown even if those elements are not in search query. Due to this the actual searched element is deep down in the list, so the users miss it sometimes thinking its not in the list

> Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.

Error from autocomplete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session template handling to prevent duplicates and invalid entries from appearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->