### PR TITLE
Refactor: Rename google sheet to consistent case

### DIFF
--- a/src/containers/SettingList/SettingList.module.css
+++ b/src/containers/SettingList/SettingList.module.css
@@ -58,6 +58,7 @@
   display: flex;
   font-weight: 700;
   font-size: 24px;
+  text-transform: capitalize;
 }
 
 .SettingTextHeader {


### PR DESCRIPTION
Target issue: https://github.com/glific/glific/issues/4141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected capitalization of a provider name in the Settings list so "Google Sheet" displays with consistent casing for improved readability.

* **Tests**
  * Added a UI test that verifies the provider name is rendered with the corrected capitalization and confirms the incorrect form is not shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->