### PR TITLE
Fix runtime crash when cachedConversations.search is undefined

### DIFF
--- a/src/containers/Chat/ChatSubscription/ChatSubscription.tsx
+++ b/src/containers/Chat/ChatSubscription/ChatSubscription.tsx
@@ -1,17 +1,12 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useRef } from 'react';
 import { useLazyQuery, useQuery } from '@apollo/client';
 
 import {
   COLLECTION_SEARCH_QUERY_VARIABLES,
-  DEFAULT_ENTITY_LIMIT,
-  DEFAULT_MESSAGE_LIMIT,
-  REFETCH_RANDOM_TIME_MAX,
-  REFETCH_RANDOM_TIME_MIN,
   SEARCH_QUERY_VARIABLES,
 } from 'common/constants';
 import { setErrorMessage } from 'common/notification';
-import { randomIntFromInterval, addLogs, handleSubscriptionError } from 'common/utils';
-import { saveConversation } from 'services/ChatService';
+import { handleSubscriptionError, addLogs } from 'common/utils';
 import { getUserSession } from 'services/AuthService';
 import { SEARCH_QUERY } from 'graphql/queries/Search';
 import {
@@ -20,7 +15,7 @@ import {
   MESSAGE_SENT_SUBSCRIPTION,
   MESSAGE_STATUS_SUBSCRIPTION,
 } from 'graphql/subscriptions/Chat';
-import { getSubscriptionDetails, recordRequests, switchSubscriptionToRefetch } from 'services/SubscriptionService';
+import { handleUpdateConversations } from './ChatSubscriptionUtils';
 
 export interface ChatSubscriptionProps {
   setDataLoaded: any;
@@ -28,166 +23,26 @@ export interface ChatSubscriptionProps {
 
 export const ChatSubscription = ({ setDataLoaded }: ChatSubscriptionProps) => {
   const queryVariables = SEARCH_QUERY_VARIABLES;
-  const entityIdsFetched: any = [];
+  const entityIdsFetched = useRef<any[]>([]);
 
-  let refetchTimer: any = null;
+  const refetchTimer = useRef<any>(null);
   const [triggerRefetch, setTriggerRefetch] = useState(false);
-  let subscriptionToRefetchSwitchHappened = false;
+  const subscriptionToRefetchSwitchHappened = useRef(false);
 
   const [getContactQuery] = useLazyQuery(SEARCH_QUERY);
 
   const updateConversations = useCallback(
-    (cachedConversations: any, subscriptionData: any, action: string) => {
-      // if there is no message data then return previous conversations
-      if (!subscriptionData.data || subscriptionToRefetchSwitchHappened) {
-        return cachedConversations;
-      }
-
-      // let's return early incase we don't have cached conversations
-      // TODO: Need to investigate why this happens
-      if (!cachedConversations) {
-        return null;
-      }
-
-      let fetchMissingContact = false;
-      // let's record message sent and received subscriptions
-      if (action === 'SENT' || action === 'RECEIVED') {
-        // set fetch missing contact flag
-        fetchMissingContact = true;
-
-        // build the request array
-        recordRequests();
-
-        // determine if we should use subscriptions or refetch the query
-        if (switchSubscriptionToRefetch() && !subscriptionToRefetchSwitchHappened) {
-          // when switch happens
-          // 1. get the random time as defined in constant
-          // 2. set the refetch action for that duration
-          // 3. if we are still in fetch mode repeat the same.
-
-          // set the switch flag
-          subscriptionToRefetchSwitchHappened = true;
-
-          // let's get the random wait time
-          const waitTime = randomIntFromInterval(REFETCH_RANDOM_TIME_MIN, REFETCH_RANDOM_TIME_MAX) * 1000;
-
-          // let's clear the timeout if exists
-          if (refetchTimer) {
-            clearTimeout(refetchTimer);
-          }
-
-          refetchTimer = setTimeout(() => {
-            // reset the switch flag
-            subscriptionToRefetchSwitchHappened = false;
-
-            // let's trigger refetch action
-            setTriggerRefetch(true);
-          }, waitTime);
-
-          return cachedConversations;
-        }
-      }
-
-      const { newMessage, entityId, collectionId, messageStatusData } = getSubscriptionDetails(
-        action,
-        subscriptionData
-      );
-
-      // loop through the cached conversations and find if contact exists
-      if (!cachedConversations?.search) {
-        return cachedConversations;
-      }
-
-      let conversationIndex = 0;
-      let conversationFound = false;
-
-      if (action === 'COLLECTION') {
-        cachedConversations.search.forEach((conversation: any, index: any) => {
-          if (conversation.group.id === collectionId) {
-            conversationIndex = index;
-            conversationFound = true;
-          }
-        });
-      } else {
-        cachedConversations.search.forEach((conversation: any, index: any) => {
-          if (conversation.contact.id === entityId) {
-            conversationIndex = index;
-            conversationFound = true;
-          }
-        });
-      }
-
-      // we should fetch missing contact only when we receive message subscriptions
-      // this means contact is not cached, so we need to fetch the conversations and add
-      // it to the cached conversations
-      // let's also skip fetching contact when we trigger this via group subscriptions
-      // let's skip fetch contact when we switch to refetch mode from subscription
-      if (!conversationFound && newMessage && !newMessage.groupId && fetchMissingContact && !triggerRefetch) {
-        const variables = {
-          contactOpts: {
-            limit: DEFAULT_ENTITY_LIMIT,
-          },
-          filter: { id: entityId },
-          messageOpts: {
-            limit: DEFAULT_MESSAGE_LIMIT,
-          },
-        };
-
-        addLogs(`${action}-contact is not cached, so we need to fetch the conversations and add to cache`, variables);
-
-        if (!entityIdsFetched.includes(entityId)) {
-          entityIdsFetched.push(entityId);
-
-          getContactQuery({
-            variables,
-          }).then(({ data: conversation }) => {
-            if (conversation && conversation.search.length > 0) {
-              // save the conversation and update cache
-
-              // temporary fix for cache. need to check why query variables change
-              saveConversation(conversation, queryVariables);
-            }
-          });
-        }
-
-        return cachedConversations;
-      }
-
-      // we need to handle 2 scenarios:
-      // 1. Add new message if message is sent or received
-      // let's start by parsing existing conversations
-      const updatedConversations = JSON.parse(JSON.stringify(cachedConversations));
-      let updatedConversation = updatedConversations.search;
-
-      // get the conversation for the contact that needs to be updated
-      updatedConversation = updatedConversation.splice(conversationIndex, 1);
-
-      // update contact last message at when receiving a new Message
-      if (action === 'RECEIVED') {
-        updatedConversation[0].contact.lastMessageAt = newMessage.insertedAt;
-        updatedConversation[0].contact.bspStatus = newMessage.contact.bspStatus;
-      }
-
-      // Add new message and move the conversation to the top
-      if (newMessage) {
-        updatedConversation[0].messages.unshift(newMessage);
-      } else {
-        updatedConversation[0].messages.forEach((message: any) => {
-          if (messageStatusData && message.id === messageStatusData.id) {
-            // eslint-disable-next-line
-            message.errors = messageStatusData.errors;
-          }
-        });
-      }
-
-      // update the conversations
-      updatedConversations.search = [...updatedConversation, ...updatedConversations.search];
-
-      // return the updated object
-      const returnConversations = { ...cachedConversations, ...updatedConversations };
-      return returnConversations;
-    },
-    [getContactQuery]
+    (cachedConversations: any, subscriptionData: any, action: string) =>
+      handleUpdateConversations(cachedConversations, subscriptionData, action, {
+        subscriptionToRefetchSwitchHappened,
+        refetchTimer,
+        setTriggerRefetch,
+        getContactQuery,
+        queryVariables,
+        triggerRefetch,
+        entityIdsFetched,
+      }),
+    [getContactQuery, queryVariables, triggerRefetch]
   );
 
   const { subscribeToMore: collectionSubscribe, data: collectionData } = useQuery<any>(SEARCH_QUERY, {

--- a/src/containers/Chat/ChatSubscription/ChatSubscriptionUtils.test.ts
+++ b/src/containers/Chat/ChatSubscription/ChatSubscriptionUtils.test.ts
@@ -1,0 +1,119 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { handleUpdateConversations } from './ChatSubscriptionUtils';
+import * as SubscriptionService from 'services/SubscriptionService';
+
+vi.mock('services/SubscriptionService', () => ({
+    getSubscriptionDetails: vi.fn(),
+    recordRequests: vi.fn(),
+    switchSubscriptionToRefetch: vi.fn(),
+}));
+
+vi.mock('services/ChatService', () => ({
+    saveConversation: vi.fn(),
+}));
+
+vi.mock('common/utils', () => ({
+    addLogs: vi.fn(),
+    randomIntFromInterval: vi.fn(() => 5),
+}));
+
+describe('ChatSubscriptionUtils', () => {
+    let context: any;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        context = {
+            subscriptionToRefetchSwitchHappened: { current: false },
+            refetchTimer: { current: null },
+            setTriggerRefetch: vi.fn(),
+            getContactQuery: vi.fn(),
+            queryVariables: {},
+            triggerRefetch: false,
+            entityIdsFetched: { current: [] },
+        };
+    });
+
+    it('should return cachedConversations if subscriptionData is empty', () => {
+        const cachedConversations = { search: [] };
+        const subscriptionData = { data: null };
+        const result = handleUpdateConversations(cachedConversations, subscriptionData, 'RECEIVED', context);
+        expect(result).toBe(cachedConversations);
+    });
+
+    it('should return null if cachedConversations is null', () => {
+        const subscriptionData = { data: { newMessage: {} } };
+        const result = handleUpdateConversations(null, subscriptionData, 'RECEIVED', context);
+        expect(result).toBeNull();
+    });
+
+    it('should return cachedConversations if search property is missing (the bug fix)', () => {
+        const cachedConversations = {};
+        const subscriptionData = { data: { newMessage: {} } };
+        vi.mocked(SubscriptionService.getSubscriptionDetails).mockReturnValue({
+            newMessage: {},
+            entityId: '1',
+        } as any);
+
+        const result = handleUpdateConversations(cachedConversations, subscriptionData, 'RECEIVED', context);
+        expect(result).toBe(cachedConversations);
+    });
+
+    it('should update conversation on RECEIVED action', () => {
+        const cachedConversations = {
+            search: [
+                {
+                    contact: { id: '1', lastMessageAt: 'old' },
+                    messages: [],
+                },
+            ],
+        };
+        const subscriptionData = { data: { newMessage: {} } };
+        const newMessage = { insertedAt: 'new', contact: { bspStatus: 'active' } };
+        vi.mocked(SubscriptionService.getSubscriptionDetails).mockReturnValue({
+            newMessage,
+            entityId: '1',
+        } as any);
+
+        const result = handleUpdateConversations(cachedConversations, subscriptionData, 'RECEIVED', context);
+
+        expect(result.search[0].contact.lastMessageAt).toBe('new');
+        expect(result.search[0].messages[0]).toBe(newMessage);
+    });
+
+    it('should trigger refetch if switchSubscriptionToRefetch is true', () => {
+        vi.useFakeTimers();
+        const cachedConversations = { search: [] };
+        const subscriptionData = { data: { newMessage: {} } };
+        vi.mocked(SubscriptionService.switchSubscriptionToRefetch).mockReturnValue(true);
+
+        handleUpdateConversations(cachedConversations, subscriptionData, 'SENT', context);
+
+        expect(context.subscriptionToRefetchSwitchHappened.current).toBe(true);
+
+        vi.runAllTimers();
+        expect(context.setTriggerRefetch).toHaveBeenCalledWith(true);
+        expect(context.subscriptionToRefetchSwitchHappened.current).toBe(false);
+        vi.useRealTimers();
+    });
+
+    it('should handle COLLECTION action', () => {
+        const cachedConversations = {
+            search: [
+                {
+                    group: { id: 'coll_1' },
+                    messages: [{ id: 'msg_1' }],
+                },
+            ],
+        };
+        const subscriptionData = { data: { newMessage: {} } };
+        const newMessage = { id: 'msg_2', insertedAt: 'new' };
+        vi.mocked(SubscriptionService.getSubscriptionDetails).mockReturnValue({
+            newMessage,
+            collectionId: 'coll_1',
+        } as any);
+
+        const result = handleUpdateConversations(cachedConversations, subscriptionData, 'COLLECTION', context);
+
+        expect(result.search[0].messages[0]).toBe(newMessage);
+    });
+});

--- a/src/containers/Chat/ChatSubscription/ChatSubscriptionUtils.ts
+++ b/src/containers/Chat/ChatSubscription/ChatSubscriptionUtils.ts
@@ -1,0 +1,168 @@
+import { DEFAULT_ENTITY_LIMIT, DEFAULT_MESSAGE_LIMIT, REFETCH_RANDOM_TIME_MAX, REFETCH_RANDOM_TIME_MIN } from 'common/constants';
+import { addLogs, randomIntFromInterval } from 'common/utils';
+import { saveConversation } from 'services/ChatService';
+import { getSubscriptionDetails, recordRequests, switchSubscriptionToRefetch } from 'services/SubscriptionService';
+
+export const handleUpdateConversations = (
+    cachedConversations: any,
+    subscriptionData: any,
+    action: string,
+    context: {
+        subscriptionToRefetchSwitchHappened: { current: boolean };
+        refetchTimer: { current: any };
+        setTriggerRefetch: (val: boolean) => void;
+        getContactQuery: any;
+        queryVariables: any;
+        triggerRefetch: boolean;
+        entityIdsFetched: { current: any[] };
+    }
+) => {
+    const {
+        subscriptionToRefetchSwitchHappened,
+        refetchTimer,
+        setTriggerRefetch,
+        getContactQuery,
+        queryVariables,
+        triggerRefetch,
+        entityIdsFetched,
+    } = context;
+
+    // if there is no message data then return previous conversations
+    if (!subscriptionData.data || subscriptionToRefetchSwitchHappened.current) {
+        return cachedConversations;
+    }
+
+    // let's return early incase we don't have cached conversations
+    if (!cachedConversations) {
+        return null;
+    }
+
+    let fetchMissingContact = false;
+    // let's record message sent and received subscriptions
+    if (action === 'SENT' || action === 'RECEIVED') {
+        // set fetch missing contact flag
+        fetchMissingContact = true;
+
+        // build the request array
+        recordRequests();
+
+        // determine if we should use subscriptions or refetch the query
+        if (switchSubscriptionToRefetch() && !subscriptionToRefetchSwitchHappened.current) {
+            // set the switch flag
+            subscriptionToRefetchSwitchHappened.current = true;
+
+            // let's get the random wait time
+            const waitTime = randomIntFromInterval(REFETCH_RANDOM_TIME_MIN, REFETCH_RANDOM_TIME_MAX) * 1000;
+
+            // let's clear the timeout if exists
+            if (refetchTimer.current) {
+                clearTimeout(refetchTimer.current);
+            }
+
+            refetchTimer.current = setTimeout(() => {
+                // reset the switch flag
+                subscriptionToRefetchSwitchHappened.current = false;
+
+                // let's trigger refetch action
+                setTriggerRefetch(true);
+            }, waitTime);
+
+            return cachedConversations;
+        }
+    }
+
+    const { newMessage, entityId, collectionId, messageStatusData } = getSubscriptionDetails(action, subscriptionData);
+
+    // loop through the cached conversations and find if contact exists
+    if (!cachedConversations?.search) {
+        return cachedConversations;
+    }
+
+    let conversationIndex = 0;
+    let conversationFound = false;
+
+    if (action === 'COLLECTION') {
+        cachedConversations.search.forEach((conversation: any, index: any) => {
+            if (conversation.group?.id === collectionId) {
+                conversationIndex = index;
+                conversationFound = true;
+            }
+        });
+    } else {
+        cachedConversations.search.forEach((conversation: any, index: any) => {
+            if (conversation.contact?.id === entityId) {
+                conversationIndex = index;
+                conversationFound = true;
+            }
+        });
+    }
+
+    // we should fetch missing contact only when we receive message subscriptions
+    if (!conversationFound && newMessage && !newMessage.groupId && fetchMissingContact && !triggerRefetch) {
+        const variables = {
+            contactOpts: {
+                limit: DEFAULT_ENTITY_LIMIT,
+            },
+            filter: { id: entityId },
+            messageOpts: {
+                limit: DEFAULT_MESSAGE_LIMIT,
+            },
+        };
+
+        addLogs(`${action}-contact is not cached, so we need to fetch the conversations and add to cache`, variables);
+
+        if (!entityIdsFetched.current.includes(entityId)) {
+            entityIdsFetched.current.push(entityId);
+
+            getContactQuery({
+                variables,
+            }).then(({ data: conversation }: any) => {
+                if (conversation && conversation.search.length > 0) {
+                    // save the conversation and update cache
+                    saveConversation(conversation, queryVariables);
+                }
+            });
+        }
+
+        return cachedConversations;
+    }
+
+    if (!conversationFound) {
+        return cachedConversations;
+    }
+
+    // we need to handle 2 scenarios:
+    // 1. Add new message if message is sent or received
+    const updatedConversations = JSON.parse(JSON.stringify(cachedConversations));
+    let updatedConversation = updatedConversations.search;
+
+    // get the conversation for the contact that needs to be updated
+    updatedConversation = updatedConversation.splice(conversationIndex, 1);
+
+    if (updatedConversation.length === 0) {
+        return cachedConversations;
+    }
+
+    // update contact last message at when receiving a new Message
+    if (action === 'RECEIVED' && updatedConversation[0].contact) {
+        updatedConversation[0].contact.lastMessageAt = newMessage.insertedAt;
+        updatedConversation[0].contact.bspStatus = newMessage.contact.bspStatus;
+    }
+
+    // Add new message and move the conversation to the top
+    if (newMessage) {
+        updatedConversation[0].messages.unshift(newMessage);
+    } else {
+        updatedConversation[0].messages.forEach((message: any) => {
+            if (messageStatusData && message.id === messageStatusData.id) {
+                message.errors = messageStatusData.errors;
+            }
+        });
+    }
+
+    // update the conversations
+    updatedConversations.search = [...updatedConversation, ...updatedConversations.search];
+
+    // return the updated object
+    return { ...cachedConversations, ...updatedConversations };
+};


### PR DESCRIPTION
Fixes #3736

### Summary
- Added null checks for cachedConversations.search
- Prevented .forEach() execution on undefined cache data
- Ensured no behavior change when cache is valid


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable chat update handling: fixes cases where incoming messages or conversation metadata could be missed or cause errors, including better handling when contact or conversation data is absent.
  * Improved refetch behavior to ensure timely synchronization of conversation lists and message ordering.
* **Tests**
  * Added comprehensive tests covering message receipt, collection updates, refetch triggering, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->