### PR TITLE
Fix: Left align action buttons in WhatsApp forms

### DIFF
--- a/src/containers/WaGroups/GroupCollections/GroupCollectionList.module.css
+++ b/src/containers/WaGroups/GroupCollections/GroupCollectionList.module.css
@@ -57,7 +57,7 @@
 .Actions {
   width: 30%;
   min-width: 200px;
-  text-align: end;
+  text-align: start;
 }
 
 .ViewButton {

--- a/src/containers/WaGroups/WaPolls/WaPollsList/WaPollsList.module.css
+++ b/src/containers/WaGroups/WaPolls/WaPollsList/WaPollsList.module.css
@@ -9,7 +9,7 @@
 .Actions {
   width: 30%;
   min-width: 200px;
-  text-align: end;
+  text-align: start;
 }
 
 .LabelText {

--- a/src/containers/WhatsAppForms/WhatsAppFormList/WhatsAppFormList.module.css
+++ b/src/containers/WhatsAppForms/WhatsAppFormList/WhatsAppFormList.module.css
@@ -8,7 +8,7 @@
   min-height: 36px !important;
 }
 
-.SearchBar > fieldset {
+.SearchBar>fieldset {
   border: none !important;
 }
 
@@ -24,7 +24,8 @@
 .Actions {
   width: 15%;
   min-width: 200px;
-  text-align: end;
+  text-align: start;
+  padding-left: 25px !important;
 }
 
 .NameText {
@@ -127,6 +128,7 @@
   z-index: 20;
   min-width: 150px;
 }
+
 .IconSize {
   font-size: 1.2rem !important;
 }

--- a/src/containers/WhatsAppForms/WhatsAppFormList/WhatsAppFormList.tsx
+++ b/src/containers/WhatsAppForms/WhatsAppFormList/WhatsAppFormList.tsx
@@ -15,7 +15,7 @@ import HighlightOffIcon from '@mui/icons-material/HighlightOff';
 
 import styles from './WhatsAppFormList.module.css';
 
-const columnStyles = [styles.Name, styles.status, styles.Label, styles.Actions];
+const columnStyles = [styles.Name, styles.Status, styles.Label, styles.Actions];
 
 const queries = {
   filterItemsQuery: LIST_WHATSAPP_FORMS,


### PR DESCRIPTION
Fixes #3677

### Summary
Updated the WhatsApp forms action buttons to be left-aligned for consistency with other forms.

### Result
All WhatsApp form action buttons are now left-aligned and match the platform styling.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted action element alignment from right to left across group collections, polls, and form list views for improved layout consistency.
  * Added left padding to action elements in form lists.
  * Updated styling references for status column display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->