### PR TITLE
Remove specific git checkout commands for whatsapp form

### DIFF
--- a/.github/workflows/cypress-testing.yml
+++ b/.github/workflows/cypress-testing.yml
@@ -65,7 +65,6 @@ jobs:
           git clone https://github.com/glific/glific.git
           echo done. go to dir.
           cd glific
-          git checkout whatsapp-forms-phase-2
           echo done. start dev.secret.exs config
           cd priv
           mkdir cert
@@ -97,7 +96,6 @@ jobs:
           git clone https://github.com/glific/cypress-testing.git
           echo done. go to dir.
           cd cypress-testing
-          git checkout feat/whatsapp_form
           cd ..
           cp -r cypress-testing/cypress cypress
           yarn add cypress@13.6.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI/CD test workflow by removing explicit branch switching commands, now relying on the default checkout state during test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->