### PR TITLE
Revert "feat: Inline editing of assistant names in version page"

### DIFF
--- a/src/containers/Assistants/AssistantDetail/AssistantDetail.module.css
+++ b/src/containers/Assistants/AssistantDetail/AssistantDetail.module.css
@@ -16,8 +16,9 @@
   font-weight: 500;
   cursor: pointer;
   width: fit-content;
+  /* Pull up into the Heading block which has bottom padding */
   margin-top: -36px;
-  padding: 1px 24px 16px 70px;
+  padding: 0 24px 16px 106px;
   flex-shrink: 0;
   position: relative;
   z-index: 1001;
@@ -35,6 +36,8 @@
   width: 100%;
 }
 
+
+/* ── Two-panel body ────────────────────────────────── */
 .Body {
   display: flex;
   flex: 1;
@@ -78,67 +81,6 @@
   text-align: center;
   margin: 1rem 0;
   color: #555;
-}
-
-.PageHeader {
-  position: sticky;
-  top: 0;
-  z-index: 1000;
-  background: #f8faf5;
-  border-bottom: 1px solid #e0e0e0;
-  display: flex;
-  align-items: center;
-  padding: 10px 24px 22px 10px;
-  height: 110px;
-}
-
-.HeaderLeft {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-left: 10px;
-}
-
-.BackIcon {
-  cursor: pointer;
-  margin-top: 4px;
-  flex-shrink: 0;
-}
-
-.NameViewRow {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.NameText {
-  font-size: 38px;
-  font-weight: 700;
-  color: #191c1a;
-  margin-right: 2px;
-}
-
-.EditNameButton {
-  color: #119656;
-}
-
-.NameEditRow {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.NameInput {
-  font-size: 38px;
-  font-weight: 700;
-  color: #191c1a;
-  border: none;
-  border-bottom: 2px solid #119656;
-  background: transparent;
-  outline: none;
-  min-width: 200px;
-  max-width: 480px;
-  width: auto;
 }
 
 /* Unsaved changes confirmation dialog */

--- a/src/containers/Assistants/AssistantDetail/AssistantDetail.test.tsx
+++ b/src/containers/Assistants/AssistantDetail/AssistantDetail.test.tsx
@@ -6,8 +6,6 @@ import * as Notification from 'common/notification';
 import * as Utils from 'common/utils';
 import {
   ASSISTANT_DETAIL_MOCKS,
-  ASSISTANT_DETAIL_RENAME_MOCKS,
-  ASSISTANT_DETAIL_RENAME_ERROR_MOCKS,
   ASSISTANT_DETAIL_SAVE_MOCKS,
   ASSISTANT_DETAIL_SET_LIVE_MOCKS,
   assistantNotFoundMock,
@@ -345,7 +343,8 @@ test('shows assistant not found when query returns no data', async () => {
 
 test('create mode save navigates to the new assistant page', async () => {
   render(
-    <MockedProvider mocks={[createAssistantSuccessMock, getAssistant('99')]}>
+    <MockedProvider
+      mocks={[createAssistantSuccessMock, getAssistant('99')]}>
       <MemoryRouter initialEntries={['/assistants/add']}>
         <Routes>
           <Route path="/assistants/:assistantId" element={<AssistantDetail />} />
@@ -398,116 +397,4 @@ test('pressing Enter on copy assistant ID button calls copyToClipboard', async (
 
   fireEvent.keyDown(screen.getByTestId('copyAssistantId'), { key: 'Enter' });
   expect(copySpy).toHaveBeenCalledWith('asst_JhYmNWzpCVBZY2vTuohvmqjs');
-});
-
-// ── Inline name editing ───────────────────────────────────────────────────────
-
-test('edit name button is visible next to the assistant name', async () => {
-  renderAssistantDetail();
-
-  await waitFor(() => {
-    expect(screen.getByTestId('editNameButton')).toBeInTheDocument();
-    expect(screen.getByTestId('headerTitle')).toHaveTextContent('Assistant-405db438');
-  });
-});
-
-test('clicking edit name button shows input pre-filled with current name', async () => {
-  renderAssistantDetail();
-
-  await waitFor(() => {
-    expect(screen.getByTestId('editNameButton')).toBeInTheDocument();
-  });
-
-  fireEvent.click(screen.getByTestId('editNameButton'));
-
-  await waitFor(() => {
-    expect(screen.getByTestId('nameInput')).toBeInTheDocument();
-    expect(screen.getByTestId('nameInput')).toHaveValue('Assistant-405db438');
-  });
-});
-
-test('Cancel button closes the name input without saving', async () => {
-  renderAssistantDetail();
-
-  await waitFor(() => {
-    expect(screen.getByTestId('editNameButton')).toBeInTheDocument();
-  });
-
-  fireEvent.click(screen.getByTestId('editNameButton'));
-  fireEvent.change(screen.getByTestId('nameInput'), { target: { value: 'Changed Name' } });
-  fireEvent.click(screen.getByTestId('cancelNameButton'));
-
-  await waitFor(() => {
-    expect(screen.queryByTestId('nameInput')).not.toBeInTheDocument();
-    expect(screen.getByTestId('headerTitle')).toHaveTextContent('Assistant-405db438');
-  });
-});
-
-test('Save button calls UPDATE_ASSISTANT and shows success notification', async () => {
-  renderAssistantDetail(ASSISTANT_DETAIL_RENAME_MOCKS);
-
-  await waitFor(() => {
-    expect(screen.getByTestId('editNameButton')).toBeInTheDocument();
-  });
-
-  fireEvent.click(screen.getByTestId('editNameButton'));
-  fireEvent.change(screen.getByTestId('nameInput'), { target: { value: 'New Name' } });
-
-  notificationSpy.mockClear();
-  fireEvent.click(screen.getByTestId('saveNameButton'));
-
-  await waitFor(() => {
-    expect(screen.queryByTestId('nameInput')).not.toBeInTheDocument();
-  });
-});
-
-test('saving unchanged name closes input without calling API', async () => {
-  renderAssistantDetail();
-
-  await waitFor(() => {
-    expect(screen.getByTestId('editNameButton')).toBeInTheDocument();
-  });
-
-  fireEvent.click(screen.getByTestId('editNameButton'));
-  // name is unchanged — same as original
-  fireEvent.click(screen.getByTestId('saveNameButton'));
-
-  await waitFor(() => {
-    expect(screen.queryByTestId('nameInput')).not.toBeInTheDocument();
-  });
-});
-
-test('saving empty name closes input without calling API', async () => {
-  renderAssistantDetail();
-
-  await waitFor(() => {
-    expect(screen.getByTestId('editNameButton')).toBeInTheDocument();
-  });
-
-  fireEvent.click(screen.getByTestId('editNameButton'));
-  fireEvent.change(screen.getByTestId('nameInput'), { target: { value: '   ' } });
-  fireEvent.click(screen.getByTestId('saveNameButton'));
-
-  await waitFor(() => {
-    expect(screen.queryByTestId('nameInput')).not.toBeInTheDocument();
-  });
-});
-
-test('API error during rename shows an errorMessage', async () => {
-  const errorSpy = vi.spyOn(Notification, 'setErrorMessage').mockImplementation(() => {});
-  renderAssistantDetail(ASSISTANT_DETAIL_RENAME_ERROR_MOCKS);
-
-  await waitFor(() => {
-    expect(screen.getByTestId('editNameButton')).toBeInTheDocument();
-  });
-
-  fireEvent.click(screen.getByTestId('editNameButton'));
-  fireEvent.change(screen.getByTestId('nameInput'), { target: { value: 'New Name' } });
-  fireEvent.click(screen.getByTestId('saveNameButton'));
-
-  await waitFor(() => {
-    expect(errorSpy).toHaveBeenCalled();
-  });
-
-  errorSpy.mockRestore();
 });

--- a/src/containers/Assistants/AssistantDetail/AssistantDetail.tsx
+++ b/src/containers/Assistants/AssistantDetail/AssistantDetail.tsx
@@ -1,23 +1,19 @@
-import { useMutation, useQuery } from '@apollo/client';
-import { IconButton, Modal } from '@mui/material';
-import { useEffect, useRef, useState } from 'react';
+import { useQuery } from '@apollo/client';
+import { Modal } from '@mui/material';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router';
 
 import { Button } from 'components/UI/Form/Button/Button';
 
 import { copyToClipboard } from 'common/utils';
-import { setErrorMessage } from 'common/notification';
 
 import { Heading } from 'components/UI/Heading/Heading';
 import { Loading } from 'components/UI/Layout/Loading/Loading';
 
 import { GET_ASSISTANT } from 'graphql/queries/Assistant';
-import { UPDATE_ASSISTANT } from 'graphql/mutations/Assistant';
 
 import CopyIcon from 'assets/images/CopyGreen.svg?react';
-import EditIcon from 'assets/images/icons/Edit.svg?react';
-import BackIcon from 'assets/images/icons/BackIconFlow.svg?react';
 
 import { ConfigEditor } from './ConfigEditor';
 import type { AssistantVersion } from '../VersionPanel/VersionPanel';
@@ -35,20 +31,7 @@ export const AssistantDetail = () => {
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [pendingVersion, setPendingVersion] = useState<AssistantVersion | null>(null);
 
-  const [isEditingName, setIsEditingName] = useState(false);
-  const [nameValue, setNameValue] = useState('');
-  const nameInputRef = useRef<HTMLInputElement>(null);
-
-  const [updateAssistant, { loading: savingName }] = useMutation(UPDATE_ASSISTANT);
-
   const isCreateMode = assistantId === 'add';
-
-  useEffect(() => {
-    if (isEditingName) {
-      nameInputRef.current?.focus();
-      nameInputRef.current?.select();
-    }
-  }, [isEditingName]);
 
   useEffect(() => {
     if (!assistantId) {
@@ -76,32 +59,6 @@ export const AssistantDetail = () => {
   if (!isCreateMode && !assistantData) {
     return <p className={styles.NotFound}>{t('Assistant not found')}</p>;
   }
-
-  const handleEditName = () => {
-    setNameValue(assistantData?.name ?? '');
-    setIsEditingName(true);
-  };
-
-  const handleSaveName = async () => {
-    const trimmed = nameValue.trim();
-    if (!trimmed || trimmed === assistantData?.name) {
-      setIsEditingName(false);
-      return;
-    }
-    try {
-      const response = await updateAssistant({
-        variables: { updateAssistantId: assistantId, input: { name: trimmed } },
-        refetchQueries: [{ query: GET_ASSISTANT, variables: { assistantId } }],
-      });
-      if (response.data?.updateAssistant?.errors?.length > 0) {
-        setErrorMessage(response.data.updateAssistant.errors[0]);
-        return;
-      }
-      setIsEditingName(false);
-    } catch (err: unknown) {
-      setErrorMessage(err);
-    }
-  };
 
   const handleSaved = (newId?: string) => {
     if (isCreateMode && newId) {
@@ -134,44 +91,10 @@ export const AssistantDetail = () => {
 
   return (
     <div className={styles.Page} data-testid="assistantDetailContainer">
-      {isCreateMode ? (
-        <Heading formTitle={t('Create New Assistant')} backLink="/assistants-new" />
-      ) : (
-        <div className={styles.PageHeader} data-testid="heading">
-          <div className={styles.HeaderLeft}>
-            <BackIcon className={styles.BackIcon} onClick={() => navigate('/assistants')} data-testid="back-button" />
-            {isEditingName ? (
-              <div className={styles.NameEditRow}>
-                <input
-                  ref={nameInputRef}
-                  className={styles.NameInput}
-                  value={nameValue}
-                  onChange={(e) => setNameValue(e.target.value)}
-                  data-testid="nameInput"
-                />
-                <Button variant="contained" onClick={handleSaveName} loading={savingName} data-testid="saveNameButton">
-                  {t('Save')}
-                </Button>
-                <Button variant="outlined" onClick={() => setIsEditingName(false)} data-testid="cancelNameButton">
-                  {t('Cancel')}
-                </Button>
-              </div>
-            ) : (
-              <div className={styles.NameViewRow} data-testid="headerTitle">
-                <span className={styles.NameText}>{assistantData?.name ?? ''}</span>
-                <IconButton
-                  size="small"
-                  onClick={handleEditName}
-                  data-testid="editNameButton"
-                  className={styles.EditNameButton}
-                >
-                  <EditIcon />
-                </IconButton>
-              </div>
-            )}
-          </div>
-        </div>
-      )}
+      <Heading
+        formTitle={isCreateMode ? t('Create New Assistant') : (assistantData?.name ?? '')}
+        backLink="/assistants"
+      />
 
       {!isCreateMode && assistantData?.assistantId && (
         <span
@@ -236,17 +159,14 @@ export const AssistantDetail = () => {
           <div className={styles.DialogBox}>
             <div className={styles.Dialog}>
               <h5 className={styles.DialogTitle}>{t('Unsaved changes')}</h5>
-              <p className={styles.DialogBody}>{t('You have unsaved changes. Are you sure you want to leave?')}</p>
+              <p className={styles.DialogBody}>
+                {t('You have unsaved changes. Are you sure you want to leave?')}
+              </p>
               <div className={styles.DialogActions}>
                 <Button data-testid="version-switch-stay" onClick={cancelVersionSwitch} variant="outlined">
                   {t('Stay')}
                 </Button>
-                <Button
-                  data-testid="version-switch-leave"
-                  onClick={confirmVersionSwitch}
-                  variant="contained"
-                  color="error"
-                >
+                <Button data-testid="version-switch-leave" onClick={confirmVersionSwitch} variant="contained" color="error">
                   {t('Leave')}
                 </Button>
               </div>

--- a/src/i18n/en/en.json
+++ b/src/i18n/en/en.json
@@ -537,7 +537,6 @@
   "You won't be able to use this assistant.": "You won't be able to use this assistant.",
   "Purpose-built AI that uses OpenAI's models and calls tools": "Purpose-built AI that uses OpenAI's models and calls tools",
   "Assistant created successfully": "Assistant created successfully",
-  "Assistant name updated successfully": "Assistant name updated successfully",
   "Assistant cloned successfully": "Assistant cloned successfully",
   "Assistant clone initiated": "Assistant clone initiated",
   "Clone Assistant": "Clone Assistant",

--- a/src/mocks/Assistants.ts
+++ b/src/mocks/Assistants.ts
@@ -395,43 +395,6 @@ const setLiveVersion = (assistantId: string, versionId: string, liveVersionNumbe
   },
 });
 
-const updateAssistantName = (id: string, name: string) => ({
-  request: {
-    query: UPDATE_ASSISTANT,
-    variables: { updateAssistantId: id, input: { name } },
-  },
-  result: { data: { updateAssistant: { errors: null } } },
-});
-
-const updateAssistantNameError = (id: string, name: string) => ({
-  request: {
-    query: UPDATE_ASSISTANT,
-    variables: { updateAssistantId: id, input: { name } },
-  },
-  result: {
-    data: { updateAssistant: { errors: [{ key: 'name', message: 'Name already taken' }] } },
-  },
-});
-
-export const ASSISTANT_DETAIL_RENAME_MOCKS = [
-  getAssistant('1'),
-  getAssistant('1'),
-  getAssistantVersions('1'),
-  getAssistantVersions('1'),
-  getAssistantVersions('1'),
-  updateAssistantName('1', 'New Name'),
-  getAssistant('1'), // refetch after rename
-];
-
-export const ASSISTANT_DETAIL_RENAME_ERROR_MOCKS = [
-  getAssistant('1'),
-  getAssistant('1'),
-  getAssistantVersions('1'),
-  getAssistantVersions('1'),
-  getAssistantVersions('1'),
-  updateAssistantNameError('1', 'New Name'),
-];
-
 export const ASSISTANT_DETAIL_MOCKS = [
   getAssistant('1'),
   getAssistant('1'),


### PR DESCRIPTION
Reverts glific/glific-frontend#3882

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Feature Removal**
  * Removed the ability to inline edit assistant names from the detail view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->