### PR TITLE
Revert "Revert "feat: Inline editing of assistant names in version pa…

### DIFF
--- a/src/containers/Assistants/AssistantDetail/AssistantDetail.module.css
+++ b/src/containers/Assistants/AssistantDetail/AssistantDetail.module.css
@@ -16,9 +16,8 @@
   font-weight: 500;
   cursor: pointer;
   width: fit-content;
-  /* Pull up into the Heading block which has bottom padding */
   margin-top: -36px;
-  padding: 0 24px 16px 106px;
+  padding: 1px 24px 16px 70px;
   flex-shrink: 0;
   position: relative;
   z-index: 1001;
@@ -36,8 +35,6 @@
   width: 100%;
 }
 
-
-/* ── Two-panel body ────────────────────────────────── */
 .Body {
   display: flex;
   flex: 1;
@@ -81,6 +78,67 @@
   text-align: center;
   margin: 1rem 0;
   color: #555;
+}
+
+.PageHeader {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background: #f8faf5;
+  border-bottom: 1px solid #e0e0e0;
+  display: flex;
+  align-items: center;
+  padding: 10px 24px 22px 10px;
+  height: 110px;
+}
+
+.HeaderLeft {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-left: 10px;
+}
+
+.BackIcon {
+  cursor: pointer;
+  margin-top: 4px;
+  flex-shrink: 0;
+}
+
+.NameViewRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.NameText {
+  font-size: 38px;
+  font-weight: 700;
+  color: #191c1a;
+  margin-right: 2px;
+}
+
+.EditNameButton {
+  color: #119656;
+}
+
+.NameEditRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.NameInput {
+  font-size: 38px;
+  font-weight: 700;
+  color: #191c1a;
+  border: none;
+  border-bottom: 2px solid #119656;
+  background: transparent;
+  outline: none;
+  min-width: 200px;
+  max-width: 480px;
+  width: auto;
 }
 
 /* Unsaved changes confirmation dialog */

--- a/src/containers/Assistants/AssistantDetail/AssistantDetail.test.tsx
+++ b/src/containers/Assistants/AssistantDetail/AssistantDetail.test.tsx
@@ -6,6 +6,8 @@ import * as Notification from 'common/notification';
 import * as Utils from 'common/utils';
 import {
   ASSISTANT_DETAIL_MOCKS,
+  ASSISTANT_DETAIL_RENAME_MOCKS,
+  ASSISTANT_DETAIL_RENAME_ERROR_MOCKS,
   ASSISTANT_DETAIL_SAVE_MOCKS,
   ASSISTANT_DETAIL_SET_LIVE_MOCKS,
   assistantNotFoundMock,
@@ -343,8 +345,7 @@ test('shows assistant not found when query returns no data', async () => {
 
 test('create mode save navigates to the new assistant page', async () => {
   render(
-    <MockedProvider
-      mocks={[createAssistantSuccessMock, getAssistant('99')]}>
+    <MockedProvider mocks={[createAssistantSuccessMock, getAssistant('99')]}>
       <MemoryRouter initialEntries={['/assistants/add']}>
         <Routes>
           <Route path="/assistants/:assistantId" element={<AssistantDetail />} />
@@ -397,4 +398,116 @@ test('pressing Enter on copy assistant ID button calls copyToClipboard', async (
 
   fireEvent.keyDown(screen.getByTestId('copyAssistantId'), { key: 'Enter' });
   expect(copySpy).toHaveBeenCalledWith('asst_JhYmNWzpCVBZY2vTuohvmqjs');
+});
+
+// ── Inline name editing ───────────────────────────────────────────────────────
+
+test('edit name button is visible next to the assistant name', async () => {
+  renderAssistantDetail();
+
+  await waitFor(() => {
+    expect(screen.getByTestId('editNameButton')).toBeInTheDocument();
+    expect(screen.getByTestId('headerTitle')).toHaveTextContent('Assistant-405db438');
+  });
+});
+
+test('clicking edit name button shows input pre-filled with current name', async () => {
+  renderAssistantDetail();
+
+  await waitFor(() => {
+    expect(screen.getByTestId('editNameButton')).toBeInTheDocument();
+  });
+
+  fireEvent.click(screen.getByTestId('editNameButton'));
+
+  await waitFor(() => {
+    expect(screen.getByTestId('nameInput')).toBeInTheDocument();
+    expect(screen.getByTestId('nameInput')).toHaveValue('Assistant-405db438');
+  });
+});
+
+test('Cancel button closes the name input without saving', async () => {
+  renderAssistantDetail();
+
+  await waitFor(() => {
+    expect(screen.getByTestId('editNameButton')).toBeInTheDocument();
+  });
+
+  fireEvent.click(screen.getByTestId('editNameButton'));
+  fireEvent.change(screen.getByTestId('nameInput'), { target: { value: 'Changed Name' } });
+  fireEvent.click(screen.getByTestId('cancelNameButton'));
+
+  await waitFor(() => {
+    expect(screen.queryByTestId('nameInput')).not.toBeInTheDocument();
+    expect(screen.getByTestId('headerTitle')).toHaveTextContent('Assistant-405db438');
+  });
+});
+
+test('Save button calls UPDATE_ASSISTANT and shows success notification', async () => {
+  renderAssistantDetail(ASSISTANT_DETAIL_RENAME_MOCKS);
+
+  await waitFor(() => {
+    expect(screen.getByTestId('editNameButton')).toBeInTheDocument();
+  });
+
+  fireEvent.click(screen.getByTestId('editNameButton'));
+  fireEvent.change(screen.getByTestId('nameInput'), { target: { value: 'New Name' } });
+
+  notificationSpy.mockClear();
+  fireEvent.click(screen.getByTestId('saveNameButton'));
+
+  await waitFor(() => {
+    expect(screen.queryByTestId('nameInput')).not.toBeInTheDocument();
+  });
+});
+
+test('saving unchanged name closes input without calling API', async () => {
+  renderAssistantDetail();
+
+  await waitFor(() => {
+    expect(screen.getByTestId('editNameButton')).toBeInTheDocument();
+  });
+
+  fireEvent.click(screen.getByTestId('editNameButton'));
+  // name is unchanged — same as original
+  fireEvent.click(screen.getByTestId('saveNameButton'));
+
+  await waitFor(() => {
+    expect(screen.queryByTestId('nameInput')).not.toBeInTheDocument();
+  });
+});
+
+test('saving empty name closes input without calling API', async () => {
+  renderAssistantDetail();
+
+  await waitFor(() => {
+    expect(screen.getByTestId('editNameButton')).toBeInTheDocument();
+  });
+
+  fireEvent.click(screen.getByTestId('editNameButton'));
+  fireEvent.change(screen.getByTestId('nameInput'), { target: { value: '   ' } });
+  fireEvent.click(screen.getByTestId('saveNameButton'));
+
+  await waitFor(() => {
+    expect(screen.queryByTestId('nameInput')).not.toBeInTheDocument();
+  });
+});
+
+test('API error during rename shows an errorMessage', async () => {
+  const errorSpy = vi.spyOn(Notification, 'setErrorMessage').mockImplementation(() => {});
+  renderAssistantDetail(ASSISTANT_DETAIL_RENAME_ERROR_MOCKS);
+
+  await waitFor(() => {
+    expect(screen.getByTestId('editNameButton')).toBeInTheDocument();
+  });
+
+  fireEvent.click(screen.getByTestId('editNameButton'));
+  fireEvent.change(screen.getByTestId('nameInput'), { target: { value: 'New Name' } });
+  fireEvent.click(screen.getByTestId('saveNameButton'));
+
+  await waitFor(() => {
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  errorSpy.mockRestore();
 });

--- a/src/containers/Assistants/AssistantDetail/AssistantDetail.tsx
+++ b/src/containers/Assistants/AssistantDetail/AssistantDetail.tsx
@@ -1,19 +1,23 @@
-import { useQuery } from '@apollo/client';
-import { Modal } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { useMutation, useQuery } from '@apollo/client';
+import { IconButton, Modal } from '@mui/material';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router';
 
 import { Button } from 'components/UI/Form/Button/Button';
 
 import { copyToClipboard } from 'common/utils';
+import { setErrorMessage } from 'common/notification';
 
 import { Heading } from 'components/UI/Heading/Heading';
 import { Loading } from 'components/UI/Layout/Loading/Loading';
 
 import { GET_ASSISTANT } from 'graphql/queries/Assistant';
+import { UPDATE_ASSISTANT } from 'graphql/mutations/Assistant';
 
 import CopyIcon from 'assets/images/CopyGreen.svg?react';
+import EditIcon from 'assets/images/icons/Edit.svg?react';
+import BackIcon from 'assets/images/icons/BackIconFlow.svg?react';
 
 import { ConfigEditor } from './ConfigEditor';
 import type { AssistantVersion } from '../VersionPanel/VersionPanel';
@@ -31,7 +35,20 @@ export const AssistantDetail = () => {
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const [pendingVersion, setPendingVersion] = useState<AssistantVersion | null>(null);
 
+  const [isEditingName, setIsEditingName] = useState(false);
+  const [nameValue, setNameValue] = useState('');
+  const nameInputRef = useRef<HTMLInputElement>(null);
+
+  const [updateAssistant, { loading: savingName }] = useMutation(UPDATE_ASSISTANT);
+
   const isCreateMode = assistantId === 'add';
+
+  useEffect(() => {
+    if (isEditingName) {
+      nameInputRef.current?.focus();
+      nameInputRef.current?.select();
+    }
+  }, [isEditingName]);
 
   useEffect(() => {
     if (!assistantId) {
@@ -59,6 +76,32 @@ export const AssistantDetail = () => {
   if (!isCreateMode && !assistantData) {
     return <p className={styles.NotFound}>{t('Assistant not found')}</p>;
   }
+
+  const handleEditName = () => {
+    setNameValue(assistantData?.name ?? '');
+    setIsEditingName(true);
+  };
+
+  const handleSaveName = async () => {
+    const trimmed = nameValue.trim();
+    if (!trimmed || trimmed === assistantData?.name) {
+      setIsEditingName(false);
+      return;
+    }
+    try {
+      const response = await updateAssistant({
+        variables: { updateAssistantId: assistantId, input: { name: trimmed } },
+        refetchQueries: [{ query: GET_ASSISTANT, variables: { assistantId } }],
+      });
+      if (response.data?.updateAssistant?.errors?.length > 0) {
+        setErrorMessage(response.data.updateAssistant.errors[0]);
+        return;
+      }
+      setIsEditingName(false);
+    } catch (err: unknown) {
+      setErrorMessage(err);
+    }
+  };
 
   const handleSaved = (newId?: string) => {
     if (isCreateMode && newId) {
@@ -91,10 +134,44 @@ export const AssistantDetail = () => {
 
   return (
     <div className={styles.Page} data-testid="assistantDetailContainer">
-      <Heading
-        formTitle={isCreateMode ? t('Create New Assistant') : (assistantData?.name ?? '')}
-        backLink="/assistants"
-      />
+      {isCreateMode ? (
+        <Heading formTitle={t('Create New Assistant')} backLink="/assistants-new" />
+      ) : (
+        <div className={styles.PageHeader} data-testid="heading">
+          <div className={styles.HeaderLeft}>
+            <BackIcon className={styles.BackIcon} onClick={() => navigate('/assistants')} data-testid="back-button" />
+            {isEditingName ? (
+              <div className={styles.NameEditRow}>
+                <input
+                  ref={nameInputRef}
+                  className={styles.NameInput}
+                  value={nameValue}
+                  onChange={(e) => setNameValue(e.target.value)}
+                  data-testid="nameInput"
+                />
+                <Button variant="contained" onClick={handleSaveName} loading={savingName} data-testid="saveNameButton">
+                  {t('Save')}
+                </Button>
+                <Button variant="outlined" onClick={() => setIsEditingName(false)} data-testid="cancelNameButton">
+                  {t('Cancel')}
+                </Button>
+              </div>
+            ) : (
+              <div className={styles.NameViewRow} data-testid="headerTitle">
+                <span className={styles.NameText}>{assistantData?.name ?? ''}</span>
+                <IconButton
+                  size="small"
+                  onClick={handleEditName}
+                  data-testid="editNameButton"
+                  className={styles.EditNameButton}
+                >
+                  <EditIcon />
+                </IconButton>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
 
       {!isCreateMode && assistantData?.assistantId && (
         <span
@@ -159,14 +236,17 @@ export const AssistantDetail = () => {
           <div className={styles.DialogBox}>
             <div className={styles.Dialog}>
               <h5 className={styles.DialogTitle}>{t('Unsaved changes')}</h5>
-              <p className={styles.DialogBody}>
-                {t('You have unsaved changes. Are you sure you want to leave?')}
-              </p>
+              <p className={styles.DialogBody}>{t('You have unsaved changes. Are you sure you want to leave?')}</p>
               <div className={styles.DialogActions}>
                 <Button data-testid="version-switch-stay" onClick={cancelVersionSwitch} variant="outlined">
                   {t('Stay')}
                 </Button>
-                <Button data-testid="version-switch-leave" onClick={confirmVersionSwitch} variant="contained" color="error">
+                <Button
+                  data-testid="version-switch-leave"
+                  onClick={confirmVersionSwitch}
+                  variant="contained"
+                  color="error"
+                >
                   {t('Leave')}
                 </Button>
               </div>

--- a/src/i18n/en/en.json
+++ b/src/i18n/en/en.json
@@ -537,6 +537,7 @@
   "You won't be able to use this assistant.": "You won't be able to use this assistant.",
   "Purpose-built AI that uses OpenAI's models and calls tools": "Purpose-built AI that uses OpenAI's models and calls tools",
   "Assistant created successfully": "Assistant created successfully",
+  "Assistant name updated successfully": "Assistant name updated successfully",
   "Assistant cloned successfully": "Assistant cloned successfully",
   "Assistant clone initiated": "Assistant clone initiated",
   "Clone Assistant": "Clone Assistant",

--- a/src/mocks/Assistants.ts
+++ b/src/mocks/Assistants.ts
@@ -395,6 +395,43 @@ const setLiveVersion = (assistantId: string, versionId: string, liveVersionNumbe
   },
 });
 
+const updateAssistantName = (id: string, name: string) => ({
+  request: {
+    query: UPDATE_ASSISTANT,
+    variables: { updateAssistantId: id, input: { name } },
+  },
+  result: { data: { updateAssistant: { errors: null } } },
+});
+
+const updateAssistantNameError = (id: string, name: string) => ({
+  request: {
+    query: UPDATE_ASSISTANT,
+    variables: { updateAssistantId: id, input: { name } },
+  },
+  result: {
+    data: { updateAssistant: { errors: [{ key: 'name', message: 'Name already taken' }] } },
+  },
+});
+
+export const ASSISTANT_DETAIL_RENAME_MOCKS = [
+  getAssistant('1'),
+  getAssistant('1'),
+  getAssistantVersions('1'),
+  getAssistantVersions('1'),
+  getAssistantVersions('1'),
+  updateAssistantName('1', 'New Name'),
+  getAssistant('1'), // refetch after rename
+];
+
+export const ASSISTANT_DETAIL_RENAME_ERROR_MOCKS = [
+  getAssistant('1'),
+  getAssistant('1'),
+  getAssistantVersions('1'),
+  getAssistantVersions('1'),
+  getAssistantVersions('1'),
+  updateAssistantNameError('1', 'New Name'),
+];
+
 export const ASSISTANT_DETAIL_MOCKS = [
   getAssistant('1'),
   getAssistant('1'),


### PR DESCRIPTION
…ge" (#3884)"

This reverts commit c1fbd0e144ad4cbadfd3e67c466e4075f1738895.

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/glific/glific-frontend) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Please ensure coding standard and conventions are followed. You can find the details at https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing

-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline name editing for assistants—edit assistant names directly from the detail page with Save and Cancel options.
  * Improved page header with sticky positioning and enhanced visual styling for better layout and usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->