### PR TITLE
fix: truncate long assistant names in header 

### DIFF
--- a/src/containers/Assistants/AssistantDetail/AssistantDetail.module.css
+++ b/src/containers/Assistants/AssistantDetail/AssistantDetail.module.css
@@ -116,10 +116,15 @@
   font-weight: 700;
   color: #191c1a;
   margin-right: 2px;
+  max-width: 560px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .EditNameButton {
   color: #119656;
+  flex-shrink: 0;
 }
 
 .NameEditRow {

--- a/src/containers/Assistants/AssistantDetail/ConfigEditor.module.css
+++ b/src/containers/Assistants/AssistantDetail/ConfigEditor.module.css
@@ -50,7 +50,7 @@
   color: #073f24;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: normal;
   min-width: 0;
   flex: 1;
 }

--- a/src/containers/Assistants/AssistantDetail/ConfigEditor.module.css
+++ b/src/containers/Assistants/AssistantDetail/ConfigEditor.module.css
@@ -41,18 +41,25 @@
   margin: 0 -2rem;
   padding: 0 2rem;
   box-shadow: 0 4px 4px 0 #0000000a;
+  overflow: hidden;
 }
 
 .Breadcrumb {
   font-size: 1rem;
   font-weight: 600;
   color: #073f24;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  flex: 1;
 }
 
 .HeaderActions {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  flex-shrink: 0;
 }
 
 .CreateActions {


### PR DESCRIPTION
### Summary 

 The size of the icon should not change based on the size of the assistant name. Assistant name should use fixed width

before:
<img width="1272" height="244" alt="Screenshot 2026-04-10 at 6 53 43 PM" src="https://github.com/user-attachments/assets/f923129b-f1f5-4473-bf95-984ec47f86fc" />


After :

 
<img width="1294" height="359" alt="Screenshot 2026-04-10 at 6 54 03 PM" src="https://github.com/user-attachments/assets/c97cb9fb-184b-4c8f-9dcd-37fe502065f4" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Long assistant names now truncate with ellipsis instead of causing layout overflow
  * Header and breadcrumb elements improved to handle constrained space with proper text truncation
  * Edit buttons and action controls maintain stable positioning in responsive layouts without shifting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->