### PR TITLE
Remove unsupported file extension 'pptx' 

### DIFF
--- a/src/containers/Assistants/AssistantOptions/AssistantOptions.tsx
+++ b/src/containers/Assistants/AssistantOptions/AssistantOptions.tsx
@@ -531,7 +531,7 @@ export const AssistantOptions = ({
                 <input
                   data-testid="uploadFile"
                   type="file"
-                  accept=".csv,.doc,.docx,.html,.java,.md,.pdf,.pptx,.txt"
+                  accept=".csv,.doc,.docx,.html,.java,.md,.pdf,.txt"
                   onChange={handleFileChange}
                   style={{ display: 'none' }}
                   multiple
@@ -603,7 +603,7 @@ export const AssistantOptions = ({
           )}
           <div className={styles.UploadInfo}>
             <span>Individual file size limit: 20MB</span>
-            <span>Allowed file formats: .csv, .doc, .docx, .html, .java, .md, .pdf, .pptx, .txt</span>
+            <span>Allowed file formats: .csv, .doc, .docx, .html, .java, .md, .pdf, .txt</span>
             <span>Each file takes approx 15 secs to upload.</span>
           </div>
         </div>

--- a/src/containers/Assistants/AssistantOptions/AssistantOptions.tsx
+++ b/src/containers/Assistants/AssistantOptions/AssistantOptions.tsx
@@ -602,7 +602,7 @@ export const AssistantOptions = ({
           )}
           <div className={styles.UploadInfo}>
             <span>Individual file size limit: 20MB</span>
-            <span>Allowed file formats: .csv, .doc, .docx, .html, .java, .md, .pdf, .txt</span>
+            <span>{t('Allowed file formats: .csv, .doc, .docx, .html, .java, .md, .pdf, .txt')}</span>
             <span>Each file takes approx 15 secs to upload.</span>
           </div>
         </div>

--- a/src/containers/Assistants/AssistantOptions/KnowledgeBaseOptions.tsx
+++ b/src/containers/Assistants/AssistantOptions/KnowledgeBaseOptions.tsx
@@ -537,7 +537,7 @@ export const KnowledgeBaseOptions = ({
                       <input
                         data-testid="uploadFile"
                         type="file"
-                        accept=".csv,.doc,.docx,.html,.java,.md,.pdf,.pptx,.txt"
+                        accept=".csv,.doc,.docx,.html,.java,.md,.pdf,.txt"
                         onChange={handleFileChange}
                         style={{ display: 'none' }}
                         multiple

--- a/src/i18n/en/en.json
+++ b/src/i18n/en/en.json
@@ -565,6 +565,7 @@
   "Temperature": "Temperature",
   "Upload File": "Upload File",
   "Manage Files": "Manage Files",
+  "Allowed file formats: .csv, .doc, .docx, .html, .java, .md, .pdf, .txt": "Allowed file formats: .csv, .doc, .docx, .html, .java, .md, .pdf, .txt",
   "Manage Knowledge Base": "Manage Knowledge Base",
   "You are adding more files to existing Knowledge Base": "You are adding more files to existing Knowledge Base",
   "Selected File(s)": "Selected File(s)",


### PR DESCRIPTION
### Summary 

1. Updated the list in the knowledge base dialog box.
2. Removed it from the validation list so it is no longer accepted on the frontend.
<img width="595" height="349" alt="Screenshot 2026-04-13 at 8 38 13 PM" src="https://github.com/user-attachments/assets/aa530125-5c7a-473d-ab05-abd5cd97b122" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Removed support for PowerPoint (.pptx) uploads; accepted file formats updated across the upload UI and messaging.
* **Localization**
  * Updated the displayed allowed-formats text to use the app translations and added the corresponding English entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->