### PR TITLE
fix assistants list header and helper text

### DIFF
--- a/src/common/HelpData.tsx
+++ b/src/common/HelpData.tsx
@@ -105,8 +105,16 @@ export const blockedContactsInfo: HelpDataProps = {
 
 export const assistantsInfo: HelpDataProps = {
   heading: t(
+    'Assistants can call OpenAI’s models with specific instructions to tune their personality and capabilities. Assistants can access multiple tools in parallel. Assistants can access files in several formats as part of their creation. When using tools, Assistants can also create files (e.g., images, spreadsheets, etc) and cite files they reference in the Messages they create.'
+  ),
+  link: 'https://glific.github.io/docs/docs/Integrations/Filesearch%20Using%20OpenAI%20Assistants/'
+};
+
+export const assistantListInfo: HelpDataProps = {
+  heading: t(
     'Assistants can call OpenAI’s models with specific instructions to tune their personality and capabilities. Assistants can access files provided by you to generate answers from.'
   ),
+  link: 'https://glific.github.io/docs/docs/Integrations/Filesearch%20Using%20OpenAI%20Assistants/'
 };
 
 export const templateStatusInfo: HelpDataProps = {

--- a/src/containers/Assistants/AssistantList/AssistantList.test.tsx
+++ b/src/containers/Assistants/AssistantList/AssistantList.test.tsx
@@ -38,7 +38,7 @@ test('renders AI Assistant heading', async () => {
   renderAssistantList();
 
   await waitFor(() => {
-    expect(screen.getByText('AI Assistant')).toBeInTheDocument();
+    expect(screen.getByText('AI Assistants')).toBeInTheDocument();
   });
 });
 

--- a/src/containers/Assistants/AssistantList/AssistantList.tsx
+++ b/src/containers/Assistants/AssistantList/AssistantList.tsx
@@ -11,10 +11,11 @@ import DuplicateIcon from 'assets/images/icons/Duplicate.svg?react';
 import EditIcon from 'assets/images/icons/Edit.svg?react';
 import CopyIcon from 'assets/images/icons/Settings/Copy.svg?react';
 
-import { assistantsInfo } from 'common/HelpData';
+import { assistantListInfo } from 'common/HelpData';
 import { setErrorMessage, setNotification } from 'common/notification';
 import { copyToClipboard } from 'common/utils';
 import { DialogBox } from 'components/UI/DialogBox/DialogBox';
+import { Heading } from 'components/UI/Heading/Heading';
 import { List } from 'containers/List/List';
 import { CLONE_ASSISTANT, DELETE_ASSISTANT } from 'graphql/mutations/Assistant';
 import { FILTER_ASSISTANTS, GET_ASSISTANT, GET_ASSISTANTS_COUNT } from 'graphql/queries/Assistant';
@@ -175,9 +176,19 @@ export const AssistantList = () => {
 
   return (
     <>
+      <Heading
+        formTitle={t('AI Assistants')}
+        helpData={assistantListInfo}
+        headerHelp={t('AI that answers based on your context')}
+        button={{
+          show: true,
+          label: t('Create New Assistant'),
+          action: () => navigate('/assistants/add'),
+        }}
+      />
       <List
-        helpData={assistantsInfo}
-        title={t('AI Assistant')}
+        title={t('AI Assistants')}
+        showHeader={false}
         listItem="assistants"
         listItemName="assistant"
         pageLink="assistants"
@@ -186,11 +197,6 @@ export const AssistantList = () => {
         {...columnAttributes}
         searchParameter={['name_or_assistant_id']}
         additionalAction={additionalAction}
-        button={{
-          show: true,
-          label: t('Create New Assistant'),
-          action: () => navigate('/assistants/add'),
-        }}
         editSupport={false}
         deleteModifier={{ variables: (id: string) => ({ deleteAssistantId: id }) }}
         sortConfig={{ sortBy: 'updated_at', sortOrder: 'desc' }}

--- a/src/containers/Assistants/AssistantList/AssistantList.tsx
+++ b/src/containers/Assistants/AssistantList/AssistantList.tsx
@@ -15,7 +15,6 @@ import { assistantListInfo } from 'common/HelpData';
 import { setErrorMessage, setNotification } from 'common/notification';
 import { copyToClipboard } from 'common/utils';
 import { DialogBox } from 'components/UI/DialogBox/DialogBox';
-import { Heading } from 'components/UI/Heading/Heading';
 import { List } from 'containers/List/List';
 import { CLONE_ASSISTANT, DELETE_ASSISTANT } from 'graphql/mutations/Assistant';
 import { FILTER_ASSISTANTS, GET_ASSISTANT, GET_ASSISTANTS_COUNT } from 'graphql/queries/Assistant';
@@ -176,19 +175,9 @@ export const AssistantList = () => {
 
   return (
     <>
-      <Heading
-        formTitle={t('AI Assistants')}
-        helpData={assistantListInfo}
-        headerHelp={t('AI that answers based on your context')}
-        button={{
-          show: true,
-          label: t('Create New Assistant'),
-          action: () => navigate('/assistants/add'),
-        }}
-      />
       <List
+        helpData={assistantListInfo}
         title={t('AI Assistants')}
-        showHeader={false}
         listItem="assistants"
         listItemName="assistant"
         pageLink="assistants"
@@ -197,6 +186,11 @@ export const AssistantList = () => {
         {...columnAttributes}
         searchParameter={['name_or_assistant_id']}
         additionalAction={additionalAction}
+        button={{
+          show: true,
+          label: t('Create New Assistant'),
+          action: () => navigate('/assistants/add'),
+        }}
         editSupport={false}
         deleteModifier={{ variables: (id: string) => ({ deleteAssistantId: id }) }}
         sortConfig={{ sortBy: 'updated_at', sortOrder: 'desc' }}

--- a/src/i18n/en/en.json
+++ b/src/i18n/en/en.json
@@ -587,6 +587,7 @@
   "Are you sure you want to update the phone number?": "Are you sure you want to update the phone number?",
   "It will not be possible to update the number later. The new number will be {{phone}}.": "It will not be possible to update the number later. The new number will be {{phone}}.",
   "Only lowercase alphanumeric characters and underscores are allowed.": "Only lowercase alphanumeric characters and underscores are allowed.",
+  "Assistants can call OpenAI’s models with specific instructions to tune their personality and capabilities. Assistants can access multiple tools in parallel. Assistants can access files in several formats as part of their creation. When using tools, Assistants can also create files (e.g., images, spreadsheets, etc) and cite files they reference in the Messages they create.": "Assistants can call OpenAI’s models with specific instructions to tune their personality and capabilities. Assistants can access multiple tools in parallel. Assistants can access files in several formats as part of their creation. When using tools, Assistants can also create files (e.g., images, spreadsheets, etc) and cite files they reference in the Messages they create.",
   "Share": "Share",
   "Draft": "Draft",
   "Published": "Published",
@@ -617,7 +618,8 @@
   "You have unsaved changes. Are you sure you want to leave?": "You have unsaved changes. Are you sure you want to leave?",
   "Stay": "Stay",
   "Leave": "Leave",
-  "Assistants can call OpenAI’s models with specific instructions to tune their personality and capabilities. Assistants can access files provided by you to generate answers from.": "'Assistants can call OpenAI’s models with specific instructions to tune their personality and capabilities. Assistants can access files provided by you to generate answers from.",
+  "Assistants can call OpenAI’s models with specific instructions to tune their personality and capabilities. Assistants can access files provided by you to generate answers from.": "Assistants can call OpenAI’s models with specific instructions to tune their personality and capabilities. Assistants can access files provided by you to generate answers from.",
   "Allowed file formats:": "Allowed file formats:",
-  ".csv, .doc, .docx, .html, .htm, .md, .markdown, .pdf, .txt": ".csv, .doc, .docx, .html, .htm, .md, .markdown, .pdf, .txt"
+  ".csv, .doc, .docx, .html, .htm, .md, .markdown, .pdf, .txt": ".csv, .doc, .docx, .html, .htm, .md, .markdown, .pdf, .txt",
+  "AI that answers based on your context": "AI that answers based on your context"
 }


### PR DESCRIPTION
**Changes**
- Remove ' in the assistants pages helper text
- Split header tooltip for and new ui
- Add helper text for new assistants list ui

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the AI Assistants page with a dedicated header, page title, and "Create New Assistant" button for improved navigation and accessibility

* **Documentation**
  * Enhanced help descriptions with detailed information about assistant capabilities, including model calling, parallel tool use, multi-format file support, and file citations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->