### PR TITLE
fix: use updateAssistantAttrs for assistant rename to prevent new version creation

### DIFF
--- a/src/containers/Assistants/AssistantDetail/AssistantDetail.tsx
+++ b/src/containers/Assistants/AssistantDetail/AssistantDetail.tsx
@@ -12,7 +12,7 @@ import { copyToClipboard } from 'common/utils';
 import { Heading } from 'components/UI/Heading/Heading';
 import { Loading } from 'components/UI/Layout/Loading/Loading';
 
-import { UPDATE_ASSISTANT } from 'graphql/mutations/Assistant';
+import { UPDATE_ASSISTANT_ATTRS } from 'graphql/mutations/Assistant';
 import { GET_ASSISTANT } from 'graphql/queries/Assistant';
 
 import CopyIcon from 'assets/images/CopyGreen.svg?react';
@@ -39,7 +39,7 @@ export const AssistantDetail = () => {
   const [nameValue, setNameValue] = useState('');
   const nameInputRef = useRef<HTMLInputElement>(null);
 
-  const [updateAssistant, { loading: savingName }] = useMutation(UPDATE_ASSISTANT);
+  const [updateAssistantAttrs, { loading: savingName }] = useMutation(UPDATE_ASSISTANT_ATTRS);
 
   const isCreateMode = assistantId === 'add';
 
@@ -89,12 +89,12 @@ export const AssistantDetail = () => {
       return;
     }
     try {
-      const response = await updateAssistant({
-        variables: { updateAssistantId: assistantId, input: { name: trimmed } },
+      const response = await updateAssistantAttrs({
+        variables: { id: assistantId, input: { name: trimmed } },
         refetchQueries: [{ query: GET_ASSISTANT, variables: { assistantId } }],
       });
-      if (response.data?.updateAssistant?.errors?.length > 0) {
-        setErrorMessage(response.data.updateAssistant.errors[0]);
+      if (response.data?.updateAssistantAttrs?.errors?.length > 0) {
+        setErrorMessage(response.data.updateAssistantAttrs.errors[0]);
         return;
       }
       setIsEditingName(false);

--- a/src/graphql/mutations/Assistant.ts
+++ b/src/graphql/mutations/Assistant.ts
@@ -26,6 +26,21 @@ export const UPDATE_ASSISTANT = gql`
   }
 `;
 
+export const UPDATE_ASSISTANT_ATTRS = gql`
+  mutation UpdateAssistantAttrs($id: ID!, $input: AssistantAttrsInput!) {
+    updateAssistantAttrs(id: $id, input: $input) {
+      assistant {
+        id
+        name
+      }
+      errors {
+        key
+        message
+      }
+    }
+  }
+`;
+
 export const UPLOAD_FILE_TO_KAAPI = gql`
   mutation UploadFilesearchFile($media: Upload!) {
     uploadFilesearchFile(media: $media) {

--- a/src/mocks/Assistants.ts
+++ b/src/mocks/Assistants.ts
@@ -5,6 +5,7 @@ import {
   DELETE_ASSISTANT,
   SET_LIVE_VERSION,
   UPDATE_ASSISTANT,
+  UPDATE_ASSISTANT_ATTRS,
   UPLOAD_FILE_TO_KAAPI,
 } from 'graphql/mutations/Assistant';
 import {
@@ -449,19 +450,19 @@ const setLiveVersion = (assistantId: string, versionId: string, liveVersionNumbe
 
 const updateAssistantName = (id: string, name: string) => ({
   request: {
-    query: UPDATE_ASSISTANT,
-    variables: { updateAssistantId: id, input: { name } },
+    query: UPDATE_ASSISTANT_ATTRS,
+    variables: { id, input: { name } },
   },
-  result: { data: { updateAssistant: { errors: null } } },
+  result: { data: { updateAssistantAttrs: { assistant: { id, name }, errors: null } } },
 });
 
 const updateAssistantNameError = (id: string, name: string) => ({
   request: {
-    query: UPDATE_ASSISTANT,
-    variables: { updateAssistantId: id, input: { name } },
+    query: UPDATE_ASSISTANT_ATTRS,
+    variables: { id, input: { name } },
   },
   result: {
-    data: { updateAssistant: { errors: [{ key: 'name', message: 'Name already taken' }] } },
+    data: { updateAssistantAttrs: { assistant: null, errors: [{ key: 'name', message: 'Name already taken' }] } },
   },
 });
 


### PR DESCRIPTION
## Summary

- Added `UPDATE_ASSISTANT_ATTRS` mutation which calls the new backend `updateAssistantAttrs` API
- Switched `AssistantDetail` rename flow from `UPDATE_ASSISTANT` to `UPDATE_ASSISTANT_ATTRS` — the old `updateAssistant` mutation was creating a new assistant version on every rename because the backend treats any `updateAssistant` call as a version save
- Updated mocks accordingly

## Test plan

- [ ] Rename an assistant from the detail page — verify no new version is created in the version panel
- [ ] Verify saving actual version changes (instructions, model, temperature) still creates a new version
- [ ] Run `npx vitest run src/containers/Assistants/AssistantDetail/` — all 57 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)