### PR TITLE
fix: restore failed status chip and disable Set As LIVE for failed versions

### DIFF
--- a/src/containers/Assistants/AssistantDetail/ConfigEditor.tsx
+++ b/src/containers/Assistants/AssistantDetail/ConfigEditor.tsx
@@ -160,6 +160,14 @@ export const ConfigEditor = ({
     },
   });
 
+  const setLiveTooltip = version?.isLive
+    ? t('This version is already live')
+    : version?.status === 'failed'
+      ? t('Cannot set a failed version as live')
+      : t('Set this version as LIVE tooltip');
+
+  const isSetLiveDisabled = version?.isLive || version?.status === 'failed' || newVersionInProgress || settingLive;
+
   const handleSetLive = () => {
     if (!version) return;
     setLiveVersion({
@@ -307,17 +315,14 @@ export const ConfigEditor = ({
                   {t('Unsaved changes')}
                 </span>
               )}
-              <Tooltip
-                title={version?.isLive ? t('This version is already live') : t('Set this version as LIVE tooltip')}
-                arrow
-              >
+              <Tooltip title={setLiveTooltip} arrow>
                 <span>
                   <Button
                     variant="outlined"
                     data-testid="setLiveButton"
                     onClick={handleSetLive}
                     loading={settingLive}
-                    disabled={version?.isLive || newVersionInProgress || settingLive}
+                    disabled={isSetLiveDisabled}
                   >
                     {t('Set As LIVE')}
                   </Button>

--- a/src/containers/Assistants/VersionPanel/VersionPanel.test.tsx
+++ b/src/containers/Assistants/VersionPanel/VersionPanel.test.tsx
@@ -82,15 +82,13 @@ describe('VersionPanel', () => {
     expect(screen.queryByTestId('versionStatus')).not.toBeInTheDocument();
   });
 
-  it('does not show status chip for failed status', async () => {
+  it('shows failed status chip correctly', async () => {
     const versionsWithFailed = [{ ...mockVersions[0], status: 'failed' }];
     renderVersionPanel({}, [getVersionsMock('1', versionsWithFailed)]);
 
     await waitFor(() => {
-      expect(screen.getAllByTestId('versionCard')).toHaveLength(1);
+      expect(screen.getByTestId('versionStatus')).toHaveTextContent('Failed');
     });
-
-    expect(screen.queryByTestId('versionStatus')).not.toBeInTheDocument();
   });
 
   it('shows empty state when no versions exist', async () => {

--- a/src/containers/Assistants/VersionPanel/VersionPanel.tsx
+++ b/src/containers/Assistants/VersionPanel/VersionPanel.tsx
@@ -44,6 +44,11 @@ interface VersionPanelProps {
 }
 
 
+const statusConfig: Record<string, { label: string; styleKey: string }> = {
+  in_progress: { label: 'In Progress', styleKey: 'InProgress' },
+  failed: { label: 'Failed', styleKey: 'Failed' },
+};
+
 export const VersionPanel = ({
   assistantId,
   selectedVersionId,
@@ -104,12 +109,12 @@ export const VersionPanel = ({
                   {version.isLive && (
                     <Chip data-testid="liveBadge" label={t('LIVE')} size="small" className={styles.LiveBadge} />
                   )}
-                  {version.status === 'in_progress' && (
+                  {statusConfig[version.status] && (
                     <Chip
                       data-testid="versionStatus"
-                      label="In Progress"
+                      label={t(statusConfig[version.status].label as any)}
                       size="small"
-                      className={`${styles.StatusChip} ${styles.InProgress}`}
+                      className={`${styles.StatusChip} ${styles[statusConfig[version.status].styleKey]}`}
                     />
                   )}
                 </div>

--- a/src/i18n/en/en.json
+++ b/src/i18n/en/en.json
@@ -605,6 +605,8 @@
   "LIVE": "LIVE",
   "Set As LIVE": "Set As LIVE",
   "This version is already live": "This version is already live",
+  "Cannot set a failed version as live": "Cannot set a failed version as live",
+  "In Progress": "In Progress",
   "Promote this version so flows use it": "Promote this version so flows use it",
   "Set this version as LIVE tooltip": "Set this version as \"LIVE\": Once made live, this assistant will respond using this version of prompt, knowledge base, and settings for all flows where this is used. You can switch between versions anytime.",
   "Save your work as a new version. This version won't be used in flows until you set it as live.": "Save your work as a new version. This version won't be used in flows until you set it as live.",


### PR DESCRIPTION
Fixes #3910

## Summary

- Restores the **Failed** status chip in `VersionPanel` that was accidentally removed in #3892 — only `in_progress` was kept, but `failed` should also be visible
- Disables the **Set As LIVE** button (with an explanatory tooltip) when a version's status is `failed`
- Adds missing i18n strings to `en.json`: `"In Progress"`, `"Cannot set a failed version as live"`
- Extracts `setLiveTooltip` and `isSetLiveDisabled` variables in `ConfigEditor` to keep JSX clean

## Test plan

- [ ] Version with `failed` status shows a red "Failed" chip in the version panel
- [ ] Version with `in_progress` status still shows the orange "In Progress" chip
- [ ] "Set As LIVE" button is disabled and shows tooltip "Cannot set a failed version as live" when status is `failed`
- [ ] "Set As LIVE" button works normally for `ready` versions
- [ ] All existing unit tests pass (`npx vitest run src/containers/Assistants/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)