### PR TITLE
Configure Dependabot for npm package updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/" 
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3


### PR DESCRIPTION
## Summary

1- Since Snyk only reports vulnerabilities and few updates and Dependabot is better suited for handling package updates, we should configure Dependabot specifically only  for updating dependencies.