### PR TITLE
Warn about assistant nodes after flow import using structured field

### DIFF
--- a/src/containers/Flow/FlowList/FlowList.test.tsx
+++ b/src/containers/Flow/FlowList/FlowList.test.tsx
@@ -370,7 +370,7 @@ describe('Template flows', () => {
     });
   });
 
-  test('Template flows > should display failed assistants when import has assistant errors', async () => {
+  test('Template flows > should display assistant nodes that need an assistant assigned', async () => {
     const mockImportFlowWithAssistantError = {
       request: { query: IMPORT_FLOW },
       result: {
@@ -378,9 +378,9 @@ describe('Template flows', () => {
           importFlow: {
             status: [
               {
+                assistantNodeUuids: ['3fb647a3-c935-4906-8dd0-c0e63105ee3d', 'b1d2e9ff-1234-4abc-9876-deadbeefcafe'],
                 flowName: 'Test Flow',
-                status:
-                  'Failed to import assistant Assistant ID: a_pJMxxxZfGfDicrgAD Failed to import assistant Assistant ID: asst_testsD',
+                status: 'Successfully imported',
               },
             ],
           },
@@ -433,13 +433,15 @@ describe('Template flows', () => {
     const helpLink = await inDialog.findByText(/create a new assistant/i);
     const para = helpLink.closest('p');
     expect(para).toBeTruthy();
-    expect(normalize(para!.textContent || '')).toContain('flow imported successfully, but failed to import assistants');
+    expect(normalize(para!.textContent || '')).toContain(
+      'flow imported successfully. this flow contains assistant node(s) that need an assistant assigned'
+    );
 
-    const failedLabels = inDialog.getAllByText((_, el) => normalize(el?.textContent || '') === 'failed assistants:');
-    expect(failedLabels.length).toBeGreaterThan(0);
+    const nodeLabels = inDialog.getAllByText((_, el) => normalize(el?.textContent || '') === 'assistant node uuids:');
+    expect(nodeLabels.length).toBeGreaterThan(0);
 
-    expect(inDialog.getByText('a_pJMxxxZfGfDicrgAD')).toBeInTheDocument();
-    expect(inDialog.getByText('asst_testsD')).toBeInTheDocument();
+    expect(inDialog.getByText('3fb647a3-c935-4906-8dd0-c0e63105ee3d')).toBeInTheDocument();
+    expect(inDialog.getByText('b1d2e9ff-1234-4abc-9876-deadbeefcafe')).toBeInTheDocument();
 
     expect(helpLink).toHaveAttribute(
       'href',

--- a/src/containers/Flow/FlowList/FlowList.tsx
+++ b/src/containers/Flow/FlowList/FlowList.tsx
@@ -175,26 +175,14 @@ export const FlowList = () => {
       >
         <div className={styles.ImportDialog}>
           {importStatus.map((status: any) => {
-            const statusText = status.status ?? '';
-            const hasAssistantError = statusText.includes('Failed to import assistant');
+            const assistantNodeUuids: string[] = status.assistantNodeUuids ?? [];
 
-            const warningChunks = statusText
-              .split(/Failed to import assistant/g)
-              .slice(1)
-              .filter(Boolean);
-
-            const assistantIds: string[] = warningChunks
-              .map((chunk: string) => {
-                const m = chunk.match(/Assistant ID:\s*([a-zA-Z0-9_]+)/);
-                return m ? m[1] : null;
-              })
-              .filter((id: string | null): id is string => id !== null);
-
-            if (hasAssistantError && assistantIds.length > 0) {
+            if (assistantNodeUuids.length > 0) {
               return (
-                <div key={status.FlowName} className={styles.StatusContainer}>
+                <div key={status.flowName} className={styles.StatusContainer}>
                   <p className={styles.StatusMessage}>
-                    Flow imported successfully, but failed to import assistants. Please{' '}
+                    Flow imported successfully. This flow contains assistant node(s) that need an assistant assigned.
+                    Please{' '}
                     <a
                       href="https://glific.github.io/docs/docs/Integrations/Filesearch%20Using%20OpenAI%20Assistants/#how-to-create-an-openai-assistant-in-glific"
                       className={styles.HelpLink}
@@ -203,15 +191,15 @@ export const FlowList = () => {
                     >
                       create a new assistant
                     </a>{' '}
-                    and replace the existing one in the flow.
+                    and assign it to the following node(s):
                   </p>
                   <div className={styles.SectionTitle}>
-                    <strong>{assistantIds.length === 1 ? 'Failed Assistant:' : 'Failed Assistants:'}</strong>
+                    <strong>{assistantNodeUuids.length === 1 ? 'Assistant Node UUID:' : 'Assistant Node UUIDs:'}</strong>
                   </div>
                   <ol className={styles.AssistantListPlain}>
-                    {assistantIds.map((id: string) => (
-                      <li key={id}>
-                        <code className={styles.AssistantCod}>{id}</code>
+                    {assistantNodeUuids.map((uuid: string) => (
+                      <li key={uuid}>
+                        <code className={styles.AssistantCod}>{uuid}</code>
                       </li>
                     ))}
                   </ol>

--- a/src/graphql/mutations/Flow.ts
+++ b/src/graphql/mutations/Flow.ts
@@ -131,6 +131,7 @@ export const IMPORT_FLOW = gql`
   mutation importFlow($flow: Json!) {
     importFlow(flow: $flow) {
       status {
+        assistantNodeUuids
         flowName
         status
       }

--- a/src/mocks/Flow.tsx
+++ b/src/mocks/Flow.tsx
@@ -463,10 +463,12 @@ export const importFlow = {
       importFlow: {
         status: [
           {
+            assistantNodeUuids: [],
             flowName: 'Registration flow',
             status: 'Successfully imported',
           },
           {
+            assistantNodeUuids: [],
             flowName: 'Optin',
             status: 'Successfully imported',
           },


### PR DESCRIPTION
Issue #4946

**Description**
  - The importFlow mutation now returns assistantNodeUuids, a structured list of node UUIDs in the imported flow that reference an assistant. FE uses this directly.
  - The warning dialog only appears when the imported flow actually contains assistant nodes.
  - Updated the heading to "Assistant Node UUID(s):" so users know what they're looking at in the list.
  
[ Backend PR](https://github.com/glific/glific/pull/5033)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flow import functionality to better handle assistant node assignment requirements. Status messages now clearly display which assistant nodes need assignment, streamlining the flow import workflow and reducing user confusion during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->