### PR TITLE
Bump heroku-buildpack-nodejs to v344 and tighten node engines

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
-https://github.com/heroku/heroku-buildpack-nodejs.git#v244
+https://github.com/heroku/heroku-buildpack-nodejs.git#v344
 https://github.com/heroku/heroku-buildpack-nginx.git

--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
-https://github.com/heroku/heroku-buildpack-nodejs.git#v183
+https://github.com/heroku/heroku-buildpack-nodejs.git#v244
 https://github.com/heroku/heroku-buildpack-nginx.git

--- a/.github/workflows/e2e-tests-slow.yml
+++ b/.github/workflows/e2e-tests-slow.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Use latest Node.js
         uses: actions/setup-node@v6
+        with:
+          node-version-file: '.tool-versions'
 
       - name: Setup elixir
         uses: erlef/setup-beam@v1

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Use latest Node.js
         uses: actions/setup-node@v6
+        with:
+          node-version-file: '.tool-versions'
 
       - name: Setup elixir
         uses: erlef/setup-beam@v1

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -9,6 +9,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.tool-versions'
+          cache: 'yarn'
+
       - name: Install Dependencies
         run: |
           cp .env.example .env

--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with:
+          node-version-file: '.tool-versions'
           cache: 'yarn'
 
       - name: Install Dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glific-frontend",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "engines": {
-    "node": ">=20.0.0 <23"
+    "node": ">=22.12.0 <23"
   },
   "eslintConfig": {
     "extends": "react-app"

--- a/src/containers/InteractiveMessage/InteractiveMessage.tsx
+++ b/src/containers/InteractiveMessage/InteractiveMessage.tsx
@@ -449,6 +449,8 @@ export const InteractiveMessage = () => {
   };
 
   const afterSave = (data: any, saveClick: boolean, message?: any) => {
+    console.log('called');
+
     if (!saveClick) {
       if (params.id) {
         handleLanguageChange(nextLanguage);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7460,16 +7460,8 @@ streamx@^2.12.0, streamx@^2.12.5, streamx@^2.13.2, streamx@^2.14.0:
     fast-fifo "^1.3.2"
     text-decoder "^1.1.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -7586,14 +7578,8 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  name strip-ansi-cjs
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
 **Description**
 
Prepares the frontend for the gigalixir-24 stack upgrade by:
 - bumping heroku-buildpack-nodejs from v183 → v344
 - tightening [engines.node to >=22.12.0 <23](https://nodejs.org/en/about/previous-releases) (so the buildpack stops picking incompatible Node 22.0.0)
 - pinning all CI workflows to read Node version from .tool-versions()ocal dev (asdf/nvm/mise reads .tool-versions)       and CI now use the exact same Node)
 - yarn.lock changes are cosmetic alias consolidation only- no package versions changed.

**Test plan**

  - Unit + E2E tests pass on CI with Node 22.21.1
  - Staging gigalixir build succeeds on current stack, then on gigalixir-24
  - Staging app smoke test: login, flow editor, chat, GraphQL all work

