### PR TITLE
feat: add CSV template download functionality and update link to button

### DIFF
--- a/src/containers/AIEvals/AIEvaluationCreate/AIEvaluationCreate.module.css
+++ b/src/containers/AIEvals/AIEvaluationCreate/AIEvaluationCreate.module.css
@@ -33,10 +33,15 @@
 
 .TemplateLink {
   display: block;
+  background: none;
+  border: none;
+  padding: 0;
   color: #2e7d32;
   text-decoration: underline;
   cursor: pointer;
   margin-top: 8px;
+  font-size: inherit;
+  text-align: left;
 }
 
 .TemplateLink:hover {

--- a/src/containers/AIEvals/AIEvaluationCreate/AIEvaluationCreate.test.tsx
+++ b/src/containers/AIEvals/AIEvaluationCreate/AIEvaluationCreate.test.tsx
@@ -168,7 +168,7 @@ describe('AIEvaluationCreate', () => {
     });
 
     expect(screen.getByRole('button', { name: 'Upload Golden QA' })).toBeInTheDocument();
-    expect(screen.getByRole('link')).toBeInTheDocument();
+    expect(screen.getByTestId('templateCsvButton')).toBeInTheDocument();
   });
 
   test('renders Upload Golden QA button', async () => {

--- a/src/containers/AIEvals/AIEvaluationCreate/AIEvaluationCreate.test.tsx
+++ b/src/containers/AIEvals/AIEvaluationCreate/AIEvaluationCreate.test.tsx
@@ -171,6 +171,46 @@ describe('AIEvaluationCreate', () => {
     expect(screen.getByTestId('templateCsvButton')).toBeInTheDocument();
   });
 
+  test('clicking the CSV template button downloads golden_qa_template.csv with correct content', async () => {
+    render(wrapper());
+
+    await waitFor(() => {
+      expect(screen.getByText('Create AI Evaluation')).toBeInTheDocument();
+    });
+
+    const mockObjectUrl = 'blob:mock-url';
+    const createObjectURLSpy = vi.spyOn(URL, 'createObjectURL').mockReturnValue(mockObjectUrl);
+    const revokeObjectURLSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+    const mockClick = vi.fn();
+    let capturedAnchor: HTMLAnchorElement | null = null;
+    const originalCreateElement = document.createElement.bind(document);
+    const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+      if (tagName === 'a') {
+        const anchor = originalCreateElement('a') as HTMLAnchorElement;
+        anchor.click = mockClick;
+        capturedAnchor = anchor;
+        return anchor;
+      }
+      return originalCreateElement(tagName as keyof HTMLElementTagNameMap);
+    });
+
+    fireEvent.click(screen.getByTestId('templateCsvButton'));
+
+    expect(createObjectURLSpy).toHaveBeenCalledOnce();
+    const blob = createObjectURLSpy.mock.calls[0][0] as Blob;
+    expect(blob.type).toBe('text/csv;charset=utf-8;');
+
+    expect(capturedAnchor).not.toBeNull();
+    expect(capturedAnchor!.download).toBe('golden_qa_template.csv');
+    expect(mockClick).toHaveBeenCalledOnce();
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith(mockObjectUrl);
+
+    createObjectURLSpy.mockRestore();
+    revokeObjectURLSpy.mockRestore();
+    createElementSpy.mockRestore();
+  });
+
   test('renders Upload Golden QA button', async () => {
     render(wrapper());
 
@@ -390,7 +430,14 @@ describe('AIEvaluationCreate', () => {
   });
 
   test('shows success notification and navigates to chat on successful submission', async () => {
-    render(wrapper([getListAiEvaluationsMock, getAssistantConfigVersionsMock, getListGoldenQaForCreateMock, getCreateEvaluationSuccessMock]));
+    render(
+      wrapper([
+        getListAiEvaluationsMock,
+        getAssistantConfigVersionsMock,
+        getListGoldenQaForCreateMock,
+        getCreateEvaluationSuccessMock,
+      ])
+    );
 
     await fillAndSubmitForm();
 
@@ -488,12 +535,7 @@ describe('AIEvaluationCreate', () => {
     };
 
     render(
-      wrapper([
-        getListAiEvaluationsMock,
-        getAssistantConfigVersionsMock,
-        getListGoldenQaForCreateMock,
-        matchingMock,
-      ])
+      wrapper([getListAiEvaluationsMock, getAssistantConfigVersionsMock, getListGoldenQaForCreateMock, matchingMock])
     );
 
     await fillAndSubmitForm();
@@ -518,12 +560,7 @@ describe('AIEvaluationCreate', () => {
     };
 
     render(
-      wrapper([
-        getListAiEvaluationsMock,
-        getAssistantConfigVersionsMock,
-        getListGoldenQaForCreateMock,
-        matchingMock,
-      ])
+      wrapper([getListAiEvaluationsMock, getAssistantConfigVersionsMock, getListGoldenQaForCreateMock, matchingMock])
     );
 
     await fillAndSubmitForm();

--- a/src/containers/AIEvals/AIEvaluationCreate/AIEvaluationCreate.tsx
+++ b/src/containers/AIEvals/AIEvaluationCreate/AIEvaluationCreate.tsx
@@ -15,6 +15,17 @@ import * as Yup from 'yup';
 import { UploadGoldenQaDialog } from 'containers/AIEvals/UploadGoldenQaDialog/UploadGoldenQaDialog';
 import styles from './AIEvaluationCreate.module.css';
 
+const downloadTemplateCsv = () => {
+  const csvContent = 'Question,Answer\n"What is X?","Answer to X"\n"What is Y?","Answer to Y"';
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'golden_qa_template.csv';
+  link.click();
+  URL.revokeObjectURL(url);
+};
+
 const getGoldenQAHelperContent = () => (
   <div className={styles.GoldenQAHelper}>
     <p className={styles.GoldenQAHelperDescription}>
@@ -26,9 +37,9 @@ const getGoldenQAHelperContent = () => (
       <div className={styles.CSVFormatExample}>{t('Expected CSV Format:')}</div>
       <div className={styles.CSVFormatExample}>{t('Question, Answer')}</div>
       <div className={styles.CSVFormatExample}>{'"What Is X","Answer"'}</div>
-      <a href="#" className={styles.TemplateLink} target="_blank" rel="noopener noreferrer">
+      <button type="button" data-testid="templateCsvButton" className={styles.TemplateLink} onClick={downloadTemplateCsv}>
         {t('Click Here For The Template Csv')}
-      </a>
+      </button>
     </div>
   </div>
 );


### PR DESCRIPTION
Closes: https://github.com/glific/glific/issues/5026

- Replaced the broken href="#" anchor with a downloadTemplateCsv function that creates a proper sample CSV (Question,Answer with two example
   rows), generates a blob URL, triggers the download as golden_qa_template.csv, then cleans up the object URL
- The <a> tag became a <button> with background: none; border: none CSS so it still looks like a link
- Added data-testid="templateCsvButton" and updated the test to use it (avoids relying on i18n text that isn't mocked in that test file)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSV template download: Users can now download a pre-formatted CSV template for Golden QA evaluations, streamlining the data preparation and submission process.

* **Style**
  * Improved styling consistency for the template download button to ensure proper display and user experience.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/glific/glific-frontend/pull/3934)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->