### PR TITLE
fix(AskGlific): route subscription responses to the originating tab

### DIFF
--- a/src/containers/AskGlific/AskGlific.test.tsx
+++ b/src/containers/AskGlific/AskGlific.test.tsx
@@ -614,6 +614,86 @@ describe('AskGlific', () => {
     expect(thumbUp.className).toContain('FeedbackButtonActive');
   });
 
+  test('it should ignore subscription events whose requestId was not issued by this tab', async () => {
+    const otherTabSubMock = createSubscriptionMock({ requestId: 'a-different-tab-uuid' });
+
+    renderAskGlific({ mocks: [conversationsMock, suggestionMock, otherTabSubMock] });
+
+    fireEvent.click(screen.getAllByTestId('suggestion')[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('thinking...')).toBeInTheDocument();
+    });
+
+    // Give the subscription event time to be delivered and rejected.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+
+    expect(screen.getByText('thinking...')).toBeInTheDocument();
+    expect(screen.queryByText('This is a mock response from the bot.')).not.toBeInTheDocument();
+  });
+
+  test('it should disable the send button while a response is being generated', async () => {
+    const slowSubMock = createSubscriptionMock({ delay: 1000 });
+    const typedMock = createAskGlificMock('Hello');
+
+    renderAskGlific({ mocks: [conversationsMock, typedMock, slowSubMock] });
+
+    const textbox = screen.getByTestId('textbox');
+    fireEvent.change(textbox, { target: { value: 'Hello' } });
+    fireEvent.keyDown(textbox, { key: 'Enter', shiftKey: false });
+
+    await waitFor(() => {
+      expect(screen.getByText('thinking...')).toBeInTheDocument();
+    });
+
+    // Type new text so the button's not-empty condition is satisfied — the
+    // only remaining reason it should be disabled is the in-flight request.
+    fireEvent.change(textbox, { target: { value: 'Another message' } });
+    expect(screen.getByTestId('send-icon')).toBeDisabled();
+  });
+
+  test('it should block Enter-to-send while a response is being generated', async () => {
+    const slowSubMock = createSubscriptionMock({ delay: 1000 });
+    const firstMock = createAskGlificMock('First');
+
+    renderAskGlific({ mocks: [conversationsMock, firstMock, slowSubMock] });
+
+    const textbox = screen.getByTestId('textbox');
+    fireEvent.change(textbox, { target: { value: 'First' } });
+    fireEvent.keyDown(textbox, { key: 'Enter', shiftKey: false });
+
+    await waitFor(() => {
+      expect(screen.getByText('thinking...')).toBeInTheDocument();
+    });
+
+    fireEvent.change(textbox, { target: { value: 'Second' } });
+    fireEvent.keyDown(textbox, { key: 'Enter', shiftKey: false });
+
+    // 'Second' would only show as a user message <div> if the second send went
+    // through. The textarea also contains 'Second' as its value, so scope the
+    // assertion to divs only.
+    expect(screen.queryByText('Second', { selector: 'div' })).not.toBeInTheDocument();
+  });
+
+  test('it should block suggestion clicks while a response is being generated', async () => {
+    const slowSubMock = createSubscriptionMock({ delay: 1000 });
+
+    renderAskGlific({ mocks: [conversationsMock, suggestionMock, slowSubMock] });
+
+    const suggestions = screen.getAllByTestId('suggestion');
+    fireEvent.click(suggestions[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('thinking...')).toBeInTheDocument();
+    });
+
+    // Click a different suggestion — should be ignored, no new mutation fired.
+    fireEvent.click(suggestions[1]);
+
+    // The second suggestion's text should not appear as a user message.
+    expect(screen.queryByText(suggestions[1].textContent || '')).not.toBeInTheDocument();
+  });
+
   test('it should show history panel in sidebar mode and select conversation', async () => {
     renderAskGlific({ mocks: [conversationsWithDataMock, messagesMock] });
 

--- a/src/containers/AskGlific/AskGlific.test.tsx
+++ b/src/containers/AskGlific/AskGlific.test.tsx
@@ -1,6 +1,6 @@
 import { MockedProvider } from '@apollo/client/testing';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { ASK_GLIFIC_FEEDBACK } from 'graphql/mutations/AskGlific';
+import { ASK_GLIFIC, ASK_GLIFIC_FEEDBACK } from 'graphql/mutations/AskGlific';
 import { GET_ASK_GLIFIC_CONVERSATIONS, GET_ASK_GLIFIC_MESSAGES } from 'graphql/queries/AskGlific';
 import {
   askGlificErrorMock,
@@ -12,6 +12,7 @@ import {
   feedbackDislikeMock,
   feedbackMock,
   messagesMock,
+  MOCK_REQUEST_ID,
   subscriptionMock,
   suggestionMock,
 } from 'mocks/AskGlific';
@@ -692,6 +693,124 @@ describe('AskGlific', () => {
 
     // The second suggestion's text should not appear as a user message.
     expect(screen.queryByText(suggestions[1].textContent || '')).not.toBeInTheDocument();
+  });
+
+  test('handleSendMessage resets loading state after a mutation error so the user can retry', async () => {
+    const failingSendMock = {
+      request: {
+        query: ASK_GLIFIC,
+        variables: {
+          input: {
+            query: 'Will fail',
+            conversationId: '',
+            pageUrl: window.location.href,
+            requestId: MOCK_REQUEST_ID,
+          },
+        },
+      },
+      error: new Error('Network down'),
+    };
+
+    const retrySendMock = createAskGlificMock('Retry attempt');
+    const retrySubMock = createSubscriptionMock({ answer: 'It worked!', delay: 30 });
+
+    renderAskGlific({ mocks: [conversationsMock, failingSendMock, retrySendMock, retrySubMock] });
+
+    const textbox = screen.getByTestId('textbox');
+    fireEvent.change(textbox, { target: { value: 'Will fail' } });
+    fireEvent.keyDown(textbox, { key: 'Enter', shiftKey: false });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Sorry, I encountered an error while processing your request. Please try again.')
+      ).toBeInTheDocument();
+    });
+
+    // After the error, loading must have been cleared (otherwise the retry
+    // Enter press would be blocked by the in-flight guard).
+    fireEvent.change(textbox, { target: { value: 'Retry attempt' } });
+    fireEvent.keyDown(textbox, { key: 'Enter', shiftKey: false });
+
+    await waitFor(() => {
+      expect(screen.getByText('It worked!')).toBeInTheDocument();
+    });
+  });
+
+  test('clicking the title in sidebar mode toggles history and re-fetches conversations on open', async () => {
+    const emptyOnMount = {
+      request: {
+        query: GET_ASK_GLIFIC_CONVERSATIONS,
+        variables: { limit: 10, lastId: '' },
+      },
+      result: {
+        data: {
+          askGlificConversations: {
+            conversations: [],
+            hasMore: false,
+            limit: 10,
+          },
+        },
+      },
+      maxUsageCount: 1,
+    };
+
+    const dataOnRefresh = {
+      request: {
+        query: GET_ASK_GLIFIC_CONVERSATIONS,
+        variables: { limit: 10, lastId: '' },
+      },
+      result: {
+        data: {
+          askGlificConversations: {
+            conversations: [
+              {
+                id: 'conv-new',
+                name: 'Fresh Conversation',
+                status: 'normal',
+                createdAt: now,
+                updatedAt: now,
+              },
+            ],
+            hasMore: false,
+            limit: 10,
+          },
+        },
+      },
+      maxUsageCount: Number.MAX_SAFE_INTEGER,
+    };
+
+    renderAskGlific({ mocks: [emptyOnMount, dataOnRefresh] });
+
+    await waitFor(() => {
+      expect(screen.getByText('Ask Glific! Learn About How It Works?')).toBeInTheDocument();
+    });
+
+    // Switch to sidebar mode (auto-opens the history panel with the empty initial fetch).
+    fireEvent.click(screen.getByTestId('display-mode-btn'));
+    await waitFor(() => {
+      expect(screen.getByText('Sidebar')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText('Sidebar'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('history-panel')).toBeInTheDocument();
+      expect(screen.getByTestId('no-conversations')).toBeInTheDocument();
+    });
+
+    // Click title to close history panel.
+    const title = screen.getByText('New chat');
+    fireEvent.click(title);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('history-panel')).not.toBeInTheDocument();
+    });
+
+    // Click title again to re-open — triggers a fresh loadConversations.
+    fireEvent.click(title);
+
+    await waitFor(() => {
+      expect(screen.getByText('Fresh Conversation')).toBeInTheDocument();
+    });
   });
 
   test('it should show history panel in sidebar mode and select conversation', async () => {

--- a/src/containers/AskGlific/AskGlific.tsx
+++ b/src/containers/AskGlific/AskGlific.tsx
@@ -103,6 +103,10 @@ const AskGlific = ({ open, setOpen }: AskGlificProps) => {
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  // Tracking number for the in-flight mutation. The subscription is org+user wide
+  // (other tabs of the same user receive the same events), so we only accept events
+  // whose echoed requestId matches the one we issued.
+  const pendingRequestIdRef = useRef<string | null>(null);
 
   const [hasMoreConversations, setHasMoreConversations] = useState(false);
   const [lastConversationId, setLastConversationId] = useState('');
@@ -119,6 +123,12 @@ const AskGlific = ({ open, setOpen }: AskGlificProps) => {
     onData: ({ data }) => {
       const result = data?.data?.askGlificResponse;
       if (!result) return;
+
+      // Subscription is org+user wide, so events for other tabs reach us too.
+      // Only accept the event whose echoed requestId matches the one we issued.
+      if (!result.requestId || result.requestId !== pendingRequestIdRef.current) return;
+      pendingRequestIdRef.current = null;
+      const wasNewConversation = !conversationId;
 
       if (result.errors?.length) {
         setMessages((prev) => [
@@ -143,6 +153,11 @@ const AskGlific = ({ open, setOpen }: AskGlificProps) => {
             messageId: result.messageId || undefined,
           },
         ]);
+        // First response of a new conversation — pull it into the history list so
+        // it shows up without a refresh.
+        if (wasNewConversation) {
+          loadConversations();
+        }
       }
       setIsLoading(false);
     },
@@ -282,6 +297,9 @@ const AskGlific = ({ open, setOpen }: AskGlificProps) => {
   const handleSendMessage = async (msg: Message, currentMessages = messages) => {
     setIsLoading(true);
 
+    const requestId = crypto.randomUUID();
+    pendingRequestIdRef.current = requestId;
+
     try {
       await askGlific({
         variables: {
@@ -289,10 +307,12 @@ const AskGlific = ({ open, setOpen }: AskGlificProps) => {
             query: msg.content,
             conversationId: conversationId || '',
             pageUrl: window.location.href,
+            requestId,
           },
         },
       });
     } catch {
+      pendingRequestIdRef.current = null;
       const errorMessage: Message = {
         role: 'error',
         content: 'Sorry, I encountered an error while processing your request. Please try again.',
@@ -304,7 +324,7 @@ const AskGlific = ({ open, setOpen }: AskGlificProps) => {
   };
 
   const handleOk = () => {
-    if (!message.trim()) return;
+    if (!message.trim() || isLoading) return;
     const userMessage: Message = { role: 'user', content: message, timestamp: new Date() };
     const updatedMessages = [...messages, userMessage];
     setMessages(updatedMessages);
@@ -313,6 +333,7 @@ const AskGlific = ({ open, setOpen }: AskGlificProps) => {
   };
 
   const handleSuggestionClick = (suggestion: string) => {
+    if (isLoading) return;
     const userMessage: Message = { role: 'user', content: suggestion, timestamp: new Date() };
     const updatedMessages = [...messages, userMessage];
     setMessages(updatedMessages);
@@ -320,7 +341,7 @@ const AskGlific = ({ open, setOpen }: AskGlificProps) => {
   };
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
-    if (event.key === 'Enter' && !event.shiftKey && message.trim()) {
+    if (event.key === 'Enter' && !event.shiftKey && message.trim() && !isLoading) {
       event.preventDefault();
       handleOk();
     }
@@ -462,9 +483,13 @@ const AskGlific = ({ open, setOpen }: AskGlificProps) => {
                 className={styles.HeaderLeft}
                 onClick={(e) => {
                   if (isExpandedMode) {
-                    setShowHistory((prev) => !prev);
+                    const willOpen = !showHistory;
+                    setShowHistory(willOpen);
+                    if (willOpen) loadConversations();
                   } else {
-                    setHistoryAnchor(historyAnchor ? null : e.currentTarget);
+                    const willOpen = !historyAnchor;
+                    setHistoryAnchor(willOpen ? e.currentTarget : null);
+                    if (willOpen) loadConversations();
                   }
                 }}
               >
@@ -718,7 +743,7 @@ const AskGlific = ({ open, setOpen }: AskGlificProps) => {
                     <IconButton
                       className={styles.SendButton}
                       onClick={handleOk}
-                      disabled={!message.trim()}
+                      disabled={!message.trim() || isLoading}
                       data-testid="send-icon"
                       size="small"
                     >

--- a/src/graphql/subscriptions/AskGlific.ts
+++ b/src/graphql/subscriptions/AskGlific.ts
@@ -7,6 +7,7 @@ export const ASK_GLIFIC_RESPONSE_SUBSCRIPTION = gql`
       conversationId
       conversationName
       messageId
+      requestId
       errors {
         message
       }

--- a/src/mocks/AskGlific.ts
+++ b/src/mocks/AskGlific.ts
@@ -4,12 +4,15 @@ import { ASK_GLIFIC_RESPONSE_SUBSCRIPTION } from 'graphql/subscriptions/AskGlifi
 
 const now = Math.floor(Date.now() / 1000);
 
+export const MOCK_REQUEST_ID = 'mock-request-id-1234-5678-90ab-cdef00000000';
+
 export const createSubscriptionMock = (
   overrides: Partial<{
     answer: string;
     conversationId: string;
     conversationName: string;
     messageId: string;
+    requestId: string;
     errors: { message: string }[] | null;
     delay: number;
   }> = {}
@@ -27,6 +30,7 @@ export const createSubscriptionMock = (
           conversationId: 'conv-123',
           conversationName: 'Test Chat',
           messageId: 'msg-new-001',
+          requestId: MOCK_REQUEST_ID,
           errors: null,
           ...data,
         },
@@ -142,6 +146,7 @@ export const createAskGlificMock = (query: string) => ({
         query,
         conversationId: '',
         pageUrl: window.location.href,
+        requestId: MOCK_REQUEST_ID,
       },
     },
   },
@@ -168,6 +173,7 @@ export const askGlificErrorMock = {
         query: 'Create your first chatbot',
         conversationId: '',
         pageUrl: window.location.href,
+        requestId: MOCK_REQUEST_ID,
       },
     },
   },

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -70,6 +70,8 @@ window.fetch = vi.fn() as any;
 
 window.URL.createObjectURL = vi.fn();
 
+(globalThis.crypto as any).randomUUID = () => 'mock-request-id-1234-5678-90ab-cdef00000000';
+
 if (!globalThis.TextEncoder) {
   Object.defineProperty(globalThis, 'TextEncoder', {
     value: TextEncoder,


### PR DESCRIPTION
- Generate a UUID per send, pass it as requestId in the mutation input, and
  ignore subscription events whose echoed requestId doesn't match — fixes two
  open tabs both receiving each other's responses.
- Lock send button / Enter key / suggestions while a response is in flight.
- Refresh history when the dropdown opens, and after the first response of a
  new conversation, so new chats show up without a manual refresh.