### PR TITLE
fix: update error handling navigation and button labels in ErrorBoundary

### DIFF
--- a/src/components/errorboundary/ErrorBoundary.test.tsx
+++ b/src/components/errorboundary/ErrorBoundary.test.tsx
@@ -9,18 +9,24 @@ vi.mock('react-router', async () => ({
   useNavigate: () => mockedUsedNavigate,
 }));
 
+let shouldThrow = true;
 const ThrowingChild = () => {
-  throw new Error('Test error');
+  if (shouldThrow) {
+    throw new Error('Test error');
+  }
+  return <div data-testid="recovered-child">Recovered</div>;
 };
 
-const renderWithError = () =>
-  render(
+const renderWithError = () => {
+  shouldThrow = true;
+  return render(
     <MemoryRouter>
       <ErrorBoundary>
         <ThrowingChild />
       </ErrorBoundary>
     </MemoryRouter>
   );
+};
 
 describe('ErrorBoundary', () => {
   // suppress the expected error log from React when the child throws
@@ -42,16 +48,21 @@ describe('ErrorBoundary', () => {
     expect(getByText('Close')).toBeInTheDocument();
   });
 
-  test('Close button navigates to /chat', async () => {
-    const { getByTestId } = renderWithError();
+  test('Close button navigates to /chat and dismisses the dialog', async () => {
+    const { getByTestId, queryByTestId } = renderWithError();
 
     await waitFor(() => {
-      expect(getByTestId('cancel-button')).toBeInTheDocument();
+      expect(getByTestId('ok-button')).toBeInTheDocument();
     });
 
-    fireEvent.click(getByTestId('cancel-button'));
+    // simulate route change: the throwing child would unmount, so future renders shouldn't throw
+    shouldThrow = false;
+    fireEvent.click(getByTestId('ok-button'));
 
     expect(mockedUsedNavigate).toHaveBeenCalledWith('/chat');
+    await waitFor(() => {
+      expect(queryByTestId('errorMessage')).not.toBeInTheDocument();
+    });
   });
 
   test('Retry button reloads the page', async () => {
@@ -65,10 +76,10 @@ describe('ErrorBoundary', () => {
     const { getByTestId } = renderWithError();
 
     await waitFor(() => {
-      expect(getByTestId('ok-button')).toBeInTheDocument();
+      expect(getByTestId('cancel-button')).toBeInTheDocument();
     });
 
-    fireEvent.click(getByTestId('ok-button'));
+    fireEvent.click(getByTestId('cancel-button'));
 
     expect(reloadMock).toHaveBeenCalled();
 

--- a/src/components/errorboundary/ErrorBoundary.test.tsx
+++ b/src/components/errorboundary/ErrorBoundary.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { vi } from 'vitest';
+import ErrorBoundary from './ErrorBoundary';
+
+const mockedUsedNavigate = vi.fn();
+vi.mock('react-router', async () => ({
+  ...(await vi.importActual('react-router')),
+  useNavigate: () => mockedUsedNavigate,
+}));
+
+const ThrowingChild = () => {
+  throw new Error('Test error');
+};
+
+const renderWithError = () =>
+  render(
+    <MemoryRouter>
+      <ErrorBoundary>
+        <ThrowingChild />
+      </ErrorBoundary>
+    </MemoryRouter>
+  );
+
+describe('ErrorBoundary', () => {
+  // suppress the expected error log from React when the child throws
+  const originalError = console.error;
+  beforeAll(() => {
+    console.error = vi.fn();
+  });
+  afterAll(() => {
+    console.error = originalError;
+  });
+
+  test('renders the fallback UI with Retry and Close buttons when a child throws', async () => {
+    const { getByTestId, getByText } = renderWithError();
+
+    await waitFor(() => {
+      expect(getByTestId('errorMessage')).toBeInTheDocument();
+    });
+    expect(getByText('Retry')).toBeInTheDocument();
+    expect(getByText('Close')).toBeInTheDocument();
+  });
+
+  test('Close button navigates to /chat', async () => {
+    const { getByTestId } = renderWithError();
+
+    await waitFor(() => {
+      expect(getByTestId('cancel-button')).toBeInTheDocument();
+    });
+
+    fireEvent.click(getByTestId('cancel-button'));
+
+    expect(mockedUsedNavigate).toHaveBeenCalledWith('/chat');
+  });
+
+  test('Retry button reloads the page', async () => {
+    const reloadMock = vi.fn();
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, reload: reloadMock },
+    });
+
+    const { getByTestId } = renderWithError();
+
+    await waitFor(() => {
+      expect(getByTestId('ok-button')).toBeInTheDocument();
+    });
+
+    fireEvent.click(getByTestId('ok-button'));
+
+    expect(reloadMock).toHaveBeenCalled();
+
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  });
+});

--- a/src/components/errorboundary/ErrorBoundary.tsx
+++ b/src/components/errorboundary/ErrorBoundary.tsx
@@ -48,13 +48,14 @@ class ErrorBoundary extends Component<any, any> {
                 title="Error !"
                 colorCancel="warning"
                 handleOk={() => {
-                  window.location.reload();
-                }}
-                handleCancel={() => {
+                  this.setState({ hasError: false });
                   navigate('/chat');
                 }}
-                buttonOk="Retry"
-                buttonCancel="Close"
+                handleCancel={() => {
+                  window.location.reload();
+                }}
+                buttonOk="Close"
+                buttonCancel="Retry"
                 alignButtons="center"
                 contentAlign="center"
               >

--- a/src/components/errorboundary/ErrorBoundary.tsx
+++ b/src/components/errorboundary/ErrorBoundary.tsx
@@ -51,10 +51,10 @@ class ErrorBoundary extends Component<any, any> {
                   window.location.reload();
                 }}
                 handleCancel={() => {
-                  navigate('/logout/user');
+                  navigate('/chat');
                 }}
                 buttonOk="Retry"
-                buttonCancel="Logout"
+                buttonCancel="Close"
                 alignButtons="center"
                 contentAlign="center"
               >


### PR DESCRIPTION
target issue is #3938 

Instead of adding fixes to the contact module, I replaced the "Logout" button in the ErrorBoundary with a "Close" button that redirects to /chat. Users no longer get logged out when this error surfaces, which is a better UX given how rarely this issue actually occurs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated error dialog button behavior: "Close" navigates to chat and dismisses the error, while "Retry" reloads the page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/glific/glific-frontend/pull/3951?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->