### PR TITLE
fix: preserve body bold formatting in LIST interactive messages

### DIFF
--- a/src/containers/InteractiveMessage/InteractiveMessage.test.tsx
+++ b/src/containers/InteractiveMessage/InteractiveMessage.test.tsx
@@ -12,6 +12,7 @@ import {
   getTemplateMocks3,
   getTemplateMocks4,
   getTemplateMocks5,
+  getTemplateMocks6,
   mocks,
   translateInteractiveTemplateMock,
   translateWitTrimmingMocks,
@@ -417,6 +418,25 @@ describe('Edit mode', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Edit Interactive message')).toBeInTheDocument();
+    });
+  });
+
+  test('it preserves body bold formatting while stripping markdown from LIST item options', async () => {
+    render(renderInteractiveMessage('6', getTemplateMocks6));
+
+    await waitFor(() => {
+      expect(screen.getByText('Markdown content removed')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('ok-button'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Edit Interactive message')).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      const bodyEditor = screen.getByTestId('editor-body');
+      expect(bodyEditor).toHaveTextContent('*bold body text*');
     });
   });
 });

--- a/src/containers/InteractiveMessage/InteractiveMessage.tsx
+++ b/src/containers/InteractiveMessage/InteractiveMessage.tsx
@@ -153,12 +153,14 @@ export const InteractiveMessage = () => {
       case QUICK_REPLY:
         return { ...interactiveContent, options: cleanMarkdown(interactiveContent.options) };
 
-      case LIST:
-        interactiveContent.items = interactiveContent.items.map((item: any) => ({
+      case LIST: {
+        const cleanedItems = interactiveContent.items.map((item: any) => ({
           ...item,
           options: cleanMarkdown(item.options),
         }));
-        return cleanMarkdown(interactiveContent);
+        const { body, items, ...rest } = interactiveContent;
+        return { ...cleanMarkdown(rest), items: cleanedItems, body };
+      }
 
       default:
         return interactiveContent;

--- a/src/mocks/InteractiveMessage.tsx
+++ b/src/mocks/InteractiveMessage.tsx
@@ -506,6 +506,27 @@ export const getTemplateMocks4 = [
 
 export const getTemplateMocks5 = [...mocks, getTemplateByType('5', markdownMock), getTemplateByType('5', markdownMock)];
 
+const listMarkdownMock = {
+  id: '6',
+  type: 'LIST',
+  interactiveContent:
+    '{"type":"list","title":"test list","body":"*bold body text*","globalButtons":[{"type":"text","title":"*button*"}],"items":[{"title":"Section 1","subtitle":"Section 1","options":[{"type":"text","title":"*Option 1*","description":"desc"}]}]}',
+  label: 'test list',
+  language: {
+    id: '1',
+    label: 'English',
+  },
+  sendWithTitle: true,
+  translations:
+    '{"1":{"type":"list","title":"test list","body":"*bold body text*","globalButtons":[{"type":"text","title":"*button*"}],"items":[{"title":"Section 1","subtitle":"Section 1","options":[{"type":"text","title":"*Option 1*","description":"desc"}]}]}}',
+};
+
+export const getTemplateMocks6 = [
+  ...mocks,
+  getTemplateByType('6', listMarkdownMock),
+  getTemplateByType('6', listMarkdownMock),
+];
+
 export const translateWithoutTrimmingMocks = [
   ...getTemplateMocks1,
   translateInteractiveTemplateMock(),


### PR DESCRIPTION
## PR Description:

  ### Problem

closes: https://github.com/glific/glific-frontend/issues/3957

  When editing a LIST-type interactive message with bold formatting in the body (e.g. `*text*`), saving from a second language would erase the  bold in **both** languages on reopen.

  **Root cause:** `removeMarkdownValidation` for the `LIST` case called `cleanMarkdown(interactiveContent)` on the entire content object.
  Since `cleanMarkdown` recurses through every key, it stripped markdown markers from the `body` field — not just the button labels where
  stripping is intended. The stripped body was then stored in the `translations` state and persisted on the next save.

  **Why same-language saves worked fine:** When saving in the same language, the current editor content (still showing the original bold) overwrote the stripped translation value, masking the bug. Saving in a different language kept the stripped value for the original language and persisted it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed markdown handling in interactive message LIST items to properly strip markdown from item options while preserving formatting in the message body.

* **Tests**
  * Added test coverage for markdown stripping behavior in LIST item edit mode.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/glific/glific-frontend/pull/3956?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->