### PR TITLE
fix: allow alphanumeric and special chars in trial org name validation

### DIFF
--- a/src/containers/Organization/TrialRegistration/TrialRegistration.test.tsx
+++ b/src/containers/Organization/TrialRegistration/TrialRegistration.test.tsx
@@ -54,8 +54,27 @@ describe('TrialRegistration', () => {
     fireEvent.blur(orgNameInput);
 
     await waitFor(() => {
-      expect(screen.getByText('Organization name can only contain letters, numbers, spaces, and special characters (&, ., -, ,)')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'Organization name can only contain letters, numbers, spaces, and special characters (&, ., -, ,)'
+        )
+      ).toBeInTheDocument();
     });
+  });
+
+  test('should accept organization names with allowed special characters', async () => {
+    render(wrapper);
+
+    const orgNameInput = screen.getByPlaceholderText('Organization Name');
+
+    for (const name of ['People4Good', 'Jan Sahas 2.0', 'Health & Care, Inc.']) {
+      fireEvent.change(orgNameInput, { target: { value: name } });
+      fireEvent.blur(orgNameInput);
+
+      await waitFor(() => {
+        expect(screen.queryByText(/Organization name can only contain/)).not.toBeInTheDocument();
+      });
+    }
   });
 
   test('should show validation error for invalid username', async () => {

--- a/src/containers/Organization/TrialRegistration/TrialRegistration.test.tsx
+++ b/src/containers/Organization/TrialRegistration/TrialRegistration.test.tsx
@@ -50,11 +50,11 @@ describe('TrialRegistration', () => {
     render(wrapper);
 
     const orgNameInput = screen.getByPlaceholderText('Organization Name');
-    fireEvent.change(orgNameInput, { target: { value: '123' } });
+    fireEvent.change(orgNameInput, { target: { value: 'Organization 123 @' } });
     fireEvent.blur(orgNameInput);
 
     await waitFor(() => {
-      expect(screen.getByText('Organization name can only contain alphabets and spaces')).toBeInTheDocument();
+      expect(screen.getByText('Organization name can only contain letters, numbers, spaces, and special characters (&, ., -, ,)')).toBeInTheDocument();
     });
   });
 
@@ -82,7 +82,7 @@ describe('TrialRegistration', () => {
     render(wrapper);
 
     fireEvent.change(screen.getByPlaceholderText('Organization Name'), {
-      target: { value: 'Testing Org' },
+      target: { value: 'Testing Org 1' },
     });
     fireEvent.change(screen.getByPlaceholderText('Your name'), {
       target: { value: 'Amisha' },

--- a/src/containers/Organization/TrialRegistration/TrialRegistration.tsx
+++ b/src/containers/Organization/TrialRegistration/TrialRegistration.tsx
@@ -52,7 +52,7 @@ export const TrialRegistration = () => {
   const FormSchema = Yup.object().shape({
     organizationName: Yup.string()
       .required('Organization name is required')
-      .matches(/^[A-Za-z\s]+$/, 'Organization name can only contain alphabets and spaces')
+      .matches(/^[A-Za-z0-9\s&.,\-]+$/, 'Organization name can only contain letters, numbers, spaces, and special characters (&, ., -, ,)')
       .min(2, 'Organization must be at least 2 characters'),
     username: Yup.string()
       .required('Your name is required')

--- a/src/containers/Organization/TrialRegistration/TrialRegistration.tsx
+++ b/src/containers/Organization/TrialRegistration/TrialRegistration.tsx
@@ -52,7 +52,11 @@ export const TrialRegistration = () => {
   const FormSchema = Yup.object().shape({
     organizationName: Yup.string()
       .required('Organization name is required')
-      .matches(/^[A-Za-z0-9\s&.,\-]+$/, 'Organization name can only contain letters, numbers, spaces, and special characters (&, ., -, ,)')
+      .trim()
+      .matches(
+        /^[A-Za-z0-9 &.,-]+$/,
+        'Organization name can only contain letters, numbers, spaces, and special characters (&, ., -, ,)'
+      )
       .min(2, 'Organization must be at least 2 characters'),
     username: Yup.string()
       .required('Your name is required')


### PR DESCRIPTION
## Summary

Fixes [glific/glific#5168](https://github.com/glific/glific/issues/5168)

The Organisation Name field on the trial signup page was rejecting any input containing digits or common punctuation, blocking legitimate NGO names like "People4Good", "Health360", or "Jan Sahas 2.0".

**Before (bug):**
![Organisation Name field highlighted red for "People4Good - Tech4Dev"](https://github.com/user-attachments/assets/899f744d-a70f-4617-a0a3-54fb7ea2287a)

**Changes:**
- Updated validation regex from `/^[A-Za-z\s]+$/` to `/^[A-Za-z0-9\s&.,\-]+$/` — now allows letters, numbers, spaces, and `&`, `.`, `,`, `-`
- Updated the validation error message to reflect the expanded allowed character set
- Updated the corresponding test to use a character (`@`) that remains invalid and to assert the new error message

**After**
<img width="950" height="671" alt="Screenshot 2026-06-01 at 3 08 36 PM" src="https://github.com/user-attachments/assets/99184a75-c310-4440-ad84-74ef1d5f9559" />

## Test plan
- [x] Enter "People4Good" in the Organisation Name field — should be accepted (no red border)
- [x] Enter "Health360" — should be accepted
- [x] Enter "Jan Sahas 2.0" — should be accepted
- [x] Enter "People4Good & Partners" — should be accepted
- [x] Enter a name with `@` or `!` — should still show the validation error
- [x] All existing tests pass: `npx vitest run src/containers/Organization/TrialRegistration/TrialRegistration.test.tsx`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened organization name validation to allow letters, numbers, spaces, and selected special characters (&, ., ,, -); validation message updated accordingly.

* **Tests**
  * Updated and expanded tests to verify the new allowed character set and confirm previously valid formats remain accepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->