### PR TITLE
ci: install packages needed by cypress-testing

### DIFF
--- a/.github/workflows/e2e-tests-slow.yml
+++ b/.github/workflows/e2e-tests-slow.yml
@@ -117,9 +117,9 @@ jobs:
           echo '127.0.0.1  api.glific.test' | sudo tee -a /etc/hosts
           mkdir -p project
           cd project
-          echo clone glific repo
           git clone https://github.com/glific/glific.git
           cd glific
+
           cd priv
           mkdir cert
           cd cert
@@ -167,7 +167,7 @@ jobs:
           cp -r cypress-testing/cypress ../cypress
           cp cypress-testing/cypress.config.ts.example ../cypress.config.ts
           cd ..
-          yarn add cypress@13.6.2
+          yarn add cypress@15.15.0
 
       - name: Run glific frontend
         run: |
@@ -175,7 +175,7 @@ jobs:
 
       - name: Run glific backend
         run: |
-          cd project/glific/
+          cd project/glific
           ENABLE_DB_SSL=false OPEN_AI_KEY=${{secrets.OPENAI_KEY}} mix phx.server > phoenix-server.log 2>&1 &
           echo "artifacts_path=${PWD}/phoenix-server.log" >> $GITHUB_ENV
 
@@ -187,7 +187,10 @@ jobs:
 
       - name: Cypress run
         run: |
-          yarn run cypress run --spec cypress/e2e/filesearch/Filesearch.spec.ts --record --key ${{ secrets.CYPRESS_DASHBOARD_KEY }}
+          yarn run cypress run \
+            --spec cypress/e2e/filesearch/Filesearch.spec.ts \
+            --record \
+            --key ${{ secrets.CYPRESS_DASHBOARD_KEY }}
 
       - name: Upload Phoenix server & ngrok logs
         if: always()

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -178,6 +178,7 @@ jobs:
           cp cypress-testing/cypress.config.ts.example ../cypress.config.ts
           cd cypress-testing
           yarn
+          yarn add cypress@15.15.0
           cd ..
 
       - name: Run glific frontend

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -198,7 +198,7 @@ jobs:
 
       - name: Cypress run (shard ${{ matrix.shard }}/3)
         run: |
-          cd cypress-testing
+          cd project/glific
           yarn run cypress run  --config excludeSpecPattern=cypress/e2e/filesearch/Filesearch.spec.ts --record --key ${{ secrets.CYPRESS_DASHBOARD_KEY }}
         env:
           SPLIT: 3

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -198,6 +198,7 @@ jobs:
 
       - name: Cypress run (shard ${{ matrix.shard }}/3)
         run: |
+          cd cypress-testing
           yarn run cypress run  --config excludeSpecPattern=cypress/e2e/filesearch/Filesearch.spec.ts --record --key ${{ secrets.CYPRESS_DASHBOARD_KEY }}
         env:
           SPLIT: 3

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -177,8 +177,8 @@ jobs:
           cp -r cypress-testing/cypress ../cypress
           cp cypress-testing/cypress.config.ts.example ../cypress.config.ts
           cd cypress-testing
+          yarn
           cd ..
-          yarn add cypress@13.6.2
 
       - name: Run glific frontend
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -176,10 +176,8 @@ jobs:
           git clone https://github.com/glific/cypress-testing.git
           cp -r cypress-testing/cypress ../cypress
           cp cypress-testing/cypress.config.ts.example ../cypress.config.ts
-          cd cypress-testing
-          yarn
-          yarn add cypress@15.15.0
           cd ..
+          yarn add cypress@15.15.0
 
       - name: Run glific frontend
         run: |
@@ -199,8 +197,7 @@ jobs:
 
       - name: Cypress run (shard ${{ matrix.shard }}/3)
         run: |
-          cd project/glific
-          yarn run cypress run  --config excludeSpecPattern=cypress/e2e/filesearch/Filesearch.spec.ts --record --key ${{ secrets.CYPRESS_DASHBOARD_KEY }}
+          yarn run cypress run --config excludeSpecPattern=cypress/e2e/filesearch/Filesearch.spec.ts --record --key ${{ secrets.CYPRESS_DASHBOARD_KEY }}
         env:
           SPLIT: 3
           SPLIT_INDEX: ${{ matrix.shard }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -123,12 +123,9 @@ jobs:
           echo '127.0.0.1  api.glific.test' | sudo tee -a /etc/hosts
           mkdir -p project
           cd project
-          echo clone glific repo
           git clone https://github.com/glific/glific.git
-          echo done. go to dir.
           cd glific
 
-          echo done. start dev.secret.exs config
           cd priv
           mkdir cert
           cd cert
@@ -142,7 +139,6 @@ jobs:
           cp dev.secret.exs.txt dev.secret.exs
           cp .env.dev.txt .env.dev
           sed -i 's/:max_rate_limit_request, 60/:max_rate_limit_request, 300/g' config.exs
-          echo copy done. start setup
 
       - name: Cache Elixir deps and build
         uses: actions/cache@v4
@@ -197,7 +193,10 @@ jobs:
 
       - name: Cypress run (shard ${{ matrix.shard }}/3)
         run: |
-          yarn run cypress run --config excludeSpecPattern=cypress/e2e/filesearch/Filesearch.spec.ts --record --key ${{ secrets.CYPRESS_DASHBOARD_KEY }}
+          yarn run cypress run \
+            --config '{"excludeSpecPattern":["cypress/e2e/filesearch/Filesearch.spec.ts","cypress/e2e/smoke.spec.ts"]}' \
+            --record \
+            --key ${{ secrets.CYPRESS_DASHBOARD_KEY }}
         env:
           SPLIT: 3
           SPLIT_INDEX: ${{ matrix.shard }}


### PR DESCRIPTION
- https://github.com/glific/cypress-testing/pull/222 updated the cypress version which was not installed causing failures
- We now also exclude the smoke test from regular e2e tests