### PR TITLE
chore: setup posthog group tracking

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import 'i18n/config';
 import 'assets/fonts/fonts.css';
 import gqlClient from 'config/apolloclient';
 import { SideDrawerContext } from 'context/session';
+import { PosthogSession } from 'components/PosthogSession/PosthogSession';
 import ErrorHandler from 'containers/ErrorHandler/ErrorHandler';
 import { getAuthSession } from 'services/AuthService';
 import { UnauthenticatedRoute } from 'routes/UnauthenticatedRoute/UnauthenticatedRoute';
@@ -43,6 +44,7 @@ const App = () => {
 
   return (
     <ApolloProvider client={gqlClient(navigate)}>
+      <PosthogSession />
       <ErrorHandler />
       <SideDrawerContext.Provider value={sideDrawerValues}>{routes}</SideDrawerContext.Provider>
     </ApolloProvider>

--- a/src/components/PosthogSession/PosthogSession.test.tsx
+++ b/src/components/PosthogSession/PosthogSession.test.tsx
@@ -1,0 +1,48 @@
+import { render } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as AuthService from 'services/AuthService';
+import * as PostHogService from 'services/PostHogService';
+
+import { PosthogSession } from './PosthogSession';
+
+const { mockSetupFromStoredSession } = vi.hoisted(() => ({
+  mockSetupFromStoredSession: vi.fn(),
+}));
+
+vi.mock('@posthog/react', () => ({
+  usePostHog: () => ({ identify: vi.fn(), group: vi.fn() }),
+}));
+
+vi.mock('services/PostHogService', async (importOriginal) => {
+  const actual = await importOriginal<typeof PostHogService>();
+  return {
+    ...actual,
+    setupPostHogFromStoredSession: mockSetupFromStoredSession,
+  };
+});
+
+describe('PosthogSession', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not sync when user is not authenticated', () => {
+    vi.spyOn(AuthService, 'getAuthSession').mockReturnValue(null);
+
+    render(<PosthogSession />);
+
+    expect(mockSetupFromStoredSession).not.toHaveBeenCalled();
+  });
+
+  it('syncs PostHog groups when an auth token exists', () => {
+    vi.spyOn(AuthService, 'getAuthSession').mockReturnValue('token-abc');
+
+    render(<PosthogSession />);
+
+    expect(mockSetupFromStoredSession).toHaveBeenCalledTimes(1);
+    expect(mockSetupFromStoredSession).toHaveBeenCalledWith(
+      expect.objectContaining({ identify: expect.any(Function), group: expect.any(Function) })
+    );
+  });
+});

--- a/src/components/PosthogSession/PosthogSession.tsx
+++ b/src/components/PosthogSession/PosthogSession.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { usePostHog } from '@posthog/react';
+
+import { getAuthSession } from 'services/AuthService';
+import { setupPostHogFromStoredSession } from 'services/PostHogService';
+
+/**
+ * Associates returning authenticated sessions with the PostHog organization group.
+ * Login flow sets the group explicitly; this covers page reloads and direct navigation.
+ */
+export function PosthogSession() {
+  const posthog = usePostHog();
+
+  useEffect(() => {
+    if (!getAuthSession('access_token')) {
+      return;
+    }
+
+    setupPostHogFromStoredSession(posthog);
+  }, [posthog]);
+
+  return null;
+}

--- a/src/containers/Auth/Login/Login.test.tsx
+++ b/src/containers/Auth/Login/Login.test.tsx
@@ -16,8 +16,10 @@ import { Login } from './Login';
 
 const mocks = [getCurrentUserQuery, getOrganizationServicesQuery, getOrganizationStatus('ACTIVE')];
 
-const { mockPosthogCapture } = vi.hoisted(() => ({
+const { mockPosthogCapture, mockPosthogIdentify, mockPosthogGroup } = vi.hoisted(() => ({
   mockPosthogCapture: vi.fn(),
+  mockPosthogIdentify: vi.fn(),
+  mockPosthogGroup: vi.fn(),
 }));
 
 vi.mock('axios');
@@ -28,7 +30,8 @@ vi.mock('pino-logflare', () => ({
 vi.mock('@posthog/react', () => ({
   usePostHog: () => ({
     capture: mockPosthogCapture,
-    identify: vi.fn(),
+    identify: mockPosthogIdentify,
+    group: mockPosthogGroup,
   }),
 }));
 vi.mock('config/logs', () => ({
@@ -98,6 +101,19 @@ describe('<Login />', () => {
     await waitFor(() => {
       expect(mockedAxios.post).toHaveBeenCalledWith(USER_SESSION, expect.any(Object));
       expect(localStorageSpy).toHaveBeenCalled();
+    });
+  });
+
+  it('identifies user and organization group in PostHog on successful login', async () => {
+    mockAxiosPost('success');
+    const { container } = render(wrapper(mocks));
+
+    await userAction(container);
+
+    await waitFor(() => {
+      expect(mockPosthogIdentify).toHaveBeenCalledWith('1', { access_roles: ['Admin'] });
+      expect(mockPosthogGroup).toHaveBeenCalledWith('organization', '1');
+      expect(mockPosthogCapture).toHaveBeenCalledWith('user_logged_in');
     });
   });
 

--- a/src/containers/Auth/Login/Login.tsx
+++ b/src/containers/Auth/Login/Login.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router';
 import * as Yup from 'yup';
 
+import { usePostHog } from '@posthog/react';
 import { setErrorMessage } from 'common/notification';
 import { Input } from 'components/UI/Form/Input/Input';
 import { PhoneInput } from 'components/UI/Form/PhoneInput/PhoneInput';
@@ -13,14 +14,15 @@ import setLogs from 'config/logs';
 import { setUserRolePermissions } from 'context/role';
 import { GET_ORGANIZATION_SERVICES } from 'graphql/queries/Organization';
 import { GET_CURRENT_USER } from 'graphql/queries/User';
-import { usePostHog } from '@posthog/react';
 import {
   clearAuthSession,
   clearUserSession,
+  getAuthSession,
   setAuthSession,
   setOrganizationServices,
   setUserSession,
 } from 'services/AuthService';
+import { setupPostHogUserAndOrganization } from 'services/PostHogService';
 import { Auth } from '../Auth';
 
 const notApprovedMsg = 'Your account is not approved yet. Please contact your organization admin.';
@@ -83,7 +85,15 @@ export const Login = () => {
           i18n.changeLanguage(userData.currentUser.user?.language.locale);
         }
 
-        posthog?.identify(user.id, { organization_id: user.organization.id });
+        const isTrial = getAuthSession('is_trial');
+        setupPostHogUserAndOrganization(
+          posthog,
+          { id: user.id, accessRoleLabels: userAccessRoles },
+          {
+            id: user.organization.id,
+            isTrial: isTrial === null || isTrial === undefined ? undefined : Boolean(isTrial),
+          }
+        );
         posthog?.capture('user_logged_in');
 
         const targetPath = location.state?.to || '/chat';

--- a/src/services/PostHogService.test.ts
+++ b/src/services/PostHogService.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as AuthService from 'services/AuthService';
+import {
+  AccessRole,
+  POSTHOG_GROUP_TYPE_ORGANIZATION,
+  getAccessRoleLabels,
+  identifyPostHogOrganizationGroup,
+  identifyPostHogUser,
+  setupPostHogFromStoredSession,
+  setupPostHogUserAndOrganization,
+} from './PostHogService';
+
+const createPostHogMock = () => ({
+  identify: vi.fn(),
+  group: vi.fn(),
+});
+
+describe('PostHogService', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('getAccessRoleLabels', () => {
+    it('returns labels from access roles', () => {
+      expect(getAccessRoleLabels([{ label: 'Admin' }, { label: 'Manager' }] as AccessRole[])).toEqual([
+        'Admin',
+        'Manager',
+      ]);
+    });
+
+    it('filters out roles without a label', () => {
+      expect(getAccessRoleLabels([{ label: 'Admin' }, { label: undefined }, {}])).toEqual(['Admin']);
+    });
+
+    it('returns an empty array when roles are missing', () => {
+      expect(getAccessRoleLabels(null)).toEqual([]);
+    });
+  });
+
+  describe('identifyPostHogUser', () => {
+    it('does nothing when posthog client is missing', () => {
+      expect(() => identifyPostHogUser(undefined, { id: '1' })).not.toThrow();
+    });
+
+    it('identifies the user without properties when access roles are not provided', () => {
+      const posthog = createPostHogMock();
+
+      identifyPostHogUser(posthog, { id: 'user-1' });
+
+      expect(posthog.identify).toHaveBeenCalledWith('user-1');
+      expect(posthog.group).not.toHaveBeenCalled();
+    });
+
+    it('identifies the user with access_roles', () => {
+      const posthog = createPostHogMock();
+
+      identifyPostHogUser(posthog, { id: 'user-1', accessRoleLabels: ['Admin', 'Manager'] });
+
+      expect(posthog.identify).toHaveBeenCalledWith('user-1', { access_roles: ['Admin', 'Manager'] });
+    });
+  });
+
+  describe('identifyPostHogOrganizationGroup', () => {
+    it('does nothing when posthog client is missing', () => {
+      expect(() => identifyPostHogOrganizationGroup(null, { id: '1' })).not.toThrow();
+    });
+
+    it('does nothing when organization id is empty', () => {
+      const posthog = createPostHogMock();
+
+      identifyPostHogOrganizationGroup(posthog, { id: '' });
+
+      expect(posthog.group).not.toHaveBeenCalled();
+    });
+
+    it('calls posthog.group without properties when is_trial is not set', () => {
+      const posthog = createPostHogMock();
+
+      identifyPostHogOrganizationGroup(posthog, { id: 'org-42' });
+
+      expect(posthog.group).toHaveBeenCalledWith(POSTHOG_GROUP_TYPE_ORGANIZATION, 'org-42');
+    });
+
+    it('includes is_trial when provided', () => {
+      const posthog = createPostHogMock();
+
+      identifyPostHogOrganizationGroup(posthog, {
+        id: 'org-42',
+        isTrial: true,
+      });
+
+      expect(posthog.group).toHaveBeenCalledWith(POSTHOG_GROUP_TYPE_ORGANIZATION, 'org-42', {
+        is_trial: true,
+      });
+    });
+  });
+
+  describe('setupPostHogUserAndOrganization', () => {
+    it('identifies user and organization group', () => {
+      const posthog = createPostHogMock();
+
+      setupPostHogUserAndOrganization(posthog, { id: 'user-1', accessRoleLabels: ['Admin'] }, { id: 'org-1' });
+
+      expect(posthog.identify).toHaveBeenCalledWith('user-1', { access_roles: ['Admin'] });
+      expect(posthog.group).toHaveBeenCalledWith(POSTHOG_GROUP_TYPE_ORGANIZATION, 'org-1');
+    });
+  });
+
+  describe('setupPostHogFromStoredSession', () => {
+    it('does nothing when user session is incomplete', () => {
+      const posthog = createPostHogMock();
+      vi.spyOn(AuthService, 'getUserSession').mockReturnValue(null);
+
+      setupPostHogFromStoredSession(posthog);
+
+      expect(posthog.identify).not.toHaveBeenCalled();
+      expect(posthog.group).not.toHaveBeenCalled();
+    });
+
+    it('syncs identify and group from stored session', () => {
+      const posthog = createPostHogMock();
+      vi.spyOn(AuthService, 'getUserSession').mockImplementation((key?: string) => {
+        if (key === 'id') {
+          return '7';
+        }
+        if (key === 'organizationId') {
+          return '3';
+        }
+        if (key === 'roles') {
+          return [{ label: 'Staff' }];
+        }
+        return null;
+      });
+      vi.spyOn(AuthService, 'getAuthSession').mockReturnValue(false);
+
+      setupPostHogFromStoredSession(posthog);
+
+      expect(posthog.identify).toHaveBeenCalledWith('7', { access_roles: ['Staff'] });
+      expect(posthog.group).toHaveBeenCalledWith(POSTHOG_GROUP_TYPE_ORGANIZATION, '3', {
+        is_trial: false,
+      });
+    });
+
+    it('omits is_trial when trial status is not in auth session', () => {
+      const posthog = createPostHogMock();
+      vi.spyOn(AuthService, 'getUserSession').mockImplementation((key?: string) => {
+        if (key === 'id') {
+          return '7';
+        }
+        if (key === 'organizationId') {
+          return '3';
+        }
+        return null;
+      });
+      vi.spyOn(AuthService, 'getAuthSession').mockReturnValue(null);
+
+      setupPostHogFromStoredSession(posthog);
+
+      expect(posthog.identify).toHaveBeenCalledWith('7');
+      expect(posthog.group).toHaveBeenCalledWith(POSTHOG_GROUP_TYPE_ORGANIZATION, '3');
+    });
+  });
+});

--- a/src/services/PostHogService.ts
+++ b/src/services/PostHogService.ts
@@ -1,0 +1,99 @@
+import { getAuthSession, getUserSession } from 'services/AuthService';
+
+/** PostHog group type for Glific organizations (singular per PostHog group analytics docs). */
+export const POSTHOG_GROUP_TYPE_ORGANIZATION = 'organization';
+
+export interface PostHogOrganizationGroup {
+  id: string;
+  isTrial?: boolean;
+}
+
+export interface PostHogUserIdentity {
+  id: string;
+  accessRoleLabels?: string[];
+}
+
+export type AccessRole = { label?: string };
+
+export function getAccessRoleLabels(roles: AccessRole[] | null | undefined): string[] {
+  if (!roles?.length) {
+    return [];
+  }
+
+  return roles.map((role) => role.label).filter((label): label is string => Boolean(label));
+}
+
+export type PostHogAnalyticsClient =
+  | {
+      identify: (distinctId: string, properties?: Record<string, unknown>) => void;
+      group: (groupType: string, groupKey: string, groupProperties?: Record<string, unknown>) => void;
+    }
+  | null
+  | undefined;
+
+export function identifyPostHogUser(posthog: PostHogAnalyticsClient, user: PostHogUserIdentity): void {
+  if (!posthog) {
+    return;
+  }
+
+  const properties: Record<string, string[]> = {};
+
+  if (user.accessRoleLabels?.length) {
+    properties.access_roles = user.accessRoleLabels;
+  }
+
+  if (Object.keys(properties).length) {
+    posthog.identify(user.id, properties);
+    return;
+  }
+
+  posthog.identify(user.id);
+}
+
+export function identifyPostHogOrganizationGroup(
+  posthog: PostHogAnalyticsClient,
+  organization: PostHogOrganizationGroup
+): void {
+  if (!posthog || !organization.id) {
+    return;
+  }
+
+  if (organization.isTrial === undefined) {
+    posthog.group(POSTHOG_GROUP_TYPE_ORGANIZATION, organization.id);
+    return;
+  }
+
+  posthog.group(POSTHOG_GROUP_TYPE_ORGANIZATION, organization.id, {
+    is_trial: organization.isTrial,
+  });
+}
+
+export function setupPostHogUserAndOrganization(
+  posthog: PostHogAnalyticsClient,
+  user: PostHogUserIdentity,
+  organization: PostHogOrganizationGroup
+): void {
+  identifyPostHogUser(posthog, user);
+  identifyPostHogOrganizationGroup(posthog, organization);
+}
+
+export function setupPostHogFromStoredSession(posthog: PostHogAnalyticsClient): void {
+  const userId = getUserSession('id');
+  const organizationId = getUserSession('organizationId');
+
+  if (!userId || !organizationId) {
+    return;
+  }
+
+  const isTrial = getAuthSession('is_trial');
+
+  const accessRoleLabels = getAccessRoleLabels(getUserSession('roles') as AccessRole[] | null);
+
+  const userParams = { id: String(userId), accessRoleLabels };
+  const orgParams = {
+    id: String(organizationId),
+    isTrial: isTrial === null || isTrial === undefined ? undefined : Boolean(isTrial),
+  };
+
+  setupPostHogUserAndOrganization(posthog, userParams, orgParams);
+}


### PR DESCRIPTION
Setup user organisation tracking in posthog to enable group analytics - https://posthog.com/docs/product-analytics/group-analytics

Verified in staging - https://us.posthog.com/project/440800/groups/0?select_0=%5B%22group_name%22%2C%22created_at%22%2C%22properties.is_trial%22%5D%20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced analytics tracking to capture user roles and organization trial status for improved insights into user engagement.

* **Tests**
  * Added comprehensive test coverage for analytics functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/glific/glific-frontend/pull/3963?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->