### PR TITLE
feat: add CSV download functionality with sorted rows by question_id

### DIFF
--- a/src/containers/AIEvals/AIEvaluationList/AIEvaluationList.test.tsx
+++ b/src/containers/AIEvals/AIEvaluationList/AIEvaluationList.test.tsx
@@ -10,6 +10,7 @@ import {
   getEvaluationScoresFlatArrayMock,
   getEvaluationScoresInvalidJsonMock,
   getEvaluationScoresInvalidRowsMock,
+  getEvaluationScoresOutOfOrderMock,
   getEvaluationScoresMock,
   getEvaluationScoresNetworkErrorMock,
   getEvaluationScoresNullMock,
@@ -342,6 +343,38 @@ describe('AIEvaluationList', () => {
       expect(screen.getByText('test_dataset | 2')).toBeInTheDocument();
       expect(screen.getByText('healthcare_dataset | 3')).toBeInTheDocument();
     });
+  });
+
+  it('downloaded CSV rows are sorted by question_id', async () => {
+    let capturedBlob: Blob | null = null;
+    vi.spyOn(URL, 'createObjectURL').mockImplementation((obj: Blob | MediaSource) => {
+      capturedBlob = obj as Blob;
+      return 'blob:mock-url';
+    });
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
+
+    renderComponent([getListAiEvaluationsWithItemsMock, getEvaluationScoresOutOfOrderMock('2')]);
+    await waitFor(() => expect(screen.getAllByText('Download Results')).toHaveLength(2));
+
+    fireEvent.click(screen.getAllByTestId('additionalButton')[1]);
+
+    await waitFor(() => expect(capturedBlob).not.toBeNull());
+
+    const csvText = await new Promise<string>((resolve) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.readAsText(capturedBlob!);
+    });
+
+    const [headerRow, ...dataRows] = csvText.split('\n');
+    const headers = headerRow.split(',');
+    const questionIdIndex = headers.indexOf('question_id');
+
+    const questionIds = dataRows.map((row) => Number(row.split(',')[questionIdIndex]));
+    expect(questionIds).toEqual([1, 2, 3]);
+
+    vi.restoreAllMocks();
   });
 
   it('does not render sub-info lines when all display fields are null', async () => {

--- a/src/containers/AIEvals/AIEvaluationList/AIEvaluationList.tsx
+++ b/src/containers/AIEvals/AIEvaluationList/AIEvaluationList.tsx
@@ -259,7 +259,12 @@ export const AIEvaluationList = ({ searchQuery }: AIEvaluationListProps) => {
         return;
       }
 
-      const scores = extractRows(parsed);
+      const scores = extractRows(parsed).sort((a, b) => {
+        const aNum = Number(a.question_id);
+        const bNum = Number(b.question_id);
+        if (!isNaN(aNum) && !isNaN(bNum)) return aNum - bNum;
+        return String(a.question_id ?? '').localeCompare(String(b.question_id ?? ''));
+      });
 
       if (!scores.length) {
         setNotification('No scores available to download', 'warning');

--- a/src/mocks/AIEvaluations.ts
+++ b/src/mocks/AIEvaluations.ts
@@ -573,6 +573,26 @@ export const getEvaluationScoresInvalidJsonMock = (id = '2') => ({
   },
 });
 
+export const getEvaluationScoresOutOfOrderMock = (id = '2') => ({
+  request: { query: GET_EVALUATION_SCORES, variables: { id } },
+  result: {
+    data: {
+      evaluationScores: {
+        scores: JSON.stringify({
+          score: {
+            traces: [
+              { question_id: 3, question: 'Q3', ground_truth_answer: 'A3', llm_answer: 'L3', scores: [] },
+              { question_id: 1, question: 'Q1', ground_truth_answer: 'A1', llm_answer: 'L1', scores: [] },
+              { question_id: 2, question: 'Q2', ground_truth_answer: 'A2', llm_answer: 'L2', scores: [] },
+            ],
+          },
+        }),
+        errors: [],
+      },
+    },
+  },
+});
+
 // traces are arrays (truthy, pass filter(Boolean)) but flattenRow returns null for them → jsonToCsv returns ''
 export const getEvaluationScoresInvalidRowsMock = (id = '2') => ({
   request: { query: GET_EVALUATION_SCORES, variables: { id } },


### PR DESCRIPTION

## Summary
1 - Get Evaluation API response ordering
     
The response returned by our Get Evaluation API is currently passed through directly from Kaapi.
The data is not guaranteed to be sorted by question ID, and in some evaluations the questions are appearing out of order.

## Summary by CodeRabbit

* **Bug Fixes**
  * Downloaded CSV files from AI evaluations are now properly sorted by question ID in ascending order, improving data organization and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->