### PR TITLE
fix: load vite-plugin-mkcert lazily so production builds don't require it

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,7 @@
 /// <reference types="vitest" />
 /// <reference types="vite-plugin-svgr/client" />
 import react from '@vitejs/plugin-react';
-import { ConfigEnv, UserConfigExport, defineConfig, loadEnv } from 'vite';
+import { ConfigEnv, PluginOption, UserConfigExport, defineConfig, loadEnv } from 'vite';
 // import eslint from 'vite-plugin-eslint';
 import checker from 'vite-plugin-checker';
 import svgr from 'vite-plugin-svgr';
@@ -16,7 +16,7 @@ export default async ({ command, mode }: ConfigEnv): Promise<UserConfigExport> =
   const isBuild = command === 'build';
   const enableSentry = isBuild && !!env.VITE_SENTRY_AUTH_TOKEN;
 
-  const plugins = [
+  const plugins: PluginOption[] = [
     react(),
     viteTsconfigPaths(),
     svgr(),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,14 +4,13 @@ import react from '@vitejs/plugin-react';
 import { ConfigEnv, UserConfigExport, defineConfig, loadEnv } from 'vite';
 // import eslint from 'vite-plugin-eslint';
 import checker from 'vite-plugin-checker';
-import mkcert from 'vite-plugin-mkcert';
 import svgr from 'vite-plugin-svgr';
 import viteTsconfigPaths from 'vite-tsconfig-paths';
 
 import { sentryVitePlugin } from '@sentry/vite-plugin';
 
 // https://vitejs.dev/config/
-export default ({ command, mode }: ConfigEnv): UserConfigExport => {
+export default async ({ command, mode }: ConfigEnv): Promise<UserConfigExport> => {
   const env = loadEnv(mode, process.cwd(), '');
 
   const isBuild = command === 'build';
@@ -54,6 +53,9 @@ export default ({ command, mode }: ConfigEnv): UserConfigExport => {
 
   // dev specific config
   if (command === 'serve') {
+    // mkcert is a devDependency used only for the local HTTPS dev server; import it
+    // lazily so production builds (which don't install devDependencies) never resolve it.
+    const { default: mkcert } = await import('vite-plugin-mkcert');
     return defineConfig({
       plugins: plugins.concat([checker({ typescript: true }), mkcert({ hosts: ['glific.test'] })]),
       // dev specific config


### PR DESCRIPTION
 vite-plugin-mkcert is a devDependency used only by the local HTTPS dev
  server, but it was imported statically at the top of vite.config.ts.
  Static imports are resolved whenever the config loads, so production
  builds — where devDependencies aren't installed — crashed with
  ERR_MODULE_NOT_FOUND before any branch ran. Import it lazily inside the
  serve branch instead.