### PR TITLE
feat: add multi-phone failover notifications and enhance entity display in NotificationList

### DIFF
--- a/src/containers/NotificationList/NotificationList.test.tsx
+++ b/src/containers/NotificationList/NotificationList.test.tsx
@@ -171,3 +171,35 @@ test('it should show "Contact import is in progress" message', async () => {
     });
   });
 });
+
+test('it should surface multi-phone failover notifications and link to the group', async () => {
+  render(notifications(getStatus));
+
+  // Phase 4 warning failover notification renders with its message body
+  await waitFor(() => {
+    expect(
+      screen.getByText(
+        'Primary phone 919999999999 for group Maytapi Test Group is unavailable; switched to phone 918888888888.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  // Phase 4 critical "no active phones" notification renders
+  expect(screen.getByText('No active managed phones available for group Maytapi Test Group.')).toBeInTheDocument();
+
+  // both surface under the "WA Group" category and show both severities
+  expect(screen.getAllByText('WA Group').length).toBeGreaterThanOrEqual(2);
+  expect(screen.getAllByText('Warning').length).toBeGreaterThanOrEqual(1);
+  expect(screen.getAllByText('Critical').length).toBeGreaterThanOrEqual(1);
+
+  // the group label (entity.label) is surfaced in the Entity column
+  expect(screen.getAllByText(/Maytapi Test Group/).length).toBeGreaterThanOrEqual(1);
+
+  // clicking the row action routes to the group's chat page (/group/chat/:groupId)
+  const arrowButtons = screen.getAllByTestId('ArrowForwardIcon');
+  arrowButtons.forEach((button) => fireEvent.click(button));
+
+  await waitFor(() => {
+    expect(window.open).toHaveBeenCalledWith('/group/chat/4', '_blank', 'noopener,noreferrer');
+  });
+});

--- a/src/containers/NotificationList/NotificationList.tsx
+++ b/src/containers/NotificationList/NotificationList.tsx
@@ -141,6 +141,9 @@ export const NotificationList = () => {
     }
 
     const entityObj = JSON.parse(croppedtext);
+    // WA Group (failover) notifications carry the group name as `label`; other
+    // categories use `name`. Fall back so the entity column stays readable.
+    const displayName = entityObj.name || entityObj.label;
 
     const Menus = [
       {
@@ -163,9 +166,9 @@ export const NotificationList = () => {
     return (
       <Menu menus={Menus}>
         <div className={styles.CroppedText} data-testid="NotificationRowMenu" ref={menuRef} aria-hidden="true">
-          {entityObj.name ? (
+          {displayName ? (
             <span>
-              Name: {entityObj.name}
+              Name: {displayName}
               <br />
               {croppedtext.slice(0, 25)}...
             </span>

--- a/src/mocks/Notifications.tsx
+++ b/src/mocks/Notifications.tsx
@@ -62,12 +62,22 @@ export const getNotificationsQuery = {
         },
         {
           category: 'WA Group',
-          entity: '{"id":4,"body":"hi"}',
+          entity: '{"id":4,"label":"Maytapi Test Group"}',
           id: '6',
           isRead: true,
-          message: 'Error sending message: You dont own the phone[3446].',
-          severity: '"Critical"',
+          message:
+            'Primary phone 919999999999 for group Maytapi Test Group is unavailable; switched to phone 918888888888.',
+          severity: '"Warning"',
           updatedAt: '2024-03-29T11:14:13Z',
+        },
+        {
+          category: 'WA Group',
+          entity: '{"id":4,"label":"Maytapi Test Group"}',
+          id: '10',
+          isRead: true,
+          message: 'No active managed phones available for group Maytapi Test Group.',
+          severity: '"Critical"',
+          updatedAt: '2024-03-29T11:15:13Z',
         },
         {
           category: 'Contact Upload',


### PR DESCRIPTION
target issue is #3940 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readability for WA Group failover notifications by properly displaying label information when unavailable.

* **Tests**
  * Added test coverage for multi-phone failover notification behavior, including validation of row actions and notification rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->