### PR TITLE
fix: Hide Phones section in GroupDetails component

### DIFF
--- a/src/containers/WaGroups/GroupDetails.tsx/GroupDetails.tsx
+++ b/src/containers/WaGroups/GroupDetails.tsx/GroupDetails.tsx
@@ -14,7 +14,7 @@ import { List } from 'containers/List/List';
 import { ContactDescription } from 'containers/Profile/Contact/ContactDescription/ContactDescription';
 import { UPDATE_GROUP_CONTACT } from 'graphql/mutations/Group';
 import { COUNT_COUNTACTS_WA_GROUPS, GET_WA_GROUP, LIST_CONTACTS_WA_GROUPS } from 'graphql/queries/WaGroups';
-import { PhonesPanel } from './PhonesPanel/PhonesPanel';
+// import { PhonesPanel } from './PhonesPanel/PhonesPanel';
 import styles from './GroupDetails.module.css';
 
 export const GroupDetails = () => {
@@ -188,8 +188,8 @@ export const GroupDetails = () => {
         customStyles={styles.Table}
       />
     );
-  // } else if (contentToShow === 'phones') {
-  //   contentBody = <PhonesPanel phones={groupData?.phones || []} waGroupId={params.id!} />;
+    // } else if (contentToShow === 'phones') {
+    //   contentBody = <PhonesPanel phones={groupData?.phones || []} waGroupId={params.id!} />;
   } else {
     contentBody = (
       <ContactDescription

--- a/src/containers/WaGroups/GroupDetails.tsx/GroupDetails.tsx
+++ b/src/containers/WaGroups/GroupDetails.tsx/GroupDetails.tsx
@@ -35,10 +35,10 @@ export const GroupDetails = () => {
       name: t('Members'),
       section: 'members',
     },
-    {
-      name: t('Phones'),
-      section: 'phones',
-    },
+    // {
+    //   name: t('Phones'),
+    //   section: 'phones',
+    // },
     {
       name: t('Details'),
       section: 'details',
@@ -188,8 +188,8 @@ export const GroupDetails = () => {
         customStyles={styles.Table}
       />
     );
-  } else if (contentToShow === 'phones') {
-    contentBody = <PhonesPanel phones={groupData?.phones || []} waGroupId={params.id!} />;
+  // } else if (contentToShow === 'phones') {
+  //   contentBody = <PhonesPanel phones={groupData?.phones || []} waGroupId={params.id!} />;
   } else {
     contentBody = (
       <ContactDescription


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/glific/glific-frontend) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Please ensure coding standard and conventions are followed. You can find the details at https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing

-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * The Phones tab has been disabled in the Group Details view; users will now see only the Members and Details sections. Other interactions (including delete dialog and remaining data queries) continue to operate as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->