### PR TITLE
fix: Move tags from quick tools to manage section

### DIFF
--- a/src/config/menu.ts
+++ b/src/config/menu.ts
@@ -163,13 +163,6 @@ const menus = (): Menu[] => [
         type: 'sideDrawer',
         roles: managerLevel,
       },
-      {
-        title: 'Tags',
-        path: '/tag',
-        icon: 'tag',
-        type: 'sideDrawer',
-        roles: managerLevel,
-      },
     ],
   },
   {
@@ -255,6 +248,13 @@ const menus = (): Menu[] => [
         title: 'Contact variables',
         path: '/contact-fields',
         icon: 'fields',
+        type: 'sideDrawer',
+        roles: managerLevel,
+      },
+      {
+        title: 'Tags',
+        path: '/tag',
+        icon: 'tag',
         type: 'sideDrawer',
         roles: managerLevel,
       },


### PR DESCRIPTION
## Summary

Fixes #3457
Moves the Tags menu item from the "Quick Tools" section to the "Manage" section in the sidebar navigation.

This aligns with how tags are primarily created/managed while working with Flows, HSM Templates, and Interactive Messages, and reduces clutter under Quick Tools.



### Test Plan
* Verified Tags no longer appears under Quick Tools in the sidebar
* Verified Tags now appears under Manage section (after Contact Variables)
* No other menu items affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized menu navigation by relocating the Tags menu entry from Quick tools to the Manage submenu for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->