### PR TITLE
chore: add Playwright setup + prompt-generator E2E

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,9 @@ cypress/videos
 
 # Claude worktrees
 .claude/worktrees/
+
+# Playwright
+/test-results/
+/playwright-report/
+/playwright/.cache/
+/e2e/.auth/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,34 @@
+# E2E tests (Playwright)
+
+End-to-end tests that drive the real built UI in a headless browser.
+
+These specs are **self-contained**: they seed a fake-but-valid session + the
+relevant service flags into `localStorage` (auth is decided client-side from
+`token_expiry_time`) and mock the GraphQL/REST network at the Playwright layer,
+so they run **offline** — no backend or Kaapi required. Only the SPA dev server
+needs to be running.
+
+## Run
+
+```bash
+# 1. start the dev server (serves the SPA; backend not required)
+yarn dev
+
+# 2. in another terminal, run the e2e suite
+yarn test:e2e            # headless
+yarn test:e2e:ui         # interactive UI mode
+```
+
+If the dev server isn't on the default `https://glific.test:3000`, point the
+tests at it:
+
+```bash
+PLAYWRIGHT_BASE_URL=https://glific.test:3001 yarn test:e2e
+```
+
+## Notes
+
+- First-time setup also needs the browser binary: `npx playwright install chromium`.
+- To test against a **real** backend/Kaapi instead of mocks, remove the
+  `page.route(...)` network mocks in the spec and provide a real authenticated
+  `storageState` (log in once and save it) instead of the seeded session.

--- a/e2e/prompt-generator.spec.ts
+++ b/e2e/prompt-generator.spec.ts
@@ -14,7 +14,7 @@ const GENERATED_PROMPT = 'You are MatsyaMitra, a friendly assistant for small-sc
 // the 9 mandatory answers, keyed by each question's unique placeholder so we target
 // the modal's fields (not the create-assistant form behind it)
 const ANSWERS: Array<[string, string]> = [
-  ['Organisation name and chatbot name...', 'MatsyaMitra by BlueWater Aqua'],
+  ['Organization name and chatbot name...', 'MatsyaMitra by BlueWater Aqua'],
   ['Describe the core purpose...', 'Helps fish farmers with pond and water-quality questions'],
   ['Describe your audience...', 'Small freshwater fish farmers in rural India, low literacy'],
   ['Language preference...', 'Reply in the language the user writes in'],

--- a/e2e/prompt-generator.spec.ts
+++ b/e2e/prompt-generator.spec.ts
@@ -1,0 +1,165 @@
+import { test, expect, Page } from '@playwright/test';
+
+/**
+ * E2E for the AI Prompt Generator.
+ *
+ * Self-contained: it seeds a fake-but-valid session + the promptGeneratorEnabled
+ * service flag into localStorage (auth is decided client-side from token_expiry_time),
+ * and mocks the GraphQL network so generation is deterministic and offline — no
+ * backend or Kaapi required. Only a running dev server (the SPA) is needed.
+ */
+
+const GENERATED_PROMPT = 'You are MatsyaMitra, a friendly assistant for small-scale fish farmers...';
+
+// the 9 mandatory answers, keyed by each question's unique placeholder so we target
+// the modal's fields (not the create-assistant form behind it)
+const ANSWERS: Array<[string, string]> = [
+  ['Organisation name and chatbot name...', 'MatsyaMitra by BlueWater Aqua'],
+  ['Describe the core purpose...', 'Helps fish farmers with pond and water-quality questions'],
+  ['Describe your audience...', 'Small freshwater fish farmers in rural India, low literacy'],
+  ['Language preference...', 'Reply in the language the user writes in'],
+  ['Describe the tone...', 'Friendly and practical, like a fellow farmer'],
+  ['Describe the response format...', 'Short messages, numbered steps for how-tos'],
+  ['List off-limits topics, or NA...', 'No veterinary dosages or financial advice'],
+  ['Exact fallback message...', 'Sorry, please call our helpline 1800-555-0199'],
+  ['Escalation path, or NA...', 'Reply AGENT to reach a fisheries expert'],
+];
+
+const seedAuthAndFlag = async (page: Page) => {
+  await page.addInitScript(() => {
+    const farFuture = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+    localStorage.setItem(
+      'glific_session',
+      JSON.stringify({ access_token: 'e2e-token', renewal_token: 'e2e-renewal', token_expiry_time: farFuture })
+    );
+    localStorage.setItem(
+      'glific_user',
+      JSON.stringify({
+        id: '1',
+        name: 'E2E User',
+        roles: ['Admin'],
+        organization: { id: '1' },
+        language: { locale: 'en' },
+      })
+    );
+    localStorage.setItem('organizationServices', JSON.stringify({ promptGeneratorEnabled: true }));
+  });
+};
+
+const mockNetwork = async (page: Page) => {
+  // REST (session renewal / tracker etc.) — return 200 so bootstrap doesn't block
+  await page.route(
+    (url) => url.pathname.startsWith('/api/v1'),
+    (route) => route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+  );
+
+  // GraphQL — respond by operation name; generation is mocked to resolve to :ready
+  await page.route(
+    (url) => url.pathname === '/api',
+    (route) => {
+      const body = route.request().postDataJSON();
+      const op = body?.operationName;
+      const data = (payload: unknown) =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ data: payload }) });
+
+      switch (op) {
+        // --- bootstrap: the authenticated layout needs a current user + languages ---
+        case 'currentUser':
+          return data({
+            currentUser: {
+              user: {
+                id: '1',
+                name: 'E2E User',
+                phone: '911111111111',
+                email: 'e2e@test.in',
+                accessRoles: [{ id: '1', label: 'Admin' }],
+                contact: { id: '1', name: 'E2E User', phone: '911111111111' },
+                groups: [],
+                organization: { id: '1', contact: { phone: '911111111111' } },
+                language: { id: '1', locale: 'en' },
+              },
+            },
+          });
+        case 'currentUserOrganisationLanguages':
+          return data({
+            currentUser: {
+              user: {
+                organization: {
+                  activeLanguages: [{ id: '1', label: 'English', localized: true, locale: 'en' }],
+                  defaultLanguage: { id: '1', label: 'English' },
+                },
+              },
+            },
+          });
+        case 'Assistants':
+          return data({ assistants: [] });
+        case 'CountAssistants':
+          return data({ countAssistants: 0 });
+        case 'GeneratePrompt':
+          return data({
+            generatePrompt: {
+              promptGeneration: { id: '1', status: 'in_progress', generatedPrompt: null, errorMessage: null },
+              errors: null,
+            },
+          });
+        case 'PromptGeneration':
+          return data({
+            promptGeneration: {
+              promptGeneration: { id: '1', status: 'ready', generatedPrompt: GENERATED_PROMPT, errorMessage: null },
+              errors: null,
+            },
+          });
+        default:
+          // permissive fallback for layout/bootstrap queries we don't care about
+          return data({});
+      }
+    }
+  );
+};
+
+test.beforeEach(async ({ page }) => {
+  await seedAuthAndFlag(page);
+  await mockNetwork(page);
+});
+
+test('generates a prompt and applies it to the assistant instructions', async ({ page }) => {
+  await page.goto('/assistants');
+
+  // open the create-assistant form where the prompt generator entry point lives
+  await page.getByTestId('headingButton').click();
+  await expect(page.getByTestId('generateWithAiButton')).toBeVisible();
+
+  // open the generator
+  await page.getByTestId('generateWithAiButton').click();
+  await expect(page.getByTestId('betaBanner')).toBeVisible();
+
+  // all 9 are mandatory — fill each by its unique placeholder
+  for (const [placeholder, value] of ANSWERS) {
+    await page.getByPlaceholder(placeholder).fill(value);
+  }
+  await expect(page.getByTestId('answeredCount')).toHaveText(/9\/9 answered/);
+
+  // generate → poll → editable preview
+  await page.getByTestId('generatePromptButton').click();
+  await expect(page.getByTestId('reviewNotice')).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByTestId('generatedPromptInput')).toHaveValue(GENERATED_PROMPT);
+
+  // apply to the Instructions field
+  await page.getByTestId('usePromptButton').click();
+  await expect(page.getByTestId('betaBanner')).toBeHidden();
+  await expect(page.getByText('Prompt added to Instructions')).toBeVisible();
+});
+
+test('blocks generation and flags gaps when answers are missing', async ({ page }) => {
+  await page.goto('/assistants');
+  await page.getByTestId('headingButton').click();
+  await page.getByTestId('generateWithAiButton').click();
+  await expect(page.getByTestId('betaBanner')).toBeVisible();
+
+  await expect(page.getByTestId('answeredCount')).toHaveText(/0\/9 answered/);
+
+  // clicking with everything blank must not start generating
+  await page.getByTestId('generatePromptButton').click();
+  await expect(page.getByTestId('generatingState')).toHaveCount(0);
+  await expect(page.getByTestId('betaBanner')).toBeVisible();
+});

--- a/package.json
+++ b/package.json
@@ -83,7 +83,9 @@
     "extract-translations": "i18next",
     "test": "vitest watch",
     "test:no-watch": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "engines": {
     "node": ">=22.12.0 <23"
@@ -104,6 +106,7 @@
     ]
   },
   "devDependencies": {
+    "@playwright/test": "1.61.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Playwright E2E config.
+ *
+ * The tests drive the real built UI but mock the GraphQL/REST network at the
+ * Playwright layer, so they run offline without a backend or Kaapi. Point
+ * PLAYWRIGHT_BASE_URL at a running dev server (default: the local vite host).
+ *
+ * Run:  yarn dev   (in one terminal)
+ *       yarn test:e2e
+ */
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: '**/*.spec.ts',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || 'https://glific.test:3000',
+    // local dev server uses a mkcert self-signed cert
+    ignoreHTTPSErrors: true,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1572,6 +1572,13 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.2.9.tgz#d229a7b7f9dac167a156992ef23c7f023653f53b"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
+"@playwright/test@1.61.0":
+  version "1.61.0"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.61.0.tgz#dcc3d43e581aab2985d70413309d89350e980ad8"
+  integrity sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==
+  dependencies:
+    playwright "1.61.0"
+
 "@polka/url@^1.0.0-next.24":
   version "1.0.0-next.29"
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.29.tgz#5a40109a1ab5f84d6fd8fc928b19f367cbe7e7b1"
@@ -4598,6 +4605,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -6649,6 +6661,20 @@ player.style@^0.3.0:
   dependencies:
     media-chrome "~4.16.1"
 
+playwright-core@1.61.0:
+  version "1.61.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.61.0.tgz#caf8078b2a39cd7738dc75ec11cb3b47f385c3f0"
+  integrity sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==
+
+playwright@1.61.0:
+  version "1.61.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.61.0.tgz#7082df3df08ffa82b11420ea5fae84a40bd16e3f"
+  integrity sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==
+  dependencies:
+    playwright-core "1.61.0"
+  optionalDependencies:
+    fsevents "2.3.2"
+
 pluralize@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
@@ -7693,16 +7719,7 @@ streamx@^2.12.0, streamx@^2.12.5, streamx@^2.13.2, streamx@^2.14.0:
     fast-fifo "^1.3.2"
     text-decoder "^1.1.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -7819,14 +7836,7 @@ stringify-object@^3.2.1:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
Scaffolds Playwright (config, scripts, gitignore) and adds a self-contained E2E for the AI Prompt Generator.

https://www.browserstack.com/guide/playwright-vs-cypress

## What
- `@playwright/test` + `playwright.config.ts` + `yarn test:e2e` / `test:e2e:ui` scripts.
- `e2e/prompt-generator.spec.ts` — drives the real UI but seeds a valid session + the `promptGeneratorEnabled` flag into localStorage (auth is client-side) and mocks the GraphQL/REST network, so it runs **offline** against just the SPA dev server (no backend or Kaapi needed).
- `e2e/README.md` with run instructions.

## Coverage
1. Happy path: create form → Generate with AI → fill 9 fields → generate → poll → preview → apply to Instructions.
2. Validation path: clicking Generate with gaps shows `0/9 answered` and does not start generating.

## Run
```bash
yarn dev            # terminal 1 (SPA only)
yarn test:e2e:ui    # terminal 2 (or test:e2e headless)
```

Based on the M4 branch since the e2e exercises the prompt-generator feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)