### PR TITLE
feat: add Generate with AI to the new (config-versions) assistant UI

### DIFF
--- a/src/containers/Assistants/AssistantDetail/ConfigEditor.module.css
+++ b/src/containers/Assistants/AssistantDetail/ConfigEditor.module.css
@@ -93,6 +93,32 @@
   flex-direction: column;
 }
 
+.LabelRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.GenerateWithAiButton {
+  text-transform: none;
+  font-size: 13px;
+  white-space: nowrap;
+  margin-right: 0.25rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.BetaBadge {
+  margin-left: 0.35rem;
+  font-size: 9px;
+  font-weight: 600;
+  line-height: 1;
+  padding: 2px 4px;
+  border-radius: 4px;
+  background-color: #119656;
+  color: #fff;
+}
+
 .Label {
   color: #555;
   font-size: 0.875rem;

--- a/src/containers/Assistants/AssistantDetail/ConfigEditor.module.css
+++ b/src/containers/Assistants/AssistantDetail/ConfigEditor.module.css
@@ -98,6 +98,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
 .GenerateWithAiButton {
@@ -105,7 +106,12 @@
   font-size: 13px;
   white-space: nowrap;
   margin-right: 0.25rem;
-  padding: 0.25rem 0.5rem;
+  padding: 0.25rem 0.75rem;
+  /* the shared Button base adds a drop shadow + white fill + 27px pill radius; drop
+     them so this reads as a clean rounded-rectangle button like "Manage Files" */
+  box-shadow: none !important;
+  background-color: transparent;
+  border-radius: 6px;
 }
 
 .BetaBadge {

--- a/src/containers/Assistants/AssistantDetail/ConfigEditor.test.tsx
+++ b/src/containers/Assistants/AssistantDetail/ConfigEditor.test.tsx
@@ -14,6 +14,24 @@ import {
 
 import { ConfigEditor } from './ConfigEditor';
 
+// Stub the prompt generator modal so the apply-flow is exercised without its real
+// polling timers (which are slow and can leak across test files in CI).
+const MOCK_GENERATED_PROMPT = 'Generated prompt from modal';
+vi.mock('../CreateAssistant/PromptGeneratorModal', () => ({
+  initialPromptAnswers: {},
+  PromptGeneratorModal: ({ open, onApply, onClose }: any) =>
+    open ? (
+      <div data-testid="promptGeneratorModal">
+        <button type="button" data-testid="mockApplyPrompt" onClick={() => onApply(MOCK_GENERATED_PROMPT)}>
+          apply
+        </button>
+        <button type="button" data-testid="mockClosePrompt" onClick={onClose}>
+          close
+        </button>
+      </div>
+    ) : null,
+}));
+
 const notificationSpy = vi.spyOn(Notification, 'setNotification');
 
 const mockVersion = mockVersions[0];
@@ -367,6 +385,31 @@ describe('ConfigEditor — Generate with AI button (prompt generator)', () => {
     localStorage.setItem('organizationServices', JSON.stringify({ promptGeneratorEnabled: true }));
     renderCreate();
     fireEvent.click(screen.getByTestId('generateWithAiButton'));
-    expect(screen.getByTestId('betaBanner')).toBeInTheDocument();
+    expect(screen.getByTestId('promptGeneratorModal')).toBeInTheDocument();
+  });
+
+  it('applies a generated prompt into the instructions field', async () => {
+    localStorage.setItem('organizationServices', JSON.stringify({ promptGeneratorEnabled: true }));
+    renderCreate();
+
+    fireEvent.click(screen.getByTestId('generateWithAiButton'));
+    fireEvent.click(screen.getByTestId('mockApplyPrompt'));
+
+    // modal closes and the generated prompt lands in the instructions field
+    await waitFor(() => expect(screen.queryByTestId('promptGeneratorModal')).not.toBeInTheDocument());
+    const instructions = screen.getAllByRole('textbox').find((el) => el.getAttribute('name') === 'instructions');
+    expect(instructions).toHaveValue(MOCK_GENERATED_PROMPT);
+    expect(notificationSpy).toHaveBeenCalledWith('Prompt added to Instructions', 'success');
+  });
+
+  it('closes the prompt generator modal on close', () => {
+    localStorage.setItem('organizationServices', JSON.stringify({ promptGeneratorEnabled: true }));
+    renderCreate();
+
+    fireEvent.click(screen.getByTestId('generateWithAiButton'));
+    expect(screen.getByTestId('promptGeneratorModal')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('mockClosePrompt'));
+    expect(screen.queryByTestId('promptGeneratorModal')).not.toBeInTheDocument();
   });
 });

--- a/src/containers/Assistants/AssistantDetail/ConfigEditor.test.tsx
+++ b/src/containers/Assistants/AssistantDetail/ConfigEditor.test.tsx
@@ -338,3 +338,35 @@ describe('ConfigEditor — expand instructions modal', () => {
     expect(screen.getByTestId('unsavedIndicator')).toBeInTheDocument();
   });
 });
+
+describe('ConfigEditor — Generate with AI button (prompt generator)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.removeItem('organizationServices');
+  });
+
+  it('shows the Generate with AI button when promptGeneratorEnabled is true', () => {
+    localStorage.setItem('organizationServices', JSON.stringify({ promptGeneratorEnabled: true }));
+    renderCreate();
+    expect(screen.getByTestId('generateWithAiButton')).toBeInTheDocument();
+  });
+
+  it('hides the Generate with AI button when the flag is off', () => {
+    localStorage.setItem('organizationServices', JSON.stringify({ promptGeneratorEnabled: false }));
+    renderCreate();
+    expect(screen.queryByTestId('generateWithAiButton')).not.toBeInTheDocument();
+  });
+
+  it('hides the button while a new version is in progress', () => {
+    localStorage.setItem('organizationServices', JSON.stringify({ promptGeneratorEnabled: true }));
+    renderEdit({ newVersionInProgress: true });
+    expect(screen.queryByTestId('generateWithAiButton')).not.toBeInTheDocument();
+  });
+
+  it('opens the prompt generator modal when the button is clicked', () => {
+    localStorage.setItem('organizationServices', JSON.stringify({ promptGeneratorEnabled: true }));
+    renderCreate();
+    fireEvent.click(screen.getByTestId('generateWithAiButton'));
+    expect(screen.getByTestId('betaBanner')).toBeInTheDocument();
+  });
+});

--- a/src/containers/Assistants/AssistantDetail/ConfigEditor.tsx
+++ b/src/containers/Assistants/AssistantDetail/ConfigEditor.tsx
@@ -225,7 +225,7 @@ export const ConfigEditor = ({
 
   const generateWithAiButton = isPromptGeneratorEnabled && !newVersionInProgress && (
     <Button
-      variant="text"
+      variant="outlined"
       size="small"
       onClick={() => setShowPromptGenerator(true)}
       data-testid="generateWithAiButton"

--- a/src/containers/Assistants/AssistantDetail/ConfigEditor.tsx
+++ b/src/containers/Assistants/AssistantDetail/ConfigEditor.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import * as Yup from 'yup';
 
 import { setErrorMessage, setNotification } from 'common/notification';
+import { getOrganizationServices } from 'services/AuthService';
 
 import { AutoComplete } from 'components/UI/Form/AutoComplete/AutoComplete';
 import { Button } from 'components/UI/Form/Button/Button';
@@ -17,6 +18,7 @@ import { GET_ASSISTANT, GET_ASSISTANT_VERSIONS } from 'graphql/queries/Assistant
 import ExpandIcon from 'assets/images/icons/ExpandContent.svg?react';
 
 import { KnowledgeBaseOptions } from '../AssistantOptions/KnowledgeBaseOptions';
+import { PromptGeneratorModal, initialPromptAnswers, PromptAnswers } from '../CreateAssistant/PromptGeneratorModal';
 import type { AssistantVersion } from '../VersionPanel/VersionPanel';
 
 import styles from './ConfigEditor.module.css';
@@ -72,6 +74,11 @@ export const ConfigEditor = ({
   const { t } = useTranslation();
   const [openInstructions, setOpenInstructions] = useState(false);
   const [hasUnsavedFiles, setHasUnsavedFiles] = useState(false);
+  const [showPromptGenerator, setShowPromptGenerator] = useState(false);
+  // prompt-generator answers live here (not inside the modal) so they survive closing
+  // and reopening the modal while the user stays on this version
+  const [promptAnswers, setPromptAnswers] = useState<PromptAnswers>(initialPromptAnswers);
+  const isPromptGeneratorEnabled = getOrganizationServices('promptGeneratorEnabled');
 
   const [updateAssistant, { loading: savingChanges }] = useMutation(UPDATE_ASSISTANT);
   const [createAssistant, { loading: creating }] = useMutation(CREATE_ASSISTANT);
@@ -216,6 +223,19 @@ export const ConfigEditor = ({
     </InputAdornment>
   );
 
+  const generateWithAiButton = isPromptGeneratorEnabled && !newVersionInProgress && (
+    <Button
+      variant="text"
+      size="small"
+      onClick={() => setShowPromptGenerator(true)}
+      data-testid="generateWithAiButton"
+      className={styles.GenerateWithAiButton}
+    >
+      {t('Generate with AI')}
+      <span className={styles.BetaBadge}>{t('BETA')}</span>
+    </Button>
+  );
+
   const formFields: any[] = [
     ...(createMode
       ? [
@@ -280,7 +300,10 @@ export const ConfigEditor = ({
     <Modal open onClose={() => setOpenInstructions(false)}>
       <div className={styles.InstructionsBox}>
         <div className={styles.Instructions}>
-          <h5>Edit system instructions</h5>
+          <div className={styles.LabelRow}>
+            <h5>Edit system instructions</h5>
+            {generateWithAiButton}
+          </div>
           <OutlinedInput
             name="expand-instructions"
             onChange={(event) => formik.setFieldValue('instructions', event.target.value)}
@@ -355,9 +378,12 @@ export const ConfigEditor = ({
           <div className={styles.FormFields}>
             {formFields.map((field: any) => (
               <div className={styles.FormSection} key={field.name}>
-                <Typography className={styles.Label} variant="h5">
-                  {field.label}
-                </Typography>
+                <div className={styles.LabelRow}>
+                  <Typography className={styles.Label} variant="h5">
+                    {field.label}
+                  </Typography>
+                  {field.name === 'instructions' && generateWithAiButton}
+                </div>
                 <Field key={field.name} {...field} />
               </div>
             ))}
@@ -382,6 +408,19 @@ export const ConfigEditor = ({
         )}
 
         {instructionsDialog}
+        {showPromptGenerator && (
+          <PromptGeneratorModal
+            open={showPromptGenerator}
+            answers={promptAnswers}
+            setAnswers={setPromptAnswers}
+            onClose={() => setShowPromptGenerator(false)}
+            onApply={(text) => {
+              formik.setFieldValue('instructions', text);
+              setShowPromptGenerator(false);
+              setNotification(t('Prompt added to Instructions'), 'success');
+            }}
+          />
+        )}
       </div>
     </FormikProvider>
   );

--- a/src/containers/Assistants/CreateAssistant/PromptGeneratorModal.test.tsx
+++ b/src/containers/Assistants/CreateAssistant/PromptGeneratorModal.test.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { MockedProvider } from '@apollo/client/testing';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 
 import * as Notification from 'common/notification';
 import {
@@ -20,8 +20,27 @@ const errorMessageSpy = vi.spyOn(Notification, 'setErrorMessage');
 // jsdom doesn't implement scrollIntoView; the modal calls it to jump to the first gap
 Element.prototype.scrollIntoView = vi.fn();
 
+// The modal polls on a real 2s interval with a 20s timeout. Driving those with the
+// real clock makes the suite slow and flaky under CI load (event-loop starvation can
+// race waitFor against the poll), so we run the async tests on a fake clock and advance
+// it deterministically — the generation flow then resolves on demand, not on wall-time.
+const POLL_INTERVAL = 2000;
+
+// flush the mutation promise + any scheduled poll ticks/timeouts on the fake clock
+const advanceGeneration = async (ms: number = POLL_INTERVAL * 3) => {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+};
+
 beforeEach(() => {
+  vi.useFakeTimers();
   vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
 });
 
 const onClose = vi.fn();
@@ -102,17 +121,12 @@ test('generates a prompt, polls to ready and shows the editable preview', async 
   fillAllAnswers();
   fireEvent.click(screen.getByTestId('generatePromptButton'));
 
-  await waitFor(() => {
-    expect(screen.getByTestId('generatingState')).toBeInTheDocument();
-  });
+  // phase flips to 'generating' synchronously on click, before the mutation resolves
+  expect(screen.getByTestId('generatingState')).toBeInTheDocument();
 
-  await waitFor(
-    () => {
-      expect(screen.getByTestId('reviewNotice')).toBeInTheDocument();
-    },
-    { timeout: 5000 }
-  );
+  await advanceGeneration();
 
+  expect(screen.getByTestId('reviewNotice')).toBeInTheDocument();
   expect(screen.getByTestId('generatedPromptInput')).toHaveValue(generatedPromptText);
 });
 
@@ -121,20 +135,12 @@ test('editing the preview and clicking Use this Prompt calls onApply with edited
 
   fillAllAnswers();
   fireEvent.click(screen.getByTestId('generatePromptButton'));
-
-  await waitFor(
-    () => {
-      expect(screen.getByTestId('generatedPromptInput')).toBeInTheDocument();
-    },
-    { timeout: 5000 }
-  );
+  await advanceGeneration();
 
   fireEvent.change(screen.getByTestId('generatedPromptInput'), { target: { value: 'Edited prompt text' } });
   fireEvent.click(screen.getByTestId('usePromptButton'));
 
-  await waitFor(() => {
-    expect(onApply).toHaveBeenCalledWith('Edited prompt text');
-  });
+  expect(onApply).toHaveBeenCalledWith('Edited prompt text');
 });
 
 test('shows error state with retry when generation fails', async () => {
@@ -142,17 +148,14 @@ test('shows error state with retry when generation fails', async () => {
 
   fillAllAnswers();
   fireEvent.click(screen.getByTestId('generatePromptButton'));
+  await advanceGeneration();
 
-  await waitFor(() => {
-    expect(screen.getByTestId('promptError')).toBeInTheDocument();
-    expect(errorMessageSpy).toHaveBeenCalled();
-  });
+  expect(screen.getByTestId('promptError')).toBeInTheDocument();
+  expect(errorMessageSpy).toHaveBeenCalled();
 
   // retry returns to the form
   fireEvent.click(screen.getByTestId('retryButton'));
-  await waitFor(() => {
-    expect(screen.getByTestId('generatePromptButton')).toBeInTheDocument();
-  });
+  expect(screen.getByTestId('generatePromptButton')).toBeInTheDocument();
 });
 
 test('shows error when the mutation returns a failed status directly', async () => {
@@ -160,10 +163,9 @@ test('shows error when the mutation returns a failed status directly', async () 
 
   fillAllAnswers();
   fireEvent.click(screen.getByTestId('generatePromptButton'));
+  await advanceGeneration();
 
-  await waitFor(() => {
-    expect(screen.getByTestId('promptError')).toBeInTheDocument();
-  });
+  expect(screen.getByTestId('promptError')).toBeInTheDocument();
 });
 
 test('treats a ready response with no prompt text as a failure', async () => {
@@ -171,10 +173,9 @@ test('treats a ready response with no prompt text as a failure', async () => {
 
   fillAllAnswers();
   fireEvent.click(screen.getByTestId('generatePromptButton'));
+  await advanceGeneration();
 
-  await waitFor(() => {
-    expect(screen.getByTestId('promptError')).toBeInTheDocument();
-  });
+  expect(screen.getByTestId('promptError')).toBeInTheDocument();
 });
 
 test('shows error when polling resolves to a failed status', async () => {
@@ -182,11 +183,7 @@ test('shows error when polling resolves to a failed status', async () => {
 
   fillAllAnswers();
   fireEvent.click(screen.getByTestId('generatePromptButton'));
+  await advanceGeneration();
 
-  await waitFor(
-    () => {
-      expect(screen.getByTestId('promptError')).toBeInTheDocument();
-    },
-    { timeout: 5000 }
-  );
+  expect(screen.getByTestId('promptError')).toBeInTheDocument();
 });


### PR DESCRIPTION
## Problem

The **Generate with AI** button only existed in the legacy assistant editor (`CreateAssistant`). Orgs with `assistant_config_versions_enabled` on are routed to the **new** assistant UI (`ConfigEditor`), which never had the button — so with the prompt-generator flag enabled, the button showed in the old UI but was **missing in the new UI**.

## Fix

Port the button + `PromptGeneratorModal` into `ConfigEditor`, gated identically to the old UI:

- Renders only when `getOrganizationServices('promptGeneratorEnabled') && !newVersionInProgress`.
- Sits next to the **Instructions** label and inside the expand-instructions modal.
- On apply, writes the generated text into the `instructions` field and notifies.
- Adds `LabelRow` / `GenerateWithAiButton` / `BetaBadge` styles (copied from the old UI).

PostHog funnel is intentionally **left out** — it isn't on `master`'s `CreateAssistant` yet, so it stays a separate change.

## Testing

- `tsc --noEmit`: 0 errors
- `ConfigEditor.test.tsx`: **30/30 pass**, including 4 new tests covering button visibility (flag on/off, new-version-in-progress) and the modal opening on click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
* Added a beta **“Generate with AI”** workflow for configuring system instructions in assistant details.
* When enabled, users can open a modal to generate an instruction, review/edit the result, and apply it to the instructions field with a success confirmation.
* The AI prompt state is preserved while the modal is opened/closed.
  
**Tests**
* Improved test reliability for the AI prompt generation flow by using deterministic time handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->