### PR TITLE
chore: add Claude Code skills (flaky tests, coverage, review-ready)

### DIFF
--- a/.claude/skills/fix-flaky-tests/SKILL.md
+++ b/.claude/skills/fix-flaky-tests/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: fix-flaky-tests
+description: Diagnose and fix flaky/nondeterministic tests in the Glific frontend (Vitest + React Testing Library + Apollo MockedProvider, plus Cypress e2e). Reproduce intermittency, classify the root cause (real-timer/polling races, cross-file timer leakage, unflushed act() updates, global/localStorage state leakage, MockedProvider mock exhaustion, Cypress infra flakes), apply the smallest safe fix (usually fake timers or proper isolation), and verify with repeated isolated + one clean concurrent run. Use when the user reports flaky tests or shares CI logs for intermittent failures.
+disable-model-invocation: true
+effort: xhigh
+---
+
+# Fix Flaky Tests (Frontend)
+
+Evidence-first workflow for flaky **Vitest** unit/component tests and **Cypress** e2e. Do not guess — reproduce, classify with evidence, fix minimally, verify.
+
+## Required inputs
+
+Do not begin until the user provides one:
+1. A list of flaky tests (file path, optionally test name), or
+2. CI logs showing the intermittent failure (the `Unit Testing` / `E2E Tests` workflow log).
+
+If neither is given, ask for it. Then extract the **exact failing test name + file + error shape** from the log — CI stderr is full of Apollo `addTypename` warnings; grep them out (`grep -vE "An error occurred|apollo.dev"`) and look for the real `FAIL … > <test name>` / `Failed Tests` line.
+
+## Reproduce locally (targeted)
+
+Vitest:
+```bash
+yarn test:no-watch src/path/to/File.test.tsx                 # one file
+yarn test:no-watch src/path/to/File.test.tsx -t "test name"  # one test
+yarn test:no-watch src/containers/<area>                     # a directory (concurrent workers)
+```
+
+Two stress modes — **run them one at a time**:
+- **Isolated**: loop the single file ~20–25×.
+- **Concurrent**: loop the whole directory ~6× (parallel workers — this reproduces the CI event-loop-starvation condition that exposes timer races).
+
+> ⚠️ **Never run two stress loops at once.** Saturating the CPU makes even healthy *synchronous* tests miss an `act()` flush and fail — a measurement artifact, not a real flake. One loop at a time, or you'll chase ghosts.
+
+If it won't reproduce locally even concurrently, the flake is almost always **real-timer/polling** (see below) — fix it structurally; you don't need a local repro to justify fake timers.
+
+## Classify the root cause (with evidence)
+
+1. **Real-timer / polling races (most common here)**
+   - Symptoms: passes in isolation, fails under CI parallel load; component uses Apollo `startPolling`/`stopPolling`, `setInterval`, or `setTimeout`; the test uses `waitFor` with a timeout to reach a polled state.
+   - Why: under load the event loop is starved, so wall-clock timers race `waitFor`’s own polling, and timers can leak across files sharing a worker.
+   - **Fix — fake timers (deterministic):**
+     ```ts
+     beforeEach(() => { vi.useFakeTimers(); vi.clearAllMocks(); });
+     afterEach(() => { vi.runOnlyPendingTimers(); vi.useRealTimers(); });
+
+     const advance = async (ms: number) => {
+       await act(async () => { await vi.advanceTimersByTimeAsync(ms); });
+     };
+     ```
+     Drive the flow by advancing the clock (`await advance(POLL_INTERVAL * 3)`) instead of `waitFor`. `advanceTimersByTimeAsync` also flushes the microtasks that resolve `MockedProvider` results. Assert synchronously after advancing. Phase changes that happen synchronously on click (e.g. `setPhase('generating')`) can be asserted before advancing.
+
+2. **Cross-file timer / state leakage**
+   - Symptoms: a *sync* test fails only when run with the rest of its directory.
+   - Fixes: fake timers (above) make leaked timers inert; `vi.clearAllMocks()` + `localStorage.removeItem(...)` in `beforeEach`; ensure the component clears its timers/polling on unmount.
+
+3. **Unflushed `act()` state updates**
+   - Symptoms: `An update to X inside a test was not wrapped in act(...)`, or an assertion races a state update.
+   - Fix: wrap the triggering interaction/timer-advance in `act`, or `await` a `findBy*`/`waitFor` for the resulting DOM.
+
+4. **Global / `localStorage` leakage**
+   - Glific reads feature flags from `localStorage['organizationServices']` (set at login). Tests that set it must clear it in `beforeEach`/`afterEach` or it leaks into later tests.
+
+5. **MockedProvider issues**
+   - Mock exhaustion (a poll ticks more times than there are mocks → "No more mocked responses") — add buffer mocks or stop polling deterministically.
+   - Order-dependent mock consumption — keep mocks per-render, not shared mutable across files.
+
+6. **Heavy child component doing real async** (alternative to fake timers)
+   - If you only need to cover a *parent’s* callback (e.g. `onApply`), **mock the child** so it invokes the callback directly — no real timers at all:
+     ```ts
+     vi.mock('../Child/Modal', () => ({
+       initialFoo: {},
+       Modal: ({ open, onApply, onClose }: any) =>
+         open ? <button data-testid="apply" onClick={() => onApply('x')}>apply</button> : null,
+     }));
+     ```
+
+7. **Cypress e2e**
+   - `Verifying Cypress can run … FAILED: Cypress verification timed out`, network/asset timeouts, or a single shard failing while others pass = **CI infrastructure flake**, not a code bug. Re-run the failed shard: `gh run rerun <e2e-run-id> --failed`. Only treat as a real flake if it reproduces across re-runs.
+
+## Apply the smallest safe fix
+
+- Prefer test/setup fixes when the product behavior is correct (it usually is for timing flakes).
+- Change app code only with proven behavioral regression.
+- Keep the same assertions; change only *how* the test reaches the state.
+
+## Hard guardrail
+
+If you cannot demonstrate the root cause with evidence **and** the structural fix (fake timers / isolation) doesn’t apply, say so plainly — do not weaken assertions, add arbitrary `waitFor` timeouts, or `skip`/`retry` the test to hide it.
+
+## Verify (mandatory)
+
+- Run the fixed file **isolated ~20×** → 0 failures.
+- Run its **directory once concurrently** (clean, nothing else running) → pass.
+- `npx tsc --noEmit` → 0 errors; `npx prettier --check <changed files>` → clean.
+- For Cypress: confirm a clean re-run of the shard.
+
+Report: root cause + why it was flaky, files changed, the stress matrix (isolated N/N, concurrent pass), and tsc/prettier status.
+
+## Glific FE conventions to respect
+
+- Vitest + React Testing Library; Apollo `MockedProvider` for GraphQL; `act` from `@testing-library/react`.
+- Use existing mocks under `src/mocks/`; don’t hand-roll GraphQL responses when a mock exists.
+- Keep `data-testid`s stable (tests and the codebase key on them).
+- The Apollo `addTypename` stderr noise is pre-existing — never treat it as the failure.
+
+## Related skills
+
+- **improve-code-coverage** — when `codecov/patch` fails after a fix.
+- **make-branch-ready-for-review** — full green-CI workflow (includes re-triggering stuck runs and re-running Cypress infra flakes).

--- a/.claude/skills/improve-code-coverage/SKILL.md
+++ b/.claude/skills/improve-code-coverage/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: improve-code-coverage
+description: Make the current branch satisfy the Glific frontend Codecov gates (project + patch) by finding uncovered changed lines with Vitest/istanbul coverage and adding focused, behavior-asserting tests until green. Use when the user asks to improve coverage, fix a codecov/patch or codecov/project failure, or satisfy codecov.yml on the current branch.
+disable-model-invocation: true
+---
+
+# Improve Code Coverage (Frontend)
+
+Iterative loop: generate Vitest coverage, find uncovered **changed** lines, add tests that assert real behavior, repeat until the gate is green. No `git push` or Codecov upload required to iterate.
+
+## Gates (`codecov.yml`)
+
+| Check | Rule |
+|-------|------|
+| **project** | target **81.5%**, threshold **0.5%** |
+| **patch** | threshold **0%** — **every changed line in the diff must be covered** |
+
+The **patch** gate is strict: a single uncovered new/changed line fails `codecov/patch`. Most failures are an un-exercised callback (e.g. an `onApply`/`onClose`/`onError` handler) or an error branch.
+
+## Tools
+
+- `yarn test:coverage` — full suite coverage (istanbul). Slow; use for the final check.
+- Scoped coverage for a single file (fast iteration):
+  ```bash
+  CI=true npx vitest run src/path/to/File.test.tsx \
+    --coverage --coverage.include='src/path/to/File.tsx'
+  ```
+  The report’s **`Uncovered Line #s`** column is your worklist.
+- Map uncovered lines to *your* diff (only changed lines count for patch):
+  ```bash
+  git diff -U0 origin/master -- src/path/to/File.tsx | grep '^@@'
+  ```
+  Lines outside your `@@` hunks are pre-existing — ignore them for `codecov/patch`.
+
+## Loop (repeat until green)
+
+1. Run scoped coverage on the changed file(s); note `Uncovered Line #s`.
+2. Cross-check against your diff hunks — keep only uncovered lines **you added/changed**.
+3. Add/extend a test that **exercises and asserts** that line’s behavior:
+   - Prefer existing mocks in `src/mocks/` and `MockedProvider`.
+   - To cover a callback handler without driving a heavy child’s real async, **mock the child** so it calls the handler directly (see **fix-flaky-tests** §6). This avoids real timers and keeps the test fast and deterministic.
+   - Cover error branches with the matching error mock (e.g. `…ErrorMocks`).
+4. Re-run scoped coverage; repeat until no changed lines are uncovered.
+5. Final: `npx tsc --noEmit` (0 errors) and `npx prettier --check <changed test files>`.
+
+## Hard rules
+
+- **Never** weaken `codecov.yml`, exclude files, or lower thresholds to go green.
+- **Never** add tests that only execute lines without asserting behavior.
+- If `codecov/patch` is failing on lines **outside your PR’s scope**, stop and ask the user — don’t backfill unrelated coverage.
+- Don’t commit unless the user asked; iterate on the working tree.
+
+## When to ask the user
+
+- 5 loops without green.
+- Patch gaps require large unrelated test work.
+- A changed line is genuinely untestable (e.g. defensive `default` branch) — propose excluding *just that line* with an `istanbul ignore` comment and ask before adding it.
+
+## Related skills
+
+- **fix-flaky-tests** — if a test fails intermittently during a coverage run, or you need fake-timers/child-mocking to cover async handlers.
+- **make-branch-ready-for-review** — push + poll CI/Codecov after the local gate is green.

--- a/.claude/skills/make-branch-ready-for-review/SKILL.md
+++ b/.claude/skills/make-branch-ready-for-review/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: make-branch-ready-for-review
+description: Take the current Glific frontend branch from local changes through green CI and addressed bot/reviewer comments, ready for human review. Runs tsc + prettier + Vitest + coverage locally, fixes the PR title to the required format, pushes, then polls Unit Testing / Prettier / E2E / Codecov / CodeRabbit until green — handling the common gotchas (un-scheduled workflows, Cypress infra flakes). Use when the user asks to make a branch review-ready or get changes ready for review.
+disable-model-invocation: true
+---
+
+# Make Branch Ready for Review (Frontend)
+
+End-to-end workflow to get **the current branch** to green CI and addressed automated review.
+
+## Prerequisites
+
+- On the intended feature branch (not `master` unless the user says so).
+- `gh` authenticated for `glific/glific-frontend`.
+- Node/yarn installed (`yarn install --frozen-lockfile` if deps are stale).
+
+## Hard rules
+
+- **Never** edit CI workflow files or disable checks to make failures pass.
+- **Never** force-push to `master`; force-push to a feature branch only with `--force-with-lease`.
+- **Never** commit secrets (`.env`, tokens).
+- During the post-push loop, fix locally and push once per iteration; **don’t** churn force-pushes for every tiny tweak — batch them, and for visual/CSS tweaks let the user confirm via HMR before pushing.
+- Stop and ask the user on high-risk or out-of-scope fixes.
+
+## Progress checklist
+
+```
+- [ ] Phase 1 — Local quality (tsc, prettier, Vitest, coverage)
+- [ ] Phase 2 — PR title + self-review
+- [ ] Phase 3 — Commit and push
+- [ ] Phase 4 — CI loop (Unit Testing, Prettier, E2E, Codecov, CodeRabbit)
+- [ ] Phase 5 — Address review comments; final green
+```
+
+## Phase 1 — Local quality
+
+```bash
+npx tsc --noEmit                                  # 0 type errors
+npx prettier --check "src/**/*.{ts,tsx,css,graphql}"   # or: yarn format (writes)
+CI=true yarn test:no-watch                        # full Vitest suite green
+```
+- Coverage: ensure the **patch** gate will pass (every changed line covered) — use **improve-code-coverage**.
+- Flaky/intermittent failures → **fix-flaky-tests** (don’t retry-loop CI hoping it passes).
+
+## Phase 2 — PR title (strict) + self-review
+
+The **`Validate PR title format`** check requires `^(feat|fix|build|chore|ci|docs|style|refactor|perf|test)!?: ` — i.e. **`<type>: ` with NO scope**. `feat(prompt-generator): …` **fails**; use `feat: …`. Fix with:
+```bash
+gh pr edit <PR#> --title "feat: <summary>"
+```
+Self-review the diff for scope creep, leftover logs, and reuse opportunities (or run the **code-review** skill).
+
+## Phase 3 — Commit and push
+
+Commit in focused chunks; confirm with the user before pushing/opening a PR if they’ve asked to. Push, then open the PR with `gh pr create` (PR-triggered CI runs against the merge ref).
+
+## Phase 4 — CI loop
+
+Workflows that gate the PR: **Unit Testing** (job shows as the `CI` check), **Prettier** (`Check formatting`), **E2E Tests** (Cypress, sharded), **Build and Deploy to Netlify**, **Validate PR title format**, plus **codecov/patch**, **codecov/project**, and **CodeRabbit**.
+
+Read the authoritative rollup:
+```bash
+gh pr view <PR#> --json statusCheckRollup \
+  -q '.statusCheckRollup[] | "\(.status // .state)/\(.conclusion // "-")  \(.name // .context)"' | sort -u
+```
+
+Gotchas seen in practice:
+- **Un-scheduled workflows:** after a push, sometimes only `PR Title Check` runs and `Unit Testing`/`Prettier`/`E2E` never get created (GitHub Actions scheduling miss). Confirm with:
+  ```bash
+  gh run list --workflow "Unit Testing" --limit 5 --json headSha,status,conclusion
+  ```
+  If there’s no run for your head SHA and nothing queued, **re-trigger** by close/reopen (no history rewrite):
+  ```bash
+  gh pr close <PR#> && gh pr reopen <PR#>
+  ```
+- **Cypress shard fails on infra** (`Verifying Cypress can run … timed out`, network/asset timeouts) while other shards pass → re-run just that shard: `gh run rerun <e2e-run-id> --failed`. Not a code failure.
+- **CI stderr noise:** Apollo `addTypename` warnings are not failures — grep them out when reading logs.
+
+Fix any real failures locally (commit), then push and re-poll.
+
+## Phase 5 — Review comments
+
+- Fetch CodeRabbit + human review comments:
+  ```bash
+  gh api repos/glific/glific-frontend/pulls/<PR#>/comments --paginate \
+    -q '.[] | "@\(.user.login) \(.path):\(.line)\n\(.body)\n---"'
+  gh pr view <PR#> --json reviews -q '.reviews[] | "@\(.user.login) [\(.state)]: \(.body)"'
+  ```
+- Apply valid suggestions (i18n via `t('English text')`, accessibility, reuse). For inherited/pre-existing nits, note why if skipping.
+- For **visual/CSS** review comments, remember the shared `Button` base style applies a white fill + drop shadow + 27px pill radius to every button — override per-component (e.g. `box-shadow: none !important`, `border-radius`) rather than editing the shared component. Let the user confirm via HMR before pushing.
+- Re-run **improve-code-coverage** / **fix-flaky-tests** if a fix touches tests.
+
+## Definition of done
+
+All gating checks green on the head SHA, CodeRabbit review completed, reviewer threads addressed, branch ready for human merge.
+
+## Related skills
+
+- **fix-flaky-tests**, **improve-code-coverage**, **code-review**.


### PR DESCRIPTION
## What

Adds three Claude Code skills under `.claude/skills/`, mirroring the backend's skill set, adapted to the frontend stack (Vitest + React Testing Library + Apollo MockedProvider + Cypress + Codecov):

- **fix-flaky-tests** — reproduce intermittency (isolated + concurrent stress, never both at once), classify the root cause, and fix. Emphasises the patterns we actually hit: real-timer/Apollo-polling races → **fake timers** (`vi.useFakeTimers` + `advanceTimersByTimeAsync`); cross-file timer leakage; mocking heavy children to cover callbacks without real async; Cypress binary/infra timeouts = re-run, not a code bug.
- **improve-code-coverage** — satisfy `codecov.yml` (project 81.5% / **patch 0% threshold = every changed line covered**); find uncovered changed lines with scoped Vitest coverage, add behaviour-asserting tests.
- **make-branch-ready-for-review** — local `tsc` + prettier + Vitest + coverage, the strict **`<type>:` no-scope PR title** rule, push, then poll Unit Testing / Prettier / E2E / Codecov / CodeRabbit — including re-triggering workflows that GitHub fails to schedule (close/reopen) and re-running Cypress infra flakes.

## Why

These encode conventions learned in practice so future agent/dev work hits fewer of the same snags (flaky polling tests, patch-coverage gaps, PR-title rejections, stuck CI). Parity with the backend `.claude/skills/`.

No app code changes — docs/config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)