### PR TITLE
feat: enable PostHog Session Replay for the prompt generator

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,4 +8,6 @@ VITE_STRIPE_PUBLISH_KEY=''
 VITE_RECAPTCHA_CLIENT_KEY='Your recaptch key'
 VITE_PUBLIC_POSTHOG_PROJECT_TOKEN='Your posthog project token'
 VITE_PUBLIC_POSTHOG_HOST='https://us.i.posthog.com'
+# Set to 'true' to enable PostHog in local dev (off by default so localhost doesn't pollute the shared project)
+VITE_PUBLIC_POSTHOG_ENABLE_DEV='false'
 VITE_AI_EVALS_INTRO_VIDEO_URL=''

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -97,6 +97,7 @@ describe('index', () => {
       api_host: configValues.POSTHOG_HOST,
       defaults: '2026-01-30',
       capture_performance: { web_vitals: true },
+      session_recording: { maskAllInputs: false, maskInputOptions: { password: true } },
     });
     expect(screen.getByTestId('posthog-provider')).toBeInTheDocument();
     expect(screen.getByTestId('mock-app')).toBeInTheDocument();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,7 +17,13 @@ function redirectOldDomain(): void {
 }
 
 function initPostHog(): boolean {
-  if (!POSTHOG_PROJECT_TOKEN) {
+  // PostHog is OFF in local dev by default, so developer machines don't pump events — and
+  // PII session recordings — into the shared project. A dev who wants to test PostHog
+  // locally can opt in by setting VITE_PUBLIC_POSTHOG_ENABLE_DEV=true in their .env.
+  // Staging/prod builds always send (when a token is present).
+  const isDev = import.meta.env.MODE === 'development';
+  const enabledInDev = import.meta.env.VITE_PUBLIC_POSTHOG_ENABLE_DEV === 'true';
+  if (!POSTHOG_PROJECT_TOKEN || (isDev && !enabledInDev)) {
     return false;
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,6 +28,17 @@ function initPostHog(): boolean {
       capture_performance: {
         web_vitals: true,
       },
+      // Session Replay privacy posture. Recording is OFF until enabled in the PostHog
+      // project settings, and — critically — it must be scoped there to the
+      // assistant/prompt-generator pages **by URL** (not by feature flag, which records
+      // the whole session). That URL scope is what keeps chat (contact numbers) and login
+      // (credentials) out of recordings entirely. Within that scope the prompt-generator
+      // inputs aren't sensitive, so we leave inputs/text visible — but always mask
+      // password fields as a safety net for credentials.
+      session_recording: {
+        maskAllInputs: false,
+        maskInputOptions: { password: true },
+      },
     });
     return true;
   } catch {


### PR DESCRIPTION
## What

Adds a `session_recording` block to `posthog.init` so PostHog Session Replay can be used for the **prompt-generator / assistant** flow.

```ts
session_recording: {
  maskAllInputs: false,            // show inputs — the 9 prompt answers aren't sensitive
  maskInputOptions: { password: true },  // always mask credential fields
}
```

## Privacy posture — read this

The inputs in the prompt generator (the 9 answers) aren't PII, so they're left **visible** in recordings — that's the point: we want to watch how users fill the form. **Passwords are always masked.**

The protection against real PII (contact numbers in chat, beneficiary data) is **scoping**, configured in the PostHog dashboard — **not** this code:

- Enable replay in **PostHog → Settings → Session Replay**.
- **Scope it by URL** to the assistant / prompt-generator pages. ⚠️ Use **URL** scoping, **not** feature-flag scoping — a feature-flag scope records the *whole session* (so chat/login would be captured); URL scoping records **only while on those pages**, keeping chat (contact numbers) and login (credentials) out entirely.

Until it's enabled + URL-scoped in the dashboard, nothing records.

## Testing
- `src/index.test.tsx` asserts the new config — 5/5 pass.
- `tsc` 0 errors, prettier clean. No effect locally (PostHog only inits with a token).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated session recording configuration tests.

* **Bug Fixes**
  * Prevented analytics from initializing in development mode.

* **Configuration Updates**
  * Enhanced session recording privacy settings: password fields are now masked while other inputs remain visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->