### PR TITLE
feat: add ConfigurePageStub for flow configuration and update routing

### DIFF
--- a/src/containers/Flow/Flow.test.tsx
+++ b/src/containers/Flow/Flow.test.tsx
@@ -1,6 +1,6 @@
 import { MockedProvider } from '@apollo/client/testing';
 import { render, waitFor, fireEvent, screen, cleanup } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router';
+import { MemoryRouter, Route, Routes, useParams } from 'react-router';
 import { vi } from 'vitest';
 
 import { getOrganizationLanguagesQuery, getOrganizationQuery } from 'mocks/Organization';
@@ -24,6 +24,11 @@ import { setErrorMessage, setNotification } from 'common/notification';
 import FlowList from './FlowList/FlowList';
 
 setOrganizationServices('{"__typename":"OrganizationServicesResult","rolesAndPermission":true}');
+
+const ConfigurePageStub = () => {
+  const { uuid } = useParams();
+  return <div>Configure: {uuid}</div>;
+};
 
 const mocks = [
   ...getOrganizationQuery,
@@ -259,6 +264,7 @@ it('should configure the flow', async () => {
         <Routes>
           <Route path="flow" element={<FlowList />} />
           <Route path="flow/:id/edit" element={<Flow />} />
+          <Route path="flow/configure/:uuid" element={<ConfigurePageStub />} />
         </Routes>
       </MemoryRouter>
     </MockedProvider>
@@ -276,6 +282,12 @@ it('should configure the flow', async () => {
 
   await waitFor(() => {
     expect(setNotification).toHaveBeenCalled();
+  });
+
+  // After editing an existing flow, Configure must navigate to the flow's UUID,
+  // not /flow/configure/undefined
+  await waitFor(() => {
+    expect(getByText('Configure: 3fa22108-f464-41e5-81d9-d8a298854429')).toBeInTheDocument();
   });
 });
 

--- a/src/containers/Flow/Flow.tsx
+++ b/src/containers/Flow/Flow.tsx
@@ -341,6 +341,7 @@ export const Flow = () => {
       redirectionLink={backLink}
       cancelLink={backLink}
       linkParameter="uuid"
+      setLinkOnUpdate
       listItem="flow"
       icon={flowIcon}
       additionalAction={additionalAction}

--- a/src/containers/Flow/Flow.tsx
+++ b/src/containers/Flow/Flow.tsx
@@ -341,7 +341,6 @@ export const Flow = () => {
       redirectionLink={backLink}
       cancelLink={backLink}
       linkParameter="uuid"
-      setLinkOnUpdate
       listItem="flow"
       icon={flowIcon}
       additionalAction={additionalAction}

--- a/src/containers/Form/FormLayout.tsx
+++ b/src/containers/Form/FormLayout.tsx
@@ -43,7 +43,6 @@ export interface FormLayoutProps {
   additionalAction?: any;
   additionalQuery?: Function | null;
   linkParameter?: any;
-  setLinkOnUpdate?: boolean;
   cancelLink?: string | null;
   languageSupport?: boolean;
   setPayload?: Function;
@@ -116,7 +115,6 @@ export const FormLayout = ({
   additionalQuery = null,
   defaultAttribute = null,
   additionalAction,
-  setLinkOnUpdate = false,
   icon,
   idType = 'id',
   additionalState,
@@ -240,7 +238,7 @@ export const FormLayout = ({
         customError.setErrors(codeErrors);
       }
     } else {
-      if ((type === 'copy' || setLinkOnUpdate) && updatedItem) setLink(updatedItem[linkParameter]);
+      setLink(updatedItem[linkParameter]);
       if (additionalQuery) {
         additionalQuery(itemId);
       }

--- a/src/containers/Form/FormLayout.tsx
+++ b/src/containers/Form/FormLayout.tsx
@@ -238,7 +238,11 @@ export const FormLayout = ({
         customError.setErrors(codeErrors);
       }
     } else {
-      if (type === 'copy') setLink(updatedItem[linkParameter]);
+      console.log('type', type);
+      console.log('updatedItem', updatedItem);
+      console.log('linkParameter', linkParameter);
+      console.log('updatedItem[linkParameter]', updatedItem[linkParameter]);
+      if (linkParameter && updatedItem) setLink(updatedItem[linkParameter]);
       if (additionalQuery) {
         additionalQuery(itemId);
       }

--- a/src/containers/Form/FormLayout.tsx
+++ b/src/containers/Form/FormLayout.tsx
@@ -238,7 +238,9 @@ export const FormLayout = ({
         customError.setErrors(codeErrors);
       }
     } else {
-      setLink(updatedItem[linkParameter]);
+      if (updatedItem) {
+        setLink(updatedItem[linkParameter]);
+      }
       if (additionalQuery) {
         additionalQuery(itemId);
       }

--- a/src/containers/Form/FormLayout.tsx
+++ b/src/containers/Form/FormLayout.tsx
@@ -238,10 +238,6 @@ export const FormLayout = ({
         customError.setErrors(codeErrors);
       }
     } else {
-      console.log('type', type);
-      console.log('updatedItem', updatedItem);
-      console.log('linkParameter', linkParameter);
-      console.log('updatedItem[linkParameter]', updatedItem[linkParameter]);
       if (linkParameter && updatedItem) setLink(updatedItem[linkParameter]);
       if (additionalQuery) {
         additionalQuery(itemId);

--- a/src/containers/Form/FormLayout.tsx
+++ b/src/containers/Form/FormLayout.tsx
@@ -43,6 +43,7 @@ export interface FormLayoutProps {
   additionalAction?: any;
   additionalQuery?: Function | null;
   linkParameter?: any;
+  setLinkOnUpdate?: boolean;
   cancelLink?: string | null;
   languageSupport?: boolean;
   setPayload?: Function;
@@ -115,6 +116,7 @@ export const FormLayout = ({
   additionalQuery = null,
   defaultAttribute = null,
   additionalAction,
+  setLinkOnUpdate = false,
   icon,
   idType = 'id',
   additionalState,
@@ -238,7 +240,7 @@ export const FormLayout = ({
         customError.setErrors(codeErrors);
       }
     } else {
-      if (linkParameter && updatedItem) setLink(updatedItem[linkParameter]);
+      if ((type === 'copy' || setLinkOnUpdate) && updatedItem) setLink(updatedItem[linkParameter]);
       if (additionalQuery) {
         additionalQuery(itemId);
       }


### PR DESCRIPTION

## Summary 

Closes: https://github.com/glific/glific/issues/5286

* **Bug Fixes**
  * Improved flow editing behavior so configured links update correctly after selecting a linked item (including when updating, not just copying).
  * After editing a flow, the app now reliably navigates to the configure screen and displays the expected flow identifier.

* **Tests**
  * Expanded test coverage for the new configure-flow route and added assertions for the expected post-edit navigation and on-screen identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for navigating to a flow configuration page after editing a flow.

* **Bug Fixes**
  * Improved update handling so the correct link is retained for all saved items, not just copy actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->