### PR TITLE
fix: warn about invalid Google Sheet nodes in import status

### DIFF
--- a/src/containers/Flow/FlowList/FlowList.module.css
+++ b/src/containers/Flow/FlowList/FlowList.module.css
@@ -206,8 +206,14 @@
   font-size: 18px;
 }
 
+.WarningSection + .WarningSection {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid #e0e0e0;
+}
+
 .StatusMessage {
-  text-align: center;
+  text-align: left;
   margin: 8px 0 10px;
   color: #333;
   font-size: 15px;

--- a/src/containers/Flow/FlowList/FlowList.test.tsx
+++ b/src/containers/Flow/FlowList/FlowList.test.tsx
@@ -14,6 +14,10 @@ import {
   releaseFlow,
   filterTemplateFlows,
   pinFlowQuery,
+  importFlowWithAssistantError,
+  importFlowWithSheetError,
+  importFlowWithAssistantAndSheetError,
+  importFlowWithoutNodeFields,
 } from 'mocks/Flow';
 import { getOrganizationQuery } from 'mocks/Organization';
 import testJSON from 'mocks/ImportFlow.json';
@@ -371,28 +375,9 @@ describe('Template flows', () => {
   });
 
   test('Template flows > should display assistant nodes that need an assistant assigned', async () => {
-    const mockImportFlowWithAssistantError = {
-      request: { query: IMPORT_FLOW },
-      result: {
-        data: {
-          importFlow: {
-            status: [
-              {
-                assistantNodeUuids: ['3fb647a3-c935-4906-8dd0-c0e63105ee3d', 'b1d2e9ff-1234-4abc-9876-deadbeefcafe'],
-                invalidSheetNodeUuids: [],
-                flowName: 'Test Flow',
-                status: 'Successfully imported',
-              },
-            ],
-          },
-        },
-      },
-      variableMatcher: () => true,
-    };
-
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const baseWithoutImport = mocks.filter((m) => (m as any)?.request?.query !== IMPORT_FLOW);
-    const testMocks = [mockImportFlowWithAssistantError, ...baseWithoutImport];
+    const testMocks = [importFlowWithAssistantError, ...baseWithoutImport];
 
     class FileReaderMock {
       onload: null | ((e: unknown) => void) = null;
@@ -458,28 +443,9 @@ describe('Template flows', () => {
   });
 
   test('Template flows > should display google sheet nodes with an invalid sheet url', async () => {
-    const mockImportFlowWithSheetError = {
-      request: { query: IMPORT_FLOW },
-      result: {
-        data: {
-          importFlow: {
-            status: [
-              {
-                assistantNodeUuids: [],
-                invalidSheetNodeUuids: ['ee3d', 'cafe'],
-                flowName: 'Test Flow',
-                status: 'Successfully imported',
-              },
-            ],
-          },
-        },
-      },
-      variableMatcher: () => true,
-    };
-
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const baseWithoutImport = mocks.filter((m) => (m as any)?.request?.query !== IMPORT_FLOW);
-    const testMocks = [mockImportFlowWithSheetError, ...baseWithoutImport];
+    const testMocks = [importFlowWithSheetError, ...baseWithoutImport];
 
     class FileReaderMock {
       onload: null | ((e: unknown) => void) = null;
@@ -529,6 +495,123 @@ describe('Template flows', () => {
 
     expect(inDialog.getByText('ee3d')).toBeInTheDocument();
     expect(inDialog.getByText('cafe')).toBeInTheDocument();
+
+    fireEvent.click(inDialog.getByTestId('ok-button'));
+    await waitFor(() => {
+      expect(screen.queryByText(/import flow status/i)).not.toBeInTheDocument();
+    });
+  });
+
+  test('Template flows > should render both assistant and google sheet warnings with singular labels for a single node each', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const baseWithoutImport = mocks.filter((m) => (m as any)?.request?.query !== IMPORT_FLOW);
+    const testMocks = [importFlowWithAssistantAndSheetError, ...baseWithoutImport];
+
+    class FileReaderMock {
+      onload: null | ((e: unknown) => void) = null;
+      result: string | null = null;
+
+      readAsText() {
+        const text = JSON.stringify(testJSON);
+        this.result = text;
+        setTimeout(() => {
+          if (this.onload) {
+            this.onload({ target: { result: text } } as unknown as ProgressEvent<FileReader>);
+          }
+        }, 0);
+      }
+    }
+
+    vi.stubGlobal('FileReader', FileReaderMock);
+
+    render(
+      <MockedProvider mocks={testMocks} addTypename={false}>
+        <MemoryRouter>
+          <FlowList />
+        </MemoryRouter>
+      </MockedProvider>
+    );
+
+    await screen.findAllByTestId('import-icon');
+    fireEvent.click(screen.getAllByTestId('import-icon')[0]);
+
+    const file = new File([JSON.stringify(testJSON)], 'test.json', { type: 'application/json' });
+    const input = await screen.findByTestId('import');
+    Object.defineProperty(input, 'files', { value: [file] });
+    fireEvent.change(input);
+
+    const title = await screen.findByText(/import flow status/i);
+    const dialog = title.closest('div')!;
+    const inDialog = within(dialog);
+
+    // Both warning sections should be visible at the same time
+    await inDialog.findByText(/create a new assistant/i);
+    expect(inDialog.getByText(/contains google sheet node/i)).toBeInTheDocument();
+
+    // Singular labels should be used when a single node uuid is present
+    const assistantLabel = inDialog.getAllByText((_, el) => normalize(el?.textContent || '') === 'assistant node uuid:');
+    expect(assistantLabel.length).toBeGreaterThan(0);
+
+    const sheetLabel = inDialog.getAllByText(
+      (_, el) => normalize(el?.textContent || '') === 'google sheet node uuid:'
+    );
+    expect(sheetLabel.length).toBeGreaterThan(0);
+
+    expect(inDialog.getByText('assistant-uuid-1')).toBeInTheDocument();
+    expect(inDialog.getByText('sheet-uuid-1')).toBeInTheDocument();
+
+    fireEvent.click(inDialog.getByTestId('ok-button'));
+    await waitFor(() => {
+      expect(screen.queryByText(/import flow status/i)).not.toBeInTheDocument();
+    });
+  });
+
+  test('Template flows > should fall back gracefully when node uuid fields are absent from the response', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const baseWithoutImport = mocks.filter((m) => (m as any)?.request?.query !== IMPORT_FLOW);
+    const testMocks = [importFlowWithoutNodeFields, ...baseWithoutImport];
+
+    class FileReaderMock {
+      onload: null | ((e: unknown) => void) = null;
+      result: string | null = null;
+
+      readAsText() {
+        const text = JSON.stringify(testJSON);
+        this.result = text;
+        setTimeout(() => {
+          if (this.onload) {
+            this.onload({ target: { result: text } } as unknown as ProgressEvent<FileReader>);
+          }
+        }, 0);
+      }
+    }
+
+    vi.stubGlobal('FileReader', FileReaderMock);
+
+    render(
+      <MockedProvider mocks={testMocks} addTypename={false}>
+        <MemoryRouter>
+          <FlowList />
+        </MemoryRouter>
+      </MockedProvider>
+    );
+
+    await screen.findAllByTestId('import-icon');
+    fireEvent.click(screen.getAllByTestId('import-icon')[0]);
+
+    const file = new File([JSON.stringify(testJSON)], 'test.json', { type: 'application/json' });
+    const input = await screen.findByTestId('import');
+    Object.defineProperty(input, 'files', { value: [file] });
+    fireEvent.change(input);
+
+    const title = await screen.findByText(/import flow status/i);
+    const dialog = title.closest('div')!;
+    const inDialog = within(dialog);
+
+    // No warning sections should render; only the plain flow status line is shown
+    expect(inDialog.queryByText(/create a new assistant/i)).not.toBeInTheDocument();
+    expect(inDialog.queryByText(/contains google sheet node/i)).not.toBeInTheDocument();
+    expect(inDialog.getByText('Successfully imported')).toBeInTheDocument();
 
     fireEvent.click(inDialog.getByTestId('ok-button'));
     await waitFor(() => {

--- a/src/containers/Flow/FlowList/FlowList.test.tsx
+++ b/src/containers/Flow/FlowList/FlowList.test.tsx
@@ -379,6 +379,7 @@ describe('Template flows', () => {
             status: [
               {
                 assistantNodeUuids: ['3fb647a3-c935-4906-8dd0-c0e63105ee3d', 'b1d2e9ff-1234-4abc-9876-deadbeefcafe'],
+                invalidSheetNodeUuids: [],
                 flowName: 'Test Flow',
                 status: 'Successfully imported',
               },
@@ -449,6 +450,85 @@ describe('Template flows', () => {
     );
     expect(helpLink).toHaveAttribute('target', '_blank');
     expect(helpLink).toHaveAttribute('rel', 'noopener noreferrer');
+
+    fireEvent.click(inDialog.getByTestId('ok-button'));
+    await waitFor(() => {
+      expect(screen.queryByText(/import flow status/i)).not.toBeInTheDocument();
+    });
+  });
+
+  test('Template flows > should display google sheet nodes with an invalid sheet url', async () => {
+    const mockImportFlowWithSheetError = {
+      request: { query: IMPORT_FLOW },
+      result: {
+        data: {
+          importFlow: {
+            status: [
+              {
+                assistantNodeUuids: [],
+                invalidSheetNodeUuids: ['ee3d', 'cafe'],
+                flowName: 'Test Flow',
+                status: 'Successfully imported',
+              },
+            ],
+          },
+        },
+      },
+      variableMatcher: () => true,
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const baseWithoutImport = mocks.filter((m) => (m as any)?.request?.query !== IMPORT_FLOW);
+    const testMocks = [mockImportFlowWithSheetError, ...baseWithoutImport];
+
+    class FileReaderMock {
+      onload: null | ((e: unknown) => void) = null;
+      result: string | null = null;
+
+      readAsText() {
+        const text = JSON.stringify(testJSON);
+        this.result = text;
+        setTimeout(() => {
+          if (this.onload) {
+            this.onload({ target: { result: text } } as unknown as ProgressEvent<FileReader>);
+          }
+        }, 0);
+      }
+    }
+
+    vi.stubGlobal('FileReader', FileReaderMock);
+
+    render(
+      <MockedProvider mocks={testMocks} addTypename={false}>
+        <MemoryRouter>
+          <FlowList />
+        </MemoryRouter>
+      </MockedProvider>
+    );
+
+    await screen.findAllByTestId('import-icon');
+    fireEvent.click(screen.getAllByTestId('import-icon')[0]);
+
+    const file = new File([JSON.stringify(testJSON)], 'test.json', { type: 'application/json' });
+    const input = await screen.findByTestId('import');
+    Object.defineProperty(input, 'files', { value: [file] });
+    fireEvent.change(input);
+
+    const title = await screen.findByText(/import flow status/i);
+    const dialog = title.closest('div')!;
+    const inDialog = within(dialog);
+
+    const para = (await inDialog.findByText(/contains google sheet node/i)).closest('p');
+    expect(para).toBeTruthy();
+    expect(normalize(para!.textContent || '')).toContain(
+      'this flow contains google sheet node(s) with an invalid or unconfigured sheet url'
+    );
+
+    const nodeLabels = inDialog.getAllByText((_, el) => normalize(el?.textContent || '') === 'google sheet node uuids:');
+    expect(nodeLabels.length).toBeGreaterThan(0);
+
+    expect(inDialog.getByText('ee3d')).toBeInTheDocument();
+    expect(inDialog.getByText('cafe')).toBeInTheDocument();
 
     fireEvent.click(inDialog.getByTestId('ok-button'));
     await waitFor(() => {

--- a/src/containers/Flow/FlowList/FlowList.test.tsx
+++ b/src/containers/Flow/FlowList/FlowList.test.tsx
@@ -490,7 +490,9 @@ describe('Template flows', () => {
       'this flow contains google sheet node(s) with an invalid or unconfigured sheet url'
     );
 
-    const nodeLabels = inDialog.getAllByText((_, el) => normalize(el?.textContent || '') === 'google sheet node uuids:');
+    const nodeLabels = inDialog.getAllByText(
+      (_, el) => normalize(el?.textContent || '') === 'google sheet node uuids:'
+    );
     expect(nodeLabels.length).toBeGreaterThan(0);
 
     expect(inDialog.getByText('ee3d')).toBeInTheDocument();
@@ -549,12 +551,12 @@ describe('Template flows', () => {
     expect(inDialog.getByText(/contains google sheet node/i)).toBeInTheDocument();
 
     // Singular labels should be used when a single node uuid is present
-    const assistantLabel = inDialog.getAllByText((_, el) => normalize(el?.textContent || '') === 'assistant node uuid:');
+    const assistantLabel = inDialog.getAllByText(
+      (_, el) => normalize(el?.textContent || '') === 'assistant node uuid:'
+    );
     expect(assistantLabel.length).toBeGreaterThan(0);
 
-    const sheetLabel = inDialog.getAllByText(
-      (_, el) => normalize(el?.textContent || '') === 'google sheet node uuid:'
-    );
+    const sheetLabel = inDialog.getAllByText((_, el) => normalize(el?.textContent || '') === 'google sheet node uuid:');
     expect(sheetLabel.length).toBeGreaterThan(0);
 
     expect(inDialog.getByText('assistant-uuid-1')).toBeInTheDocument();

--- a/src/containers/Flow/FlowList/FlowList.tsx
+++ b/src/containers/Flow/FlowList/FlowList.tsx
@@ -176,35 +176,64 @@ export const FlowList = () => {
         <div className={styles.ImportDialog}>
           {importStatus.map((status: any) => {
             const assistantNodeUuids: string[] = status.assistantNodeUuids ?? [];
+            const invalidSheetNodeUuids: string[] = status.invalidSheetNodeUuids ?? [];
 
-            if (assistantNodeUuids.length > 0) {
+            if (assistantNodeUuids.length > 0 || invalidSheetNodeUuids.length > 0) {
               return (
                 <div key={status.flowName} className={styles.StatusContainer}>
-                  <p className={styles.StatusMessage}>
-                    Flow imported successfully. This flow contains assistant node(s) that need an assistant assigned.
-                    Please{' '}
-                    <a
-                      href="https://glific.github.io/docs/docs/Integrations/Filesearch%20Using%20OpenAI%20Assistants/#how-to-create-an-openai-assistant-in-glific"
-                      className={styles.HelpLink}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      create a new assistant
-                    </a>{' '}
-                    and assign it to the following node(s):
-                  </p>
-                  <div className={styles.SectionTitle}>
-                    <strong>
-                      {assistantNodeUuids.length === 1 ? 'Assistant Node UUID:' : 'Assistant Node UUIDs:'}
-                    </strong>
-                  </div>
-                  <ol className={styles.AssistantListPlain}>
-                    {assistantNodeUuids.map((uuid: string) => (
-                      <li key={uuid}>
-                        <code className={styles.AssistantCod}>{uuid}</code>
-                      </li>
-                    ))}
-                  </ol>
+                  {assistantNodeUuids.length > 0 && (
+                    <div className={styles.WarningSection}>
+                      <p className={styles.StatusMessage}>
+                        Flow imported successfully. This flow contains assistant node(s) that need an assistant
+                        assigned. Please{' '}
+                        <a
+                          href="https://glific.github.io/docs/docs/Integrations/Filesearch%20Using%20OpenAI%20Assistants/#how-to-create-an-openai-assistant-in-glific"
+                          className={styles.HelpLink}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          create a new assistant
+                        </a>{' '}
+                        and assign it to the following node(s):
+                      </p>
+                      <div className={styles.SectionTitle}>
+                        <strong>
+                          {assistantNodeUuids.length === 1 ? 'Assistant Node UUID:' : 'Assistant Node UUIDs:'}
+                        </strong>
+                      </div>
+                      <ol className={styles.AssistantListPlain}>
+                        {assistantNodeUuids.map((uuid: string) => (
+                          <li key={uuid}>
+                            <code className={styles.AssistantCod}>{uuid}</code>
+                          </li>
+                        ))}
+                      </ol>
+                    </div>
+                  )}
+
+                  {invalidSheetNodeUuids.length > 0 && (
+                    <div className={styles.WarningSection}>
+                      <p className={styles.StatusMessage}>
+                        Flow imported successfully. This flow contains Google Sheet node(s) with an invalid or
+                        unconfigured sheet URL, so they were imported without a linked sheet. Please upload and
+                        configure your Google Sheet and update the following node(s):
+                      </p>
+                      <div className={styles.SectionTitle}>
+                        <strong>
+                          {invalidSheetNodeUuids.length === 1
+                            ? 'Google Sheet Node UUID:'
+                            : 'Google Sheet Node UUIDs:'}
+                        </strong>
+                      </div>
+                      <ol className={styles.AssistantListPlain}>
+                        {invalidSheetNodeUuids.map((uuid: string) => (
+                          <li key={uuid}>
+                            <code className={styles.AssistantCod}>{uuid}</code>
+                          </li>
+                        ))}
+                      </ol>
+                    </div>
+                  )}
                 </div>
               );
             }

--- a/src/containers/Flow/FlowList/FlowList.tsx
+++ b/src/containers/Flow/FlowList/FlowList.tsx
@@ -220,9 +220,7 @@ export const FlowList = () => {
                       </p>
                       <div className={styles.SectionTitle}>
                         <strong>
-                          {invalidSheetNodeUuids.length === 1
-                            ? 'Google Sheet Node UUID:'
-                            : 'Google Sheet Node UUIDs:'}
+                          {invalidSheetNodeUuids.length === 1 ? 'Google Sheet Node UUID:' : 'Google Sheet Node UUIDs:'}
                         </strong>
                       </div>
                       <ol className={styles.AssistantListPlain}>

--- a/src/graphql/mutations/Flow.ts
+++ b/src/graphql/mutations/Flow.ts
@@ -132,6 +132,7 @@ export const IMPORT_FLOW = gql`
     importFlow(flow: $flow) {
       status {
         assistantNodeUuids
+        invalidSheetNodeUuids
         flowName
         status
       }

--- a/src/mocks/Flow.tsx
+++ b/src/mocks/Flow.tsx
@@ -503,11 +503,13 @@ export const importFlow = {
         status: [
           {
             assistantNodeUuids: [],
+            invalidSheetNodeUuids: [],
             flowName: 'Registration flow',
             status: 'Successfully imported',
           },
           {
             assistantNodeUuids: [],
+            invalidSheetNodeUuids: [],
             flowName: 'Optin',
             status: 'Successfully imported',
           },

--- a/src/mocks/Flow.tsx
+++ b/src/mocks/Flow.tsx
@@ -519,6 +519,80 @@ export const importFlow = {
   },
 };
 
+export const importFlowWithAssistantError = {
+  request: { query: IMPORT_FLOW },
+  result: {
+    data: {
+      importFlow: {
+        status: [
+          {
+            assistantNodeUuids: ['3fb647a3-c935-4906-8dd0-c0e63105ee3d', 'b1d2e9ff-1234-4abc-9876-deadbeefcafe'],
+            invalidSheetNodeUuids: [],
+            flowName: 'Test Flow',
+            status: 'Successfully imported',
+          },
+        ],
+      },
+    },
+  },
+  variableMatcher: () => true,
+};
+
+export const importFlowWithSheetError = {
+  request: { query: IMPORT_FLOW },
+  result: {
+    data: {
+      importFlow: {
+        status: [
+          {
+            assistantNodeUuids: [],
+            invalidSheetNodeUuids: ['ee3d', 'cafe'],
+            flowName: 'Test Flow',
+            status: 'Successfully imported',
+          },
+        ],
+      },
+    },
+  },
+  variableMatcher: () => true,
+};
+
+export const importFlowWithAssistantAndSheetError = {
+  request: { query: IMPORT_FLOW },
+  result: {
+    data: {
+      importFlow: {
+        status: [
+          {
+            assistantNodeUuids: ['assistant-uuid-1'],
+            invalidSheetNodeUuids: ['sheet-uuid-1'],
+            flowName: 'Test Flow',
+            status: 'Successfully imported',
+          },
+        ],
+      },
+    },
+  },
+  variableMatcher: () => true,
+};
+
+export const importFlowWithoutNodeFields = {
+  request: { query: IMPORT_FLOW },
+  result: {
+    data: {
+      importFlow: {
+        status: [
+          {
+            flowName: 'Test Flow',
+            status: 'Successfully imported',
+          },
+        ],
+      },
+    },
+  },
+  variableMatcher: () => true,
+};
+
 export const exportFlow = {
   request: {
     query: EXPORT_FLOW,


### PR DESCRIPTION
## Problem

Closes: https://github.com/glific/glific/issues/5177


Companion frontend PR for the backend change that stops flow import from crashing on an invalid/placeholder **Link Google Sheet** URL ([glific/glific#5299](https://github.com/glific/glific/pull/5299)).

The backend now returns `invalidSheetNodeUuids` on `importFlow`. This PR surfaces them to the user.

## Changes

- `IMPORT_FLOW` mutation now selects `invalidSheetNodeUuids`.
- The **Import Flow Status** dialog renders a warning listing the Google Sheet node(s) that were imported without a linked sheet, prompting the user to upload/configure their sheet and update those node(s) — mirroring the existing assistant-node warning. A node can trigger both warnings.
- CSS fixes for the dialog: warning body text is left-aligned (was centered, looked inconsistent for the multi-line message) and stacked warning sections are separated by a divider.
- Updated the import mock and added a test asserting the Google Sheet warning + node UUIDs render.

## Tests

`src/containers/Flow/FlowList/FlowList.test.tsx` — added "should display google sheet nodes with an invalid sheet url"; all 20 FlowList tests pass.


<img width="510" height="628" alt="Screenshot 2026-06-27 at 12 08 33 AM" src="https://github.com/user-attachments/assets/c2d763fb-4fd0-4ec1-af79-a9cd9094249f" />



