### PR TITLE
feat: add WhatsApp number instruction on login and registration

### DIFF
--- a/src/containers/Auth/Auth.module.css
+++ b/src/containers/Auth/Auth.module.css
@@ -338,9 +338,11 @@
   margin-bottom: 24px;
 }
 
-/* Tighter spacing when the note sits directly above the form fields (login/registration hint) */
+/* Login/registration hint: give it room below the title but sit it close to the first
+   field (the negative bottom margin offsets the field's shared 15px .Spacing). */
 .InformationTextTight {
-  margin-bottom: 4px;
+  margin-top: 28px;
+  margin-bottom: -6px;
 }
 
 .Captcha {

--- a/src/containers/Auth/Auth.module.css
+++ b/src/containers/Auth/Auth.module.css
@@ -338,6 +338,11 @@
   margin-bottom: 24px;
 }
 
+/* Tighter spacing when the note sits directly above the form fields (login/registration hint) */
+.InformationTextTight {
+  margin-bottom: 4px;
+}
+
 .Captcha {
   display: flex;
   justify-content: center;

--- a/src/containers/Auth/Auth.module.css
+++ b/src/containers/Auth/Auth.module.css
@@ -340,10 +340,10 @@
   margin-bottom: 24px;
 }
 
-/* Login/registration hint: give it room below the title but sit it close to the first
+/* Login/registration hint: sit it roughly centered between the title and the first
    field (the negative bottom margin offsets the field's shared 15px .Spacing). */
 .InformationTextTight {
-  margin-top: 24px;
+  margin-top: 4px;
   margin-bottom: -4px;
 }
 

--- a/src/containers/Auth/Auth.module.css
+++ b/src/containers/Auth/Auth.module.css
@@ -75,6 +75,7 @@
 /* Login & reset screens: center the heading + subtitle, give the (shorter) heading more size,
    and sit closer to the top of the card. */
 .LoginBox .BoxTitle,
+.RegistrationBox .BoxTitle,
 .FirstResetBox .BoxTitle,
 .SecondResetBox .BoxTitle {
   justify-content: center;
@@ -86,6 +87,7 @@
 }
 
 .LoginBox .TitleText,
+.RegistrationBox .TitleText,
 .FirstResetBox .TitleText,
 .SecondResetBox .TitleText {
   font-size: 1.9rem;
@@ -341,8 +343,8 @@
 /* Login/registration hint: give it room below the title but sit it close to the first
    field (the negative bottom margin offsets the field's shared 15px .Spacing). */
 .InformationTextTight {
-  margin-top: 28px;
-  margin-bottom: -6px;
+  margin-top: 24px;
+  margin-bottom: -4px;
 }
 
 .Captcha {

--- a/src/containers/Auth/Auth.tsx
+++ b/src/containers/Auth/Auth.tsx
@@ -195,6 +195,14 @@ export const Auth = ({
           </div>
         )}
 
+        {(mode === 'login' || mode === 'registration') && (
+          <div className={styles.InformationText} data-testid="whatsAppNumberHint">
+            {t(
+              "Use your personal WhatsApp number to log in or create your account. Do not use your chatbot's WhatsApp number."
+            )}
+          </div>
+        )}
+
         <Formik
           initialValues={initialFormValues}
           validationSchema={validationSchema}

--- a/src/containers/Auth/Auth.tsx
+++ b/src/containers/Auth/Auth.tsx
@@ -196,7 +196,7 @@ export const Auth = ({
         )}
 
         {(mode === 'login' || mode === 'registration') && (
-          <div className={styles.InformationText} data-testid="whatsAppNumberHint">
+          <div className={`${styles.InformationText} ${styles.InformationTextTight}`} data-testid="whatsAppNumberHint">
             {t(
               "Use your personal WhatsApp number to log in or create your account. Do not use your chatbot's WhatsApp number."
             )}

--- a/src/containers/Auth/Login/Login.test.tsx
+++ b/src/containers/Auth/Login/Login.test.tsx
@@ -91,6 +91,15 @@ describe('<Login />', () => {
     expect(authContainer).toHaveTextContent('Login to your account');
   });
 
+  it('shows the WhatsApp number instruction hint', async () => {
+    mockAxiosPost('success');
+    const { findByTestId } = render(wrapper(mocks));
+    const hint = await findByTestId('whatsAppNumberHint');
+    expect(hint).toHaveTextContent(
+      "Use your personal WhatsApp number to log in or create your account. Do not use your chatbot's WhatsApp number."
+    );
+  });
+
   it('test the login form submission with correct creds', async () => {
     const localStorageSpy = vi.spyOn(Storage.prototype, 'setItem');
     mockAxiosPost('success');

--- a/src/containers/Auth/Registration/Registration.test.tsx
+++ b/src/containers/Auth/Registration/Registration.test.tsx
@@ -42,6 +42,14 @@ describe('<Registration />', () => {
     });
   });
 
+  it('shows the WhatsApp number instruction hint', async () => {
+    render(wrapper);
+    const hint = await screen.findByTestId('whatsAppNumberHint');
+    expect(hint).toHaveTextContent(
+      "Use your personal WhatsApp number to log in or create your account. Do not use your chatbot's WhatsApp number."
+    );
+  });
+
   it('should check if all the fields are in correct state', async () => {
     const user = userEvent.setup();
     const { container } = render(wrapper);

--- a/src/i18n/en/en.json
+++ b/src/i18n/en/en.json
@@ -20,6 +20,7 @@
   "An OTP was just sent. Please try again in 30 seconds.": "An OTP was just sent. Please try again in 30 seconds.",
   "We are unable to register, kindly contact your technical team.": "We are unable to register, kindly contact your technical team.",
   "Create your new account": "Create your new account",
+  "Use your personal WhatsApp number to log in or create your account. Do not use your chatbot's WhatsApp number.": "Use your personal WhatsApp number to log in or create your account. Do not use your chatbot's WhatsApp number.",
   "Continue": "Continue",
   "Your phone number": "Your phone number",
   "Please enter a phone number.": "Please enter a phone number.",

--- a/src/i18n/hi/hi.json
+++ b/src/i18n/hi/hi.json
@@ -279,6 +279,7 @@
   "We are unable to generate an OTP, kindly contact your technical team.": "हम एक ओटीपी उत्पन्न करने में असमर्थ हैं, कृपया अपनी तकनीकी टीम से संपर्क करें।",
   "We are unable to register, kindly contact your technical team.": "हम पंजीकृत नहीं हो पा रहे हैं, कृपया अपनी तकनीकी टीम से संपर्क करें।",
   "Create your new account": "अपना नया खाता बनाएँ",
+  "Use your personal WhatsApp number to log in or create your account. Do not use your chatbot's WhatsApp number.": "लॉगइन करने या अपना खाता बनाने के लिए अपने निजी व्हाट्सएप नंबर का उपयोग करें। अपने चैटबॉट के व्हाट्सएप नंबर का उपयोग न करें।",
   "Your phone number": "आपका फोन नंबर",
   "Please enter a phone number.": "कृपया फ़ोन नंबर दर्ज करें।",
   "Password": "पासवर्ड",


### PR DESCRIPTION
## What
Adds a short instruction on the **Login** and **Create Account** screens:

> Use your personal WhatsApp number to log in or create your account. Do not use your chatbot's WhatsApp number.

Closes #4010.

## Summary by CodeRabbit

* **New Features**
  * Added a helpful WhatsApp number hint on the login and registration screens.
  * The message tells users to use a personal WhatsApp number instead of a chatbot number.

* **Tests**
  * Added coverage to confirm the hint appears on both login and registration flows.

* **Documentation**
  * Added a new English translation for the WhatsApp number instruction.
<img width="536" height="560" alt="Screenshot 2026-07-06 at 5 16 36 PM" src="https://github.com/user-attachments/assets/79599766-9375-40d0-a714-c49527eaced3" />

