### PR TITLE
fix: update WA_GROUP_MEMBERS_SAMPLE link and improve status message 

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -54,7 +54,7 @@ export const DISCORD_URL = 'https://discord.gg/kyqsZAJEPK';
 export const UPLOAD_CONTACTS_SAMPLE = 'https://storage.googleapis.com/cc-tides/sample_contacts_import.csv';
 export const UPLOAD_CONTACTS_ADMIN_SAMPLE = 'https://storage.googleapis.com/cc-tides/sample_import_admin.csv';
 export const WA_GROUP_MEMBERS_SAMPLE =
-  'https://docs.google.com/spreadsheets/d/1sjGaZyVzK1FGAN4j_YHSRvl1JBX_Pg3n8yhMSJAT6bk/edit?usp=sharing';
+  'https://docs.google.com/spreadsheets/d/1-oupACzXqNWURa9nUv0rvpLrBNRTMRMN5EG-mY3zCvg/copy';
 
 export const REGISTRATION_HELP_LINK =
   'https://glific.slab.com/public/posts/02-managing-staff-members-creating-account-on-glific-gg6fkw8h';

--- a/src/containers/Chat/ChatMessages/StatusBar/StatusBar.tsx
+++ b/src/containers/Chat/ChatMessages/StatusBar/StatusBar.tsx
@@ -20,28 +20,28 @@ const StatusBar = () => {
 
   const { data } = useQuery(GET_WA_MANAGED_PHONES_STATUS);
   const hasInactivePhone = data?.waManagedPhones?.some((phone: any) => phone.status !== 'active');
+  const isOnGroupPage = location.pathname.includes('group');
 
   if (!balanceData && !orgStatus) {
     return null;
   }
 
+  const balance = balanceData ? JSON.parse(balanceData.bspbalance).balance : null;
+
   let statusMessage;
 
-  if (orgStatus && orgStatus.organization.organization.isSuspended) {
+  if (orgStatus?.organization?.organization?.isSuspended) {
     statusMessage =
       'You have reached today’s rate limit for sending HSM templates to your users. Your rate limit will be refreshed tomorrow. Please check again later.';
-  } else if (balanceData) {
-    const { balance } = JSON.parse(balanceData.bspbalance);
-    if (balance < 1 && balance > 0) {
-      statusMessage =
-        'Please recharge your Gupshup wallet immediately to continue sending messages. Users will not receive the messages that get stuck during this time.';
-    } else if (balance <= 0) {
-      statusMessage =
-        'All the outgoing messages have been suspended. Please note: on recharging, the messages that were stuck will not be sent.';
-    } else if (hasInactivePhone && location.pathname.includes('group')) {
-      statusMessage =
-        'One or more of your phones are not active. Please check the Maytapi console to ensure smooth message delivery.';
-    }
+  } else if (balance !== null && balance > 0 && balance < 1) {
+    statusMessage =
+      'Please recharge your Gupshup wallet immediately to continue sending messages. Users will not receive the messages that get stuck during this time.';
+  } else if (balance !== null && balance <= 0) {
+    statusMessage =
+      'All the outgoing messages have been suspended. Please note: on recharging, the messages that were stuck will not be sent.';
+  } else if (hasInactivePhone && isOnGroupPage) {
+    statusMessage =
+      'One or more of your phones are not active. Please check the Maytapi console to ensure smooth message delivery.';
   }
 
   if (statusMessage) {


### PR DESCRIPTION
## What & why

Two small feedback fixes for the multi-number WhatsApp groups work:

1. **Sample sheet link** — `WA_GROUP_MEMBERS_SAMPLE` pointed at an `…/edit?usp=sharing`
   URL, so users opened the shared master sheet instead of getting their own. Switched
   to a `…/copy` template link that forces a "Make a copy" of a fresh sheet.

2. **StatusBar message logic** — the banner logic was nested inside `if (balanceData)`,
   so the "one or more phones are not active" warning only showed when balance data
   happened to be present, and the branching was hard to follow.

## Changes

- `config/index.ts` — update `WA_GROUP_MEMBERS_SAMPLE` to the `/copy` template URL.
- `StatusBar.tsx`:
  - Hoisted the `balance` parse out of the branch and flattened the nested `if`s into
    a single top-level `else if` chain, so each condition is independent.
  - Added `isOnGroupPage` for readability.
  - Used optional chaining for the suspended check (`orgStatus?.organization?.organization?.isSuspended`)
    and explicit `balance !== null` guards.
  - The inactive-phone warning now evaluates independently of `balanceData`, so it shows
    on the group pages whenever a phone is inactive.

