### PR TITLE
fix: adjust LanguageBar position to account for notification bar height

### DIFF
--- a/src/components/UI/LanguageBar/LanguageBar.module.css
+++ b/src/components/UI/LanguageBar/LanguageBar.module.css
@@ -1,6 +1,6 @@
 .LanguageWrapper {
   position: fixed;
-  top: 32px;
+  top: calc(32px + var(--notification-bar-height, 0px));
   right: 24px;
   z-index: 1000;
   max-width: 500px;

--- a/src/components/simulator/Simulator.module.css
+++ b/src/components/simulator/Simulator.module.css
@@ -111,7 +111,7 @@
 .SimContainer {
   position: fixed;
   right: 20px;
-  top: 100px;
+  top: calc(100px + var(--notification-bar-height, 0px));
   z-index: 10000;
 }
 

--- a/src/containers/InteractiveMessage/InteractiveMessage.module.css
+++ b/src/containers/InteractiveMessage/InteractiveMessage.module.css
@@ -9,7 +9,7 @@
 }
 
 .Simulator > div {
-  top: 200px !important;
+  top: calc(180px + var(--notification-bar-height, 0px)) !important;
 }
 
 .DialogContent {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the language bar’s position to prevent overlap with the notification bar.
  * The language bar now shifts automatically when a notification bar is displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->