### PR TITLE
feat: enhance language handling in HSMV2 component and improve their state

### DIFF
--- a/src/containers/HSM/HSMV2/HSMV2.test.tsx
+++ b/src/containers/HSM/HSMV2/HSMV2.test.tsx
@@ -1014,7 +1014,7 @@ describe('HSMV2 language versions', () => {
       expect(screen.getByTestId('auto-translate-button')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByTestId('view-language-1'));
+    fireEvent.click(await screen.findByTestId('view-language-1'));
 
     await waitFor(() => {
       expect(screen.queryByTestId('auto-translate-button')).not.toBeInTheDocument();

--- a/src/containers/HSM/HSMV2/HSMV2.test.tsx
+++ b/src/containers/HSM/HSMV2/HSMV2.test.tsx
@@ -6,6 +6,7 @@ import { HSMV2 } from './HSMV2';
 import {
   HSM_TEMPLATE_MOCKS,
   getHSMTemplateTypeText,
+  getHSMTemplateNullLanguage,
   getHSMTemplateTypeMedia,
   CREATE_SESSION_TEMPLATE_MOCK,
   templateEditMock,
@@ -1022,6 +1023,33 @@ describe('HSMV2 language versions', () => {
     await waitFor(() => {
       expect(screen.getByDisplayValue('English')).toBeInTheDocument();
     });
+  });
+
+  test('viewing a template whose fetched data has no language still loads its other details and leaves the Language field unset', async () => {
+    const MOCKS = [
+      ...mocks,
+      getHSMTemplateNullLanguage,
+      getHSMTemplateNullLanguage,
+      familyFetchMock([familyVariants[0]]),
+    ];
+    render(
+      <MockedProvider mocks={MOCKS} addTypename={false}>
+        <MemoryRouter initialEntries={['/templates/1/edit']}>
+          <Routes>
+            <Route path="/templates/:id/edit" element={<HSMV2 />} />
+          </Routes>
+        </MemoryRouter>
+      </MockedProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('view-language-1')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId('view-language-1'));
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('account_balance')).toBeInTheDocument();
+    });
+    expect(screen.queryByDisplayValue('English')).not.toBeInTheDocument();
   });
 
   test('"Add new language" prefills the draft from the anchor template and unlocks the Language field', async () => {

--- a/src/containers/HSM/HSMV2/HSMV2.test.tsx
+++ b/src/containers/HSM/HSMV2/HSMV2.test.tsx
@@ -981,6 +981,49 @@ describe('HSMV2 language versions', () => {
     expect(screen.getByTestId('view-language-3')).toBeInTheDocument();
   });
 
+  test('viewing a language version from the auto-opened add-language flow shows it read-only, not as an editable draft', async () => {
+    const anchorOnly = [familyVariants[0]];
+    const MOCKS = [
+      ...mocks,
+      ...mocks,
+      ...WHATSAPP_FORM_MOCKS,
+      getHSMTemplateTypeText,
+      getHSMTemplateTypeText,
+      familyFetchMock(anchorOnly),
+      familyFetchMock(anchorOnly),
+    ];
+    render(
+      <MockedProvider mocks={MOCKS} addTypename={false}>
+        <MemoryRouter
+          initialEntries={[
+            {
+              pathname: '/add',
+              state: { languageAnchorId: '1', anchorShortcode: 'account_balance', openAddLanguage: true },
+            },
+          ]}
+        >
+          <Routes>
+            <Route path="/add" element={<HSMV2 />} />
+          </Routes>
+        </MemoryRouter>
+      </MockedProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auto-translate-button')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('view-language-1'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('auto-translate-button')).not.toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('English')).toBeInTheDocument();
+    });
+  });
+
   test('"Add new language" prefills the draft from the anchor template and unlocks the Language field', async () => {
     // only the anchor itself here (not familyVariants' PENDING Hindi/Marathi
     // row) — excludeLanguageIds is now derived from the family list, so
@@ -1065,6 +1108,43 @@ describe('HSMV2 language versions', () => {
     // the draft footer input itself starts empty — only the chip shows the
     // anchor's English value.
     expect(screen.queryByDisplayValue('footer')).not.toBeInTheDocument();
+  });
+
+  test('keeps the English source reference after clicking "Add new language" a second time', async () => {
+    const anchorOnly = [familyVariants[0]];
+    const MOCKS = [...mocks, ...WHATSAPP_FORM_MOCKS, getHSMTemplateTypeText, familyFetchMock(anchorOnly)];
+    render(
+      <MockedProvider mocks={MOCKS} addTypename={false}>
+        <MemoryRouter
+          initialEntries={[{ pathname: '/add', state: { languageAnchorId: '1', anchorShortcode: 'account_balance' } }]}
+        >
+          <Routes>
+            <Route path="/add" element={<HSMV2 />} />
+          </Routes>
+        </MemoryRouter>
+      </MockedProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('add-language-link')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('add-language-link'));
+    await waitFor(() => {
+      expect(screen.getByTestId('source-reference-card')).toBeInTheDocument();
+    });
+    expect(
+      within(screen.getByTestId('source-reference-card')).getByText(/You can now view your Account Balance/)
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('add-language-link'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('source-reference-card')).toBeInTheDocument();
+    });
+    expect(
+      within(screen.getByTestId('source-reference-card')).getByText(/You can now view your Account Balance/)
+    ).toBeInTheDocument();
   });
 
   test("shows the anchor's English button text as a reference in the Interactive Buttons section", async () => {

--- a/src/containers/HSM/HSMV2/HSMV2.tsx
+++ b/src/containers/HSM/HSMV2/HSMV2.tsx
@@ -287,9 +287,9 @@ export const HSMV2 = () => {
     buttons,
     hasButtons,
   }: any) => {
-    if (languageOptions.length > 0 && languageIdValue) {
+    if (languageIdValue) {
       const selectedLanguage = languageOptions.find((lang: any) => lang.id === languageIdValue.id);
-      setLanguageId(selectedLanguage || null);
+      setLanguageId(selectedLanguage || languageIdValue);
     }
 
     if (mode !== 'copy') {
@@ -432,7 +432,7 @@ export const HSMV2 = () => {
     setMode('addLanguage');
     setAddPagePreviewId(null);
     setLanguageId(null);
-    setAnchorReference({ body, footer, buttons: templateButtons, buttonType: templateType?.id });
+    setAnchorReference((prev) => prev ?? { body, footer, buttons: templateButtons, buttonType: templateType?.id });
 
     setBody('');
     setEditorState('');
@@ -711,10 +711,10 @@ export const HSMV2 = () => {
   }, [location.state?.autoExpandId, params.id]);
 
   useEffect(() => {
-    if (location.state?.openAddLanguage && mode === 'view' && newShortcode) {
+    if (location.state?.openAddLanguage && mode === 'view' && newShortcode && !anchorReference) {
       openAddLanguage();
     }
-  }, [location.state?.openAddLanguage, mode, newShortcode]);
+  }, [location.state?.openAddLanguage, mode, newShortcode, anchorReference]);
 
   useEffect(() => {
     if (needsFamilyFetch && familyFetchData?.sessionTemplates) {

--- a/src/mocks/Template.tsx
+++ b/src/mocks/Template.tsx
@@ -282,6 +282,21 @@ export const getHSMTemplateTypeText = {
   },
 };
 
+export const getHSMTemplateNullLanguage = {
+  ...getHSMTemplateTypeText,
+  result: {
+    data: {
+      sessionTemplate: {
+        ...getTemplateDataTypeText.sessionTemplate,
+        sessionTemplate: {
+          ...getTemplateDataTypeText.sessionTemplate.sessionTemplate,
+          language: null,
+        },
+      },
+    },
+  },
+};
+
 export const getHSMTemplateTypeMedia = {
   request: {
     query: GET_TEMPLATE,


### PR DESCRIPTION


## Summary

* **Bug Fixes**
  * Improved handling of selected language when opening/restoring template state.
  * Preserved the existing source language reference when repeatedly reopening “Add new language.”
  * Ensured anchor language versions open in a read-only state with the correct draft content.
  * When template data contains no language, the language UI stays unset while the rest of the content loads.
