### PR TITLE
fix: prevent crash when opening AUTHENTICATION/OTP HSM templates

### DIFF
--- a/cypress/e2e/trigger/Trigger.spec.ts
+++ b/cypress/e2e/trigger/Trigger.spec.ts
@@ -3,6 +3,17 @@ export const selectFromInput = (elementPosition, optionPosition) => {
   cy.get('.MuiAutocomplete-option').eq(optionPosition).click();
 };
 
+const typeDate = (wrapperIndex: number, date: Date) => {
+  const wrapper = () => cy.get('[data-testid="date-picker-inline"]').eq(wrapperIndex);
+
+  wrapper()
+    .find('[aria-label="Month"]')
+    .click()
+    .type(String(date.getMonth() + 1).padStart(2, '0'));
+  wrapper().find('[aria-label="Day"]').type(String(date.getDate()).padStart(2, '0'));
+  wrapper().find('[aria-label="Year"]').type(String(date.getFullYear()));
+};
+
 describe('Triggers (daily) ', () => {
   beforeEach(function () {
     // login before each test
@@ -17,21 +28,16 @@ describe('Triggers (daily) ', () => {
     // select first flow from list
     selectFromInput(0, 0);
 
-    cy.get('[data-testid="date-picker-inline"]').eq(0).click();
+    // start date: tomorrow, so it's always ahead of "now" regardless of what time gets picked
+    const startDate = new Date();
+    startDate.setDate(startDate.getDate() + 1);
+    typeDate(0, startDate);
 
-    cy.get('button[title="Next month"]').first().click();
+    // end date: well after the start date
+    const endDate = new Date(startDate);
+    endDate.setDate(endDate.getDate() + 60);
+    typeDate(1, endDate);
 
-    cy.get('button.MuiPickersDay-root').last().click();
-
-    cy.get('[data-testid="date-picker-inline"]').eq(1).click();
-
-    cy.get('button[title="Next month"]').first().click();
-    cy.get('button[title="Next month"]').first().click();
-    cy.get('button[title="Next month"]').first().click();
-
-    cy.get('button.MuiPickersDay-root').first().click();
-
-    //select start time
     cy.get('[data-testid="time-picker"]').eq(0).click();
     cy.get('li[role="option"]').first().click();
 

--- a/src/containers/HSM/HSM.helper.tsx
+++ b/src/containers/HSM/HSM.helper.tsx
@@ -64,7 +64,7 @@ export const convertButtonsToTemplate = (templateButtons: Array<any>, templateTy
  */
 export const getTemplateAndButtons = (templateType: string, message: string, buttons: string) => {
   const templateButtons = JSON.parse(buttons);
-  let result: any;
+  let result: any = [];
   if (templateType === CALL_TO_ACTION) {
     // stored buttons use Gupshup's uppercase type convention (PHONE_NUMBER/URL);
     // the rest of the UI (chip options, typeObj in getButtonTemplatePayload) expects lowercase

--- a/src/containers/HSM/HSM.test.tsx
+++ b/src/containers/HSM/HSM.test.tsx
@@ -3,7 +3,7 @@ import { MockedProvider } from '@apollo/client/testing';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { HSM } from './HSM';
-import { getVariables, getExampleFromBody } from './HSM.helper';
+import { getVariables, getExampleFromBody, getTemplateAndButtons } from './HSM.helper';
 import {
   HSM_TEMPLATE_MOCKS,
   getHSMTemplateTypeMedia,
@@ -614,6 +614,17 @@ describe('Add mode', () => {
     await waitFor(() => {
       expect(setNotification).toHaveBeenCalled();
     });
+  });
+
+  test('does not crash and returns no buttons for an AUTHENTICATION/OTP template, whose buttonType the UI does not support', () => {
+    const body = '*{{1}}* is your verification code. For your security, do not share this code. ';
+    const buttons = JSON.stringify([
+      { url: 'https://www.whatsapp.com/otp/code/?otp_type=COPY_CODE&code=otp{{1}}', type: 'URL', text: 'Copy OTP' },
+    ]);
+
+    const result = getTemplateAndButtons('OTP', body, buttons);
+
+    expect(result).toEqual({ buttons: [], template: `${body} | ` });
   });
 });
 


### PR DESCRIPTION
## Summary
Opening a WhatsApp AUTHENTICATION (OTP) template, e.g. `verify_otp`, crashed the HSM edit page with `TypeError: Cannot read properties of undefined (reading 'reduce')`.

`getTemplateAndButtons` (`HSM.helper.tsx`) only assigns its `result` variable when `templateType` is `CALL_TO_ACTION`, `QUICK_REPLY`, or `WHATSAPP_FORM`. OTP templates report `buttonType: 'OTP'`, which matches none of these, so `result` stayed `undefined` and was passed into `convertButtonsToTemplate`, which immediately calls `.reduce` on it.

###  Fix
Initialize `result` to `[]` instead of leaving it unassigned, so any button type the UI doesn't support degrades gracefully — no buttons rendered — instead of throwing. The downstream `TemplateOptionsV2` component already no-ops when `templateType` doesn't resolve to a known `BUTTON_OPTIONS` entry, so the rest of the template (body, footer, category, etc.) still loads and renders correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved template initialization stability
  
* **Tests**
  * Expanded test coverage for OTP authentication templates
  * Enhanced automated testing for date selection in trigger workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->