### PR TITLE
fix: increase wait time in smoke test and refactor smoke test

### DIFF
--- a/cypress/e2e/smoke.spec.ts
+++ b/cypress/e2e/smoke.spec.ts
@@ -14,33 +14,30 @@ describe('Flow smoke test', () => {
       cy.get('[data-testid="tableBody"]').find('a').first().click();
       cy.get('[data-testid="previewButton"]').click();
       cy.get('[data-testid="simulatedMessages"]').should('be.visible');
-      cy.wait(30000);
+      cy.wait(120000);
       cy.get('[data-testid="simulatedMessages"]')
         .find('[data-testid="simulatorMessage"]')
         .then(($messages) => {
-          const lastThree = $messages.slice(-3);
+          const today = new Date();
+          const d = String(today.getDate()).padStart(2, '0');
+          const mm = String(today.getMonth() + 1).padStart(2, '0');
+          const yyyy = today.getFullYear();
+          const formattedDate = `${d}-${mm}-${yyyy}`;
 
+          const lastThree = $messages.toArray().slice(-3);
           cy.wrap(lastThree[0]).within(() => {
             cy.get('audio').should('not.exist');
-            const today = new Date();
-            const d = String(today.getDate());
-            const mm = String(today.getMonth() + 1).padStart(2, '0');
-            const yyyy = today.getFullYear();
-            const formattedDate = `${d}/${mm}/${yyyy}`;
-            cy.get('span').first().should('have.text', `Hello World! ${formattedDate}`);
+            cy.root().invoke('text').should('not.be.empty');
           });
+
           cy.wrap(lastThree[1]).within(() => {
-            cy.get('audio').should('not.exist');
-            cy.get('span')
-              .first()
-              .invoke('text')
-              .should((text) => {
-                expect(text.toLowerCase()).to.include('elephant');
-              });
+            cy.get('[data-testid="audioMessage"]').should('exist');
           });
 
           cy.wrap(lastThree[2]).within(() => {
-            cy.get('[data-testid="audioMessage"]').should('exist');
+            cy.get('audio').should('not.exist');
+            cy.contains('Test Finished').should('be.visible');
+            cy.contains(formattedDate).should('be.visible');
           });
         });
     });

--- a/cypress/e2e/smoke.spec.ts
+++ b/cypress/e2e/smoke.spec.ts
@@ -14,7 +14,7 @@ describe('Flow smoke test', () => {
       cy.get('[data-testid="tableBody"]').find('a').first().click();
       cy.get('[data-testid="previewButton"]').click();
       cy.get('[data-testid="simulatedMessages"]').should('be.visible');
-      cy.wait(120000);
+      cy.wait(60000);
       cy.get('[data-testid="simulatedMessages"]')
         .find('[data-testid="simulatorMessage"]')
         .then(($messages) => {
@@ -27,7 +27,7 @@ describe('Flow smoke test', () => {
           const lastThree = $messages.toArray().slice(-3);
           cy.wrap(lastThree[0]).within(() => {
             cy.get('audio').should('not.exist');
-            cy.root().invoke('text').should('not.be.empty');
+            cy.root().invoke('text').should('match', /\S/);
           });
 
           cy.wrap(lastThree[1]).within(() => {


### PR DESCRIPTION
## Summary

- The smoke test's cy.wait(30000) wasn't giving the smoke-test-dont-modify flow enough time to finish its full GPT joke → text-to-speech → speech-to-text → "Test Finished" cycle before assertions ran, causing the last-3-messages check to catch the flow mid-run and fail inconsistently. Increased the wait to 60000 (1 min) so the run completes before we inspect messages.
- Updated the final-message assertions to match the flow's actual completed output: a non-empty transcript-text message, followed by an audio message, followed by a "Test Finished - <date>" message — replacing the old hardcoded "Hello World! <date>" / "elephant" checks, which no longer match what the flow sends.
- Refactored date formatting to zero-pad the day and use DD-MM-YYYY (matching the flow's Calendar.strftime("%d-%m-%Y %H:%M") output) instead of the previous unpadded D/MM/YYYY format.
- Switched $messages.slice(-3) to $messages.toArray().slice(-3) so array methods work reliably on the jQuery collection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated smoke test coverage to validate the simulator’s final messages.
  * Added checks for message text, audio presence, completion status, and the current date format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->