### PR TITLE
feat: allow Manager+ (not just Admin) to reconnect phones and set collection primary

### DIFF
--- a/src/containers/WaGroups/GroupCollections/SetCollectionPrimaryPhone/SetCollectionPrimaryPhone.test.tsx
+++ b/src/containers/WaGroups/GroupCollections/SetCollectionPrimaryPhone/SetCollectionPrimaryPhone.test.tsx
@@ -20,7 +20,12 @@ vi.mock('common/notification', async (importOriginal) => {
 });
 
 const mockRole = vi.hoisted(() => ({ value: ['Admin'] }));
-vi.mock('context/role', () => ({ getUserRole: () => mockRole.value }));
+const isManager = () =>
+  mockRole.value.includes('Admin') || mockRole.value.includes('Glific_admin') || mockRole.value.includes('Manager');
+vi.mock('context/role', () => ({
+  getUserRole: () => mockRole.value,
+  isManagerRole: () => isManager(),
+}));
 
 const renderComponent = (mocks: any[] = [phonesMock]) =>
   render(
@@ -50,10 +55,16 @@ const selectPhoneAndApply = async () => {
   fireEvent.click(screen.getByTestId('ok-button'));
 };
 
-test('hides the action for non-admin users', () => {
+test('hides the action for staff users', () => {
   mockRole.value = ['Staff'];
   renderComponent();
   expect(screen.queryByTestId('setCollectionPrimaryBtn')).not.toBeInTheDocument();
+});
+
+test('shows the action for manager users', () => {
+  mockRole.value = ['Manager'];
+  renderComponent();
+  expect(screen.getByTestId('setCollectionPrimaryBtn')).toBeInTheDocument();
 });
 
 test('shows the action for Glific_admin users', () => {

--- a/src/containers/WaGroups/GroupCollections/SetCollectionPrimaryPhone/SetCollectionPrimaryPhone.tsx
+++ b/src/containers/WaGroups/GroupCollections/SetCollectionPrimaryPhone/SetCollectionPrimaryPhone.tsx
@@ -6,7 +6,7 @@ import { Button } from 'components/UI/Form/Button/Button';
 import { DialogBox } from 'components/UI/DialogBox/DialogBox';
 import { AutoComplete } from 'components/UI/Form/AutoComplete/AutoComplete';
 import { setErrorMessage, setNotification } from 'common/notification';
-import { getUserRole } from 'context/role';
+import { isManagerRole } from 'context/role';
 import { GET_WA_MANAGED_PHONES } from 'graphql/queries/WaGroups';
 import { SET_PRIMARY_PHONE_FOR_COLLECTION } from 'graphql/mutations/Group';
 import { toActivePhoneOptions } from 'containers/WaGroups/managedPhones';
@@ -16,22 +16,21 @@ export interface SetCollectionPrimaryPhoneProps {
 }
 
 /**
- * Admin action on a WhatsApp-group collection: pick one managed phone and make it
- * the primary across every group in the collection in one bulk call. The backend
- * runs it in the background and reports skipped groups via a notification.
+ * Manager-and-above action on a WhatsApp-group collection: pick one managed phone
+ * and make it the primary across every group in the collection in one bulk call.
+ * The backend runs it in the background and reports skipped groups via a notification.
  */
 export const SetCollectionPrimaryPhone = ({ collectionId }: SetCollectionPrimaryPhoneProps) => {
   const { t } = useTranslation();
   const [open, setOpen] = useState(false);
   const [selectedPhone, setSelectedPhone] = useState<{ id: string; label: string } | null>(null);
 
-  // Only Admin / Glific_admin can drive the collection-wide primary phone.
-  const roles = getUserRole();
-  const isAdmin = roles.includes('Admin') || roles.includes('Glific_admin');
+  // Managers and above can drive the collection-wide primary phone.
+  const canManage = isManagerRole();
 
   const { data } = useQuery(GET_WA_MANAGED_PHONES, {
     variables: { filter: {} },
-    skip: !isAdmin || !open,
+    skip: !canManage || !open,
   });
 
   const phoneOptions = toActivePhoneOptions(data?.waManagedPhones);
@@ -73,7 +72,7 @@ export const SetCollectionPrimaryPhone = ({ collectionId }: SetCollectionPrimary
     }
   };
 
-  if (!isAdmin) return null;
+  if (!canManage) return null;
 
   return (
     <>

--- a/src/containers/WaGroups/PhoneManagement/PhoneManagement.test.tsx
+++ b/src/containers/WaGroups/PhoneManagement/PhoneManagement.test.tsx
@@ -63,7 +63,18 @@ test('shows Reconnect only for a non-active phone (admin)', async () => {
   expect(screen.getAllByTestId('reconnectIcon')).toHaveLength(1);
 });
 
-test('hides Reconnect for non-admins', async () => {
+test('shows Reconnect for managers (not admin-only)', async () => {
+  mockRole.value = ['Manager'];
+  renderPage();
+
+  await waitFor(() => {
+    expect(screen.getByText('918416933261')).toBeInTheDocument();
+  });
+
+  expect(screen.getAllByTestId('reconnectIcon')).toHaveLength(1);
+});
+
+test('hides Reconnect for staff', async () => {
   mockRole.value = ['Staff'];
   renderPage();
 

--- a/src/containers/WaGroups/PhoneManagement/PhoneManagement.tsx
+++ b/src/containers/WaGroups/PhoneManagement/PhoneManagement.tsx
@@ -6,7 +6,7 @@ import QrCode2Icon from '@mui/icons-material/QrCode2';
 import SyncIcon from '@mui/icons-material/Sync';
 
 import { List } from 'containers/List/List';
-import { isAdminRole, isManagerRole } from 'context/role';
+import { isManagerRole } from 'context/role';
 import { setErrorMessage, setNotification } from 'common/notification';
 import { GET_WA_MANAGED_PHONES, GET_WA_MANAGED_PHONES_COUNT } from 'graphql/queries/WaGroups';
 import { SYNC_WA_MANAGED_PHONE_STATUSES } from 'graphql/mutations/Group';
@@ -46,8 +46,8 @@ interface ManagedPhone {
 
 export const PhoneManagement = () => {
   const { t } = useTranslation();
-  const isAdmin = isAdminRole();
-  const canSync = isManagerRole();
+
+  const canManage = isManagerRole();
 
   const [reconnectPhone, setReconnectPhone] = useState<ManagedPhone | null>(null);
   const [refreshList, setRefreshList] = useState(false);
@@ -108,15 +108,15 @@ export const PhoneManagement = () => {
     columnStyles,
   };
 
-  // Reconnect is admin-only and only offered when the phone is not active
-  // (an active phone has nothing to reconnect).
+  // Reconnect is manager-and-above only and only offered when the phone is not
+  // active (an active phone has nothing to reconnect).
   const additionalAction = (phone: ManagedPhone) => [
     {
       icon: <QrCode2Icon data-testid="reconnectIcon" />,
       parameter: 'id',
       label: t('Reconnect'),
       dialog: (_id: string, item: ManagedPhone) => setReconnectPhone(item),
-      hidden: !isAdmin || phone.status === 'active',
+      hidden: !canManage || phone.status === 'active',
     },
   ];
 
@@ -129,7 +129,7 @@ export const PhoneManagement = () => {
         pageLink="group/phones"
         searchParameter={['phone']}
         button={
-          canSync
+          canManage
             ? { show: true, label: t('Sync statuses'), action: handleSync, symbol: <SyncIcon /> }
             : { show: false }
         }


### PR DESCRIPTION
Widen access for the multiple-numbers (Maytapi) WhatsApp-group actions from **Admin-only** to **Manager and above** (`Manager` / `Admin` / `Glific_admin`):

- **Reconnect a phone** — `PhoneManagement` (WhatsApp Phones page)
- **Set primary phone for a collection** — `SetCollectionPrimaryPhone` (Group Collections)