### PR TITLE
feat: open analytics page to all roles and remove supersetEnabled flag

### DIFF
--- a/src/components/UI/Layout/Navigation/SideDrawer/SideDrawer.test.tsx
+++ b/src/components/UI/Layout/Navigation/SideDrawer/SideDrawer.test.tsx
@@ -70,6 +70,19 @@ describe('side drawer testing', () => {
     });
   });
 
+  describe('Data Analytics menu visibility', () => {
+    const getAnalyticsMenu = (role: string) => getMenus('sideDrawer', role).find((m) => m.title === 'Data Analytics');
+
+    afterEach(() => {
+      localStorage.removeItem('organizationServices');
+    });
+
+    it.each(['Staff', 'Manager', 'Admin', 'Glific_admin', 'Dynamic'])('shows the menu item for %s role', (role) => {
+      setOrganizationServices(JSON.stringify({}));
+      expect(getAnalyticsMenu(role)?.path).toBe('/analytics');
+    });
+  });
+
   it('it should render component in normal mode', async () => {
     const { getByTestId } = render(
       <MockedProvider mocks={mocks}>

--- a/src/config/menu.ts
+++ b/src/config/menu.ts
@@ -215,18 +215,14 @@ const menus = (): Menu[] => [
           roles: allRoles,
         },
       ]),
-  ...(getOrganizationServices('supersetEnabled')
-    ? [
-        {
-          title: 'Data Analytics',
-          path: '/analytics',
-          icon: 'analytics',
-          type: 'sideDrawer',
-          new: true,
-          roles: managerLevel,
-        },
-      ]
-    : []),
+  {
+    title: 'Data Analytics',
+    path: '/analytics',
+    icon: 'analytics',
+    type: 'sideDrawer',
+    new: true,
+    roles: allRoles,
+  },
   {
     title: 'Manage',
     path: '/collection',

--- a/src/graphql/queries/Organization.ts
+++ b/src/graphql/queries/Organization.ts
@@ -140,7 +140,6 @@ export const GET_ORGANIZATION_SERVICES = gql`
       aiEvaluationsEnabled
       copyNodeEnabled
       promptGeneratorEnabled
-      supersetEnabled
       templateV2Enabled
     }
   }

--- a/src/routes/AuthenticatedRoute/AuthenticatedRoute.test.tsx
+++ b/src/routes/AuthenticatedRoute/AuthenticatedRoute.test.tsx
@@ -117,18 +117,11 @@ describe('<AuthenticatedRoute />', () => {
       });
     }
   );
+
   test('renders the legacy HSMList at /template when templateV2Enabled is off', async () => {
     setUserSession(JSON.stringify({ organization: { id: '1' }, roles: ['Admin'] }));
     setOrganizationServices(JSON.stringify({ templateV2Enabled: false }));
-    render(
-      <MockedProvider mocks={mocks}>
-        <MemoryRouter initialEntries={['/template']}>
-          <Suspense fallback={<Loading />}>
-            <AuthenticatedRoute />
-          </Suspense>
-        </MemoryRouter>
-      </MockedProvider>
-    );
+    renderAuthenticatedRoute({ initialEntries: ['/template'] });
 
     await waitFor(() => {
       expect(screen.getByTestId('hsm-list-old')).toBeInTheDocument();
@@ -138,15 +131,7 @@ describe('<AuthenticatedRoute />', () => {
   test('renders HSMListV2 at /template when templateV2Enabled is on', async () => {
     setUserSession(JSON.stringify({ organization: { id: '1' }, roles: ['Admin'] }));
     setOrganizationServices(JSON.stringify({ templateV2Enabled: true }));
-    render(
-      <MockedProvider mocks={mocks}>
-        <MemoryRouter initialEntries={['/template']}>
-          <Suspense fallback={<Loading />}>
-            <AuthenticatedRoute />
-          </Suspense>
-        </MemoryRouter>
-      </MockedProvider>
-    );
+    renderAuthenticatedRoute({ initialEntries: ['/template'] });
 
     await waitFor(() => {
       expect(screen.getByTestId('hsm-list-new')).toBeInTheDocument();

--- a/src/routes/AuthenticatedRoute/AuthenticatedRoute.test.tsx
+++ b/src/routes/AuthenticatedRoute/AuthenticatedRoute.test.tsx
@@ -33,6 +33,10 @@ vi.mock('containers/Assistants/AssistantDetail/AssistantDetail', () => ({
   default: () => <div data-testid="assistant-detail-new" />,
 }));
 
+vi.mock('containers/Analytics/Analytics', () => ({
+  default: () => <div data-testid="analytics-page" />,
+}));
+
 const mocks = [
   ...walletBalanceQuery,
   ...walletBalanceSubscription,
@@ -82,4 +86,24 @@ describe('<AuthenticatedRoute />', () => {
       expect(screen.getByTestId('assistant-list-new')).toBeInTheDocument();
     });
   });
+
+  test.each(['Staff', 'Manager', 'Admin', 'Glific_admin'])(
+    'renders Analytics at /analytics for %s role',
+    async (role) => {
+      setUserSession(JSON.stringify({ organization: { id: '1' }, roles: [role] }));
+      render(
+        <MockedProvider mocks={mocks}>
+          <MemoryRouter initialEntries={['/analytics']}>
+            <Suspense fallback={<Loading />}>
+              <AuthenticatedRoute />
+            </Suspense>
+          </MemoryRouter>
+        </MockedProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('analytics-page')).toBeInTheDocument();
+      });
+    }
+  );
 });

--- a/src/routes/AuthenticatedRoute/AuthenticatedRoute.test.tsx
+++ b/src/routes/AuthenticatedRoute/AuthenticatedRoute.test.tsx
@@ -52,18 +52,37 @@ const mocks = [
   getAttachmentPermissionMock,
 ];
 window.HTMLElement.prototype.scrollIntoView = function () {};
+
+interface RenderAuthenticatedRouteOptions {
+  mocks?: React.ComponentProps<typeof MockedProvider>['mocks'];
+  initialEntries?: React.ComponentProps<typeof MemoryRouter>['initialEntries'];
+}
+
+const renderAuthenticatedRoute = ({
+  mocks: mocksOverride = mocks,
+  initialEntries,
+}: RenderAuthenticatedRouteOptions = {}) => {
+  const routeTree = (
+    <Suspense fallback={<Loading />}>
+      <AuthenticatedRoute />
+    </Suspense>
+  );
+
+  return render(
+    <MockedProvider mocks={mocksOverride}>
+      {initialEntries ? (
+        <MemoryRouter initialEntries={initialEntries}>{routeTree}</MemoryRouter>
+      ) : (
+        <BrowserRouter>{routeTree}</BrowserRouter>
+      )}
+    </MockedProvider>
+  );
+};
+
 describe('<AuthenticatedRoute />', () => {
   test('it should render', async () => {
     setUserSession(JSON.stringify({ organization: { id: '1' }, roles: ['Admin'] }));
-    const { getByTestId } = render(
-      <MockedProvider mocks={mocks}>
-        <BrowserRouter>
-          <Suspense fallback={<Loading />}>
-            <AuthenticatedRoute />
-          </Suspense>
-        </BrowserRouter>
-      </MockedProvider>
-    );
+    const { getByTestId } = renderAuthenticatedRoute();
 
     await waitFor(() => {
       expect(getByTestId('app')).toBeInTheDocument();
@@ -72,15 +91,7 @@ describe('<AuthenticatedRoute />', () => {
 
   test('renders AssistantList at /assistants', async () => {
     setUserSession(JSON.stringify({ organization: { id: '1' }, roles: ['Admin'] }));
-    render(
-      <MockedProvider mocks={mocks}>
-        <MemoryRouter initialEntries={['/assistants']}>
-          <Suspense fallback={<Loading />}>
-            <AuthenticatedRoute />
-          </Suspense>
-        </MemoryRouter>
-      </MockedProvider>
-    );
+    renderAuthenticatedRoute({ initialEntries: ['/assistants'] });
 
     await waitFor(() => {
       expect(screen.getByTestId('assistant-list-new')).toBeInTheDocument();
@@ -91,15 +102,7 @@ describe('<AuthenticatedRoute />', () => {
     'renders Analytics at /analytics for %s role',
     async (role) => {
       setUserSession(JSON.stringify({ organization: { id: '1' }, roles: [role] }));
-      render(
-        <MockedProvider mocks={mocks}>
-          <MemoryRouter initialEntries={['/analytics']}>
-            <Suspense fallback={<Loading />}>
-              <AuthenticatedRoute />
-            </Suspense>
-          </MemoryRouter>
-        </MockedProvider>
-      );
+      renderAuthenticatedRoute({ initialEntries: ['/analytics'] });
 
       await waitFor(() => {
         expect(screen.getByTestId('analytics-page')).toBeInTheDocument();

--- a/src/routes/AuthenticatedRoute/AuthenticatedRoute.tsx
+++ b/src/routes/AuthenticatedRoute/AuthenticatedRoute.tsx
@@ -89,6 +89,7 @@ const staffRoutes = (
     <Route path="contact-profile/:id/*" element={<ContactProfile />} />
     <Route path="blocked-contacts" element={<BlockContactList />} />
     <Route path="myaccount" element={<MyAccount />} />
+    <Route path="analytics" element={<Analytics />} />
     <Route path="/*" element={<Chat />} />
   </Routes>
 );

--- a/src/services/AuthService.tsx
+++ b/src/services/AuthService.tsx
@@ -26,7 +26,6 @@ type ServiceType =
   | 'aiEvaluationsEnabled'
   | 'copyNodeEnabled'
   | 'promptGeneratorEnabled'
-  | 'supersetEnabled'
   | 'templateV2Enabled';
 
 // get the current authentication session


### PR DESCRIPTION
## Summary

- The **Data Analytics** page (`/analytics`) is now visible and accessible to **all authenticated roles** (Staff, Manager, Admin, Dynamic, Glific_admin) — previously it was manager-level only and hidden behind the `supersetEnabled` org-service flag.
- Removed the `supersetEnabled` feature flag from the frontend entirely:
  - `src/config/menu.ts` — menu item no longer gated on `getOrganizationServices('supersetEnabled')`; roles changed to `allRoles`
  - `src/routes/AuthenticatedRoute/AuthenticatedRoute.tsx` — added `/analytics` route to the Staff route tree
  - `src/services/AuthService.tsx` — dropped `'supersetEnabled'` from the org-services type union
  - `src/graphql/queries/Organization.ts` — dropped the field from `GET_ORGANIZATION_SERVICES`

## Tests

- `AuthenticatedRoute.test.tsx` — parameterized test asserting the Analytics page renders at `/analytics` for Staff, Manager, Admin, and Glific_admin
- `SideDrawer.test.tsx` — asserts the Data Analytics menu item appears for all roles with no org-service flag set
- All affected test files pass; `tsc --noEmit` and Prettier are clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Data Analytics access at `/analytics` for Staff, Manager, Admin, and Glific Admin roles.
  * Added Data Analytics to the navigation menu for all supported roles.
  * The Analytics menu is now available without requiring a separate service setting.

* **Bug Fixes**
  * Improved consistency between navigation visibility and Analytics route access.

* **Tests**
  * Added coverage confirming Analytics access and menu visibility across supported roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->