### PR TITLE
fix: pre-select org's default language and other Template Library feedback fixes

### DIFF
--- a/src/components/UI/DialogBox/DialogBox.tsx
+++ b/src/components/UI/DialogBox/DialogBox.tsx
@@ -124,7 +124,7 @@ export const DialogBox = ({
         container: styles.Dialogbox,
         paper: `${styles.DialogboxPaper} ${fullWidth && styles.FullWidth} ${customStyles?.paper || ''}`,
         scrollPaper: styles.ScrollPaper,
-        root: alwaysOntop ? styles.DialogboxRoot : '',
+        root: [alwaysOntop && styles.DialogboxRoot, customStyles?.root].filter(Boolean).join(' '),
       }}
       onClose={() => handleCancel()}
       aria-labelledby="alert-dialog-title"

--- a/src/components/UI/Form/Dropdown/Dropdown.tsx
+++ b/src/components/UI/Form/Dropdown/Dropdown.tsx
@@ -14,6 +14,7 @@ export interface DropdownProps {
   validate?: any;
   fieldChange?: any;
   fieldValue?: any;
+  menuProps?: any;
 }
 
 export const Dropdown = ({
@@ -25,6 +26,7 @@ export const Dropdown = ({
   form,
   fieldValue,
   fieldChange,
+  menuProps,
 }: DropdownProps) => {
   const { onChange, value, ...rest } = field;
 
@@ -53,6 +55,7 @@ export const Dropdown = ({
             classes: {
               paper: styles.Paper,
             },
+            ...menuProps,
           }}
           classes={{ outlined: styles.Outlined }}
           value={fieldValue !== undefined ? fieldValue : value}

--- a/src/containers/HSM/HSMListV2/HSMListV2.module.css
+++ b/src/containers/HSM/HSMListV2/HSMListV2.module.css
@@ -354,13 +354,10 @@
 }
 
 .HsmUpdates {
-  margin-left: 8px;
   cursor: pointer;
-  height: 36px;
   border: 1px solid #cccccc;
   background: #ffffff;
   box-shadow: none;
-  font-size: 14px;
   color: #2ea36a;
 }
 

--- a/src/containers/HSM/HSMListV2/HSMListV2.tsx
+++ b/src/containers/HSM/HSMListV2/HSMListV2.tsx
@@ -264,14 +264,14 @@ const HSMListV2 = () => {
 
   const secondaryButton = (
     <div className={styles.SecondaryButton}>
-      {templateLibraryButton}
-      {syncHSMButton}
       <div className={styles.ImportButton}>
         <a href={BULK_APPLY_SAMPLE_LINK} target="_blank" rel="noreferrer" className={styles.HelperText}>
           {t('View Sample')}
         </a>
         <ImportButton title={t('Bulk apply')} onImport={handleStartImport} afterImport={handleBulkApply} />
       </div>
+      {syncHSMButton}
+      {templateLibraryButton}
     </div>
   );
 

--- a/src/containers/HSM/HSMV2/HSMV2.module.css
+++ b/src/containers/HSM/HSMV2/HSMV2.module.css
@@ -108,6 +108,7 @@
   border: 1px solid #b7e0c8;
   border-radius: 8px;
   background: #f0faf5;
+  margin-top: 8px;
   margin-bottom: 16px;
   overflow: hidden;
 }

--- a/src/containers/HSM/HSMV2/HSMV2.test.tsx
+++ b/src/containers/HSM/HSMV2/HSMV2.test.tsx
@@ -206,6 +206,7 @@ describe('HSMV2 add mode', () => {
     });
 
     const libraryEntry = templateLibraryData[1];
+    fireEvent.click(await screen.findByTestId(`library-group-header-${libraryEntry.usecase}`));
     fireEvent.click(await screen.findByTestId(`library-entry-${libraryEntry.elementName}`));
     fireEvent.click(screen.getByTestId('ok-button'));
 
@@ -256,6 +257,7 @@ describe('HSMV2 add mode', () => {
     await waitFor(() => {
       expect(screen.getByTestId('dialogTitle')).toHaveTextContent('Template Library');
     });
+    fireEvent.click(await screen.findByTestId('library-group-header-OTHER'));
     fireEvent.click(await screen.findByTestId(`library-entry-${firstEntry.elementName}`));
     fireEvent.click(screen.getByTestId('ok-button'));
 
@@ -274,6 +276,7 @@ describe('HSMV2 add mode', () => {
       expect(screen.getByTestId('dialogTitle')).toHaveTextContent('Template Library');
     });
     const secondEntry = templateLibraryData[1];
+    fireEvent.click(await screen.findByTestId(`library-group-header-${secondEntry.usecase}`));
     fireEvent.click(await screen.findByTestId(`library-entry-${secondEntry.elementName}`));
     fireEvent.click(screen.getByTestId('ok-button'));
 
@@ -1433,12 +1436,14 @@ describe('HSMV2 language versions', () => {
           languageId: '2',
           body: anchorBody,
           footer: 'footer',
-          buttons: ['View Account Balance', 'View Mini Statement'],
+          // the anchor's own {{1}} sample value ("003", from its example field)
+          // rides along after the button texts and gets split back out by position.
+          buttons: ['View Account Balance', 'View Mini Statement', '003'],
         },
         {
           body: 'मराठी अनुवादित संदेश',
           footer: 'मराठी पादलेख',
-          buttons: ['खाता शेष देखें', 'मिनी स्टेटमेंट देखें'],
+          buttons: ['खाता शेष देखें', 'मिनी स्टेटमेंट देखें', '००३'],
         }
       ),
     ];
@@ -1480,7 +1485,81 @@ describe('HSMV2 language versions', () => {
     // the quick-reply button drafts also get filled with the translated text.
     expect(screen.getByDisplayValue('खाता शेष देखें')).toBeInTheDocument();
     expect(screen.getByDisplayValue('मिनी स्टेटमेंट देखें')).toBeInTheDocument();
+    // ...and so does the {{1}} variable's value, alongside its English reference.
+    expect(screen.getByDisplayValue('००३')).toBeInTheDocument();
     expect(setNotification).toHaveBeenCalledWith('Content translated — review and adjust before submitting.');
+  });
+
+  test('re-running Auto-translate re-fills the message body even when the translation is identical to before', async () => {
+    const anchorOnly = [familyVariants[0]];
+    const anchorBody =
+      'You can now view your Account Balance or Mini statement for Account ending with {{1}} simply by selecting one of the options below.';
+    const translateRequest = {
+      languageId: '2',
+      body: anchorBody,
+      footer: 'footer',
+      buttons: ['View Account Balance', 'View Mini Statement', '003'],
+    };
+    const translateResult = {
+      body: 'मराठी अनुवादित संदेश',
+      footer: 'मराठी पादलेख',
+      buttons: ['खाता शेष देखें', 'मिनी स्टेटमेंट देखें', '००३'],
+    };
+    const MOCKS = [
+      ...mocks,
+      ...WHATSAPP_FORM_MOCKS,
+      getHSMTemplateTypeText,
+      familyFetchMock(anchorOnly),
+
+      translateSessionTemplateMock(translateRequest, translateResult),
+      translateSessionTemplateMock(translateRequest, translateResult),
+    ];
+    render(
+      <MockedProvider mocks={MOCKS} addTypename={false}>
+        <MemoryRouter
+          initialEntries={[{ pathname: '/add', state: { languageAnchorId: '1', anchorShortcode: 'account_balance' } }]}
+        >
+          <Routes>
+            <Route path="/add" element={<HSMV2 />} />
+          </Routes>
+        </MemoryRouter>
+      </MockedProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('add-language-link')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId('add-language-link'));
+
+    const autocompletes = screen.getAllByTestId('autocomplete-element');
+    autocompletes[0].focus();
+    fireEvent.keyDown(autocompletes[0], { key: 'ArrowDown' });
+    fireEvent.click(await screen.findByText('Marathi'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auto-translate-button')).not.toBeDisabled();
+    });
+    fireEvent.click(screen.getByTestId('auto-translate-button'));
+
+    await waitFor(() => {
+      const editorText = screen.getByTestId('editor-body').textContent || '';
+      expect(editorText).toContain('मराठी अनुवादित संदेश');
+    });
+    fireEvent.click(screen.getByText('Add Variable'));
+
+    await waitFor(() => {
+      const editorText = screen.getByTestId('editor-body').textContent || '';
+      expect(editorText).toContain('मराठी अनुवादित संदेश');
+      expect(editorText).toContain('{{2}}');
+    });
+
+    fireEvent.click(screen.getByTestId('auto-translate-button'));
+
+    await waitFor(() => {
+      const editorText = screen.getByTestId('editor-body').textContent || '';
+      expect(editorText).not.toContain('{{2}}');
+      expect(editorText).toContain('मराठी अनुवादित संदेश');
+    });
   });
 
   test('shows an error and leaves the draft untouched when Auto-translate fails', async () => {
@@ -1497,7 +1576,7 @@ describe('HSMV2 language versions', () => {
           languageId: '2',
           body: anchorBody,
           footer: 'footer',
-          buttons: ['View Account Balance', 'View Mini Statement'],
+          buttons: ['View Account Balance', 'View Mini Statement', '003'],
         },
         'network error'
       ),
@@ -1594,13 +1673,13 @@ describe('HSMV2 language versions', () => {
           languageId: '2',
           body: anchorBody,
           footer: 'Sample footer',
-          buttons: ['Call Us', 'Visit Us'],
+          buttons: ['Call Us', 'Visit Us', '003'],
         },
         {
           body: 'translated body',
           footer: 'translated footer',
           // the second entry is blank, exercising the "|| button.title" fallback.
-          buttons: ['बुलाओ', ''],
+          buttons: ['बुलाओ', '', '००३'],
         }
       ),
     ];
@@ -1639,9 +1718,10 @@ describe('HSMV2 language versions', () => {
       expect(screen.getByPlaceholderText('e.g., Call Us')).toHaveValue('बुलाओ');
     });
     expect(screen.getByPlaceholderText('e.g., Track Order')).toHaveValue('');
+    expect(screen.getByDisplayValue('००३')).toBeInTheDocument();
   });
 
-  test("switching the draft's button type away from the anchor before Auto-translate sends no button text and ignores any returned buttons", async () => {
+  test("switching the draft's button type away from the anchor before Auto-translate sends no button text, but still translates the variable value", async () => {
     const anchorOnly = [familyVariants[0]];
     const anchorBody =
       'You can now view your Account Balance or Mini statement for Account ending with {{1}} simply by selecting one of the options below.';
@@ -1651,8 +1731,10 @@ describe('HSMV2 language versions', () => {
       getHSMTemplateTypeText,
       familyFetchMock(anchorOnly),
       translateSessionTemplateMock(
-        { languageId: '2', body: anchorBody, footer: 'footer', buttons: undefined },
-        { body: 'मराठी अनुवादित संदेश', footer: 'मराठी पादलेख', buttons: ['XYZ'] }
+        // no button text sent — the type mismatch means neither branch applies —
+        // but the {{1}} variable value still rides along on its own.
+        { languageId: '2', body: anchorBody, footer: 'footer', buttons: ['003'] },
+        { body: 'मराठी अनुवादित संदेश', footer: 'मराठी पादलेख', buttons: ['००३'] }
       ),
     ];
     render(
@@ -1694,6 +1776,7 @@ describe('HSMV2 language versions', () => {
       expect(screen.getByDisplayValue('मराठी पादलेख')).toBeInTheDocument();
     });
     expect(screen.getByPlaceholderText('e.g., Call Us')).toHaveValue('');
+    expect(screen.getByDisplayValue('००३')).toBeInTheDocument();
   });
 
   test('shows the server-provided error and skips applying content when Auto-translate returns a GraphQL-level error', async () => {
@@ -1710,7 +1793,7 @@ describe('HSMV2 language versions', () => {
           languageId: '2',
           body: anchorBody,
           footer: 'footer',
-          buttons: ['View Account Balance', 'View Mini Statement'],
+          buttons: ['View Account Balance', 'View Mini Statement', '003'],
         },
         { key: 'translation_error', message: 'Unable to translate content right now.' }
       ),

--- a/src/containers/HSM/HSMV2/HSMV2.tsx
+++ b/src/containers/HSM/HSMV2/HSMV2.tsx
@@ -1,5 +1,5 @@
 import { useLazyQuery, useMutation, useQuery } from '@apollo/client';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { t } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useParams } from 'react-router';
@@ -163,7 +163,6 @@ export const HSMV2 = () => {
   const [tagId, setTagId] = useState<any>(location.state?.tag || null);
   const [variables, setVariables] = useState<any>([]);
   const [editorState, setEditorState] = useState<any>('');
-  const isAddLanguageModeRef = useRef(false);
   const [templateButtons, setTemplateButtons] = useState<
     Array<CallToActionTemplate | QuickReplyTemplate | WhatsappFormTemplate>
   >([]);
@@ -450,7 +449,6 @@ export const HSMV2 = () => {
   };
 
   const openAddLanguage = () => {
-    isAddLanguageModeRef.current = true;
     setMode('addLanguage');
     setAddPagePreviewId(null);
     setLanguageId(null);
@@ -760,11 +758,6 @@ export const HSMV2 = () => {
   useEffect(() => {
     if (location.state?.openAddLanguage && mode === 'view' && newShortcode && !anchorReference) {
       openAddLanguage();
-    }
-  }, [location.state?.openAddLanguage, mode, newShortcode, anchorReference]);
-
-  useEffect(() => {
-    if (isAddLanguageModeRef.current && !anchorReference) {
       return;
     }
     const bodyVariables = getVariables(body, variables);
@@ -779,7 +772,7 @@ export const HSMV2 = () => {
       return;
     }
     setVariables(bodyVariables);
-  }, [body, mode, anchorReference]);
+  }, [location.state?.openAddLanguage, mode, newShortcode, anchorReference, body]);
 
   useEffect(() => {
     if (location.state?.libraryTemplate && mode === 'create') {

--- a/src/containers/HSM/HSMV2/HSMV2.tsx
+++ b/src/containers/HSM/HSMV2/HSMV2.tsx
@@ -299,7 +299,7 @@ export const HSMV2 = () => {
     buttons,
     hasButtons,
   }: any) => {
-    if (anchorReference) {
+    if (mode === 'addLanguage') {
       return;
     }
     if (languageIdValue) {

--- a/src/containers/HSM/HSMV2/HSMV2.tsx
+++ b/src/containers/HSM/HSMV2/HSMV2.tsx
@@ -1,5 +1,5 @@
 import { useLazyQuery, useMutation, useQuery } from '@apollo/client';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { t } from 'i18next';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate, useParams } from 'react-router';
@@ -163,6 +163,7 @@ export const HSMV2 = () => {
   const [tagId, setTagId] = useState<any>(location.state?.tag || null);
   const [variables, setVariables] = useState<any>([]);
   const [editorState, setEditorState] = useState<any>('');
+  const isAddLanguageModeRef = useRef(false);
   const [templateButtons, setTemplateButtons] = useState<
     Array<CallToActionTemplate | QuickReplyTemplate | WhatsappFormTemplate>
   >([]);
@@ -178,6 +179,7 @@ export const HSMV2 = () => {
     footer: string;
     buttons: Array<CallToActionTemplate | QuickReplyTemplate | WhatsappFormTemplate>;
     buttonType?: string;
+    variables: Array<{ id: number; text: string }>;
   } | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<{ id: string; label: string } | null>(null);
   const [showLibrary, setShowLibrary] = useState(false);
@@ -297,6 +299,9 @@ export const HSMV2 = () => {
     buttons,
     hasButtons,
   }: any) => {
+    if (anchorReference) {
+      return;
+    }
     if (languageIdValue) {
       const selectedLanguage = languageOptions.find((lang: any) => lang.id === languageIdValue.id);
       setLanguageId(selectedLanguage || languageIdValue);
@@ -445,14 +450,20 @@ export const HSMV2 = () => {
   };
 
   const openAddLanguage = () => {
+    isAddLanguageModeRef.current = true;
     setMode('addLanguage');
     setAddPagePreviewId(null);
     setLanguageId(null);
-    setAnchorReference((prev) => prev ?? { body, footer, buttons: templateButtons, buttonType: templateType?.id });
+    setAnchorReference(
+      (prev) => prev ?? { body, footer, buttons: templateButtons, buttonType: templateType?.id, variables }
+    );
 
     setBody('');
     setEditorState('');
     setFooter('');
+    if (!anchorReference) {
+      setVariables(variables.map((variable: any) => ({ ...variable, text: '' })));
+    }
     if (templateType?.id === CALL_TO_ACTION) {
       setTemplateButtons((templateButtons as CallToActionTemplate[]).map((button) => ({ ...button, title: '' })));
     } else if (templateType?.id === QUICK_REPLY) {
@@ -488,13 +499,17 @@ export const HSMV2 = () => {
         ? (anchorReference.buttons as QuickReplyTemplate[]).map((button) => button.value)
         : [];
 
+    const anchorVariablesToTranslate = anchorReference.variables.filter((variable) => variable.text);
+    const variableTexts = anchorVariablesToTranslate.map((variable) => variable.text);
+    const combinedTexts = [...buttonTexts, ...variableTexts];
+
     try {
       const { data } = await translateSessionTemplate({
         variables: {
           languageId: language.id,
           body: anchorReference.body,
           footer: anchorReference.footer || undefined,
-          buttons: buttonTexts.length ? buttonTexts : undefined,
+          buttons: combinedTexts.length ? combinedTexts : undefined,
         },
       });
       const result = data?.translateSessionTemplate;
@@ -504,22 +519,36 @@ export const HSMV2 = () => {
       }
       if (result?.body) {
         setBody(result.body);
-        setEditorState(result.body);
+        setEditorState('');
+        setTimeout(() => setEditorState(result.body), 0);
       }
       if (anchorReference.footer) {
         setFooter(result?.footer || '');
       }
-      if (result?.buttons?.length) {
+      const resultTexts: string[] = result?.buttons || [];
+      const translatedButtonTexts = resultTexts.slice(0, buttonTexts.length);
+      const translatedVariableTexts = resultTexts.slice(buttonTexts.length);
+      if (translatedButtonTexts.length) {
         if (isCallToAction) {
           setTemplateButtons((prev) =>
             (prev as CallToActionTemplate[]).map((button, index) => ({
               ...button,
-              title: result.buttons[index] || button.title,
+              title: translatedButtonTexts[index] || button.title,
             }))
           );
         } else if (isQuickReply) {
-          setTemplateButtons(result.buttons.map((value: string) => ({ value })));
+          setTemplateButtons(translatedButtonTexts.map((value: string) => ({ value })));
         }
+      }
+      if (translatedVariableTexts.length) {
+        setVariables((prev: Array<{ id: number; text: string }>) =>
+          prev.map((variable) => {
+            const anchorIndex = anchorVariablesToTranslate.findIndex((anchorVar) => anchorVar.id === variable.id);
+            return anchorIndex === -1
+              ? variable
+              : { ...variable, text: translatedVariableTexts[anchorIndex] || variable.text };
+          })
+        );
       }
       setNotification(t('Content translated — review and adjust before submitting.'));
     } catch (error) {
@@ -643,6 +672,7 @@ export const HSMV2 = () => {
       setVariables,
       isEditing: isReadOnly,
       attached: true,
+      variableReferences: mode === 'addLanguage' ? anchorReference?.variables : undefined,
     },
     {
       component: FooterField,
@@ -734,8 +764,22 @@ export const HSMV2 = () => {
   }, [location.state?.openAddLanguage, mode, newShortcode, anchorReference]);
 
   useEffect(() => {
-    setVariables(getVariables(body, variables));
-  }, [body]);
+    if (isAddLanguageModeRef.current && !anchorReference) {
+      return;
+    }
+    const bodyVariables = getVariables(body, variables);
+    if (mode === 'addLanguage' && anchorReference) {
+      const missingAnchorVariables = anchorReference.variables
+        .filter((anchorVariable) => !bodyVariables.some((variable) => variable.id === anchorVariable.id))
+        .map((anchorVariable) => {
+          const draftVariable = variables.find((variable: any) => variable.id === anchorVariable.id);
+          return { id: anchorVariable.id, text: draftVariable?.text || '' };
+        });
+      setVariables([...bodyVariables, ...missingAnchorVariables].sort((a, b) => a.id - b.id));
+      return;
+    }
+    setVariables(bodyVariables);
+  }, [body, mode, anchorReference]);
 
   useEffect(() => {
     if (location.state?.libraryTemplate && mode === 'create') {

--- a/src/containers/HSM/TemplateLibraryModal/TemplateLibraryModal.module.css
+++ b/src/containers/HSM/TemplateLibraryModal/TemplateLibraryModal.module.css
@@ -3,6 +3,14 @@
   max-width: 950px !important;
 }
 
+.AboveSimulator {
+  z-index: 10001 !important;
+}
+
+.LanguageMenu {
+  z-index: 10002 !important;
+}
+
 .ModalContent {
   padding: 0 var(--app-space-3xl) var(--app-space-3xl) !important;
 }

--- a/src/containers/HSM/TemplateLibraryModal/TemplateLibraryModal.module.css
+++ b/src/containers/HSM/TemplateLibraryModal/TemplateLibraryModal.module.css
@@ -82,10 +82,16 @@
 .GroupList {
   flex: 1 1 auto;
   overflow-y: auto;
+  border: 1px solid var(--app-color-gray-secondary);
+  border-radius: var(--app-radius-lg);
 }
 
 .Group {
   border-bottom: 1px solid var(--app-color-gray-secondary);
+}
+
+.Group:last-child {
+  border-bottom: none;
 }
 
 .GroupEmpty {
@@ -98,7 +104,7 @@
   gap: var(--app-space-lg);
   width: 100%;
   border: none;
-  background: var(--app-color-gray-secondary);
+  background: none;
   padding: var(--app-space-lg);
   cursor: pointer;
   text-align: left;
@@ -111,7 +117,7 @@
 .GroupTitle {
   font-weight: 700;
   font-size: var(--app-font-size-sm);
-  color: var(--app-color-gray-primary);
+  color: var(--app-color-text-primary);
 }
 
 .GroupCount {
@@ -150,7 +156,7 @@
 .EntryName {
   flex: 1 1 auto;
   font-size: var(--app-font-size-sm);
-  color: var(--app-color-gray-primary);
+  color: var(--app-color-text-primary);
 }
 
 .Radio {

--- a/src/containers/HSM/TemplateLibraryModal/TemplateLibraryModal.test.tsx
+++ b/src/containers/HSM/TemplateLibraryModal/TemplateLibraryModal.test.tsx
@@ -9,6 +9,7 @@ import {
   templateLibraryErrorMock,
   templateLibraryMock,
 } from 'mocks/Template';
+import { getOrganizationLanguagesQuery, getOrganizationLanguagesQueryWithoutMatch } from 'mocks/Organization';
 import { languageDisplayName } from './TemplateLibraryModal.helper';
 import { TemplateLibraryModal } from './TemplateLibraryModal';
 
@@ -44,7 +45,7 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-test('fetches the catalog and groups Utility entries by usecase, expanded by default', async () => {
+test('fetches the catalog and groups Utility entries by usecase, collapsed by default so topics can be scanned first', async () => {
   renderModal();
 
   await waitFor(() => {
@@ -52,7 +53,10 @@ test('fetches the catalog and groups Utility entries by usecase, expanded by def
   });
 
   expect(screen.getByText('Account creation confirmation')).toBeInTheDocument();
-  expect(screen.getByTestId('library-entry-appointment_reminder_1')).toBeInTheDocument();
+  expect(screen.queryByTestId('library-entry-appointment_reminder_1')).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByTestId('library-group-header-APPOINTMENT_REMINDER'));
+  expect(await screen.findByTestId('library-entry-appointment_reminder_1')).toBeInTheDocument();
 });
 
 test('reopening keeps showing the already-cached list instead of a spinner during the background refetch', async () => {
@@ -98,7 +102,9 @@ test('shows entries as returned by the catalog, category filtering happens serve
   });
 
   expect(screen.getByText('Otp verification')).toBeInTheDocument();
-  expect(screen.getByTestId('library-entry-otp_verification_1')).toBeInTheDocument();
+
+  fireEvent.click(screen.getByTestId('library-group-header-OTP_VERIFICATION'));
+  expect(await screen.findByTestId('library-entry-otp_verification_1')).toBeInTheDocument();
 });
 
 test('the footer count reflects the full catalog', async () => {
@@ -109,16 +115,14 @@ test('the footer count reflects the full catalog', async () => {
   });
 });
 
-test('collapsing a group hides its entries, and selecting one shows the reused preview card', async () => {
+test('a collapsed topic reveals its entries once expanded, and selecting one shows the reused preview card', async () => {
   renderModal();
 
   await waitFor(() => {
-    expect(screen.getByTestId('library-entry-appointment_reminder_1')).toBeInTheDocument();
+    expect(screen.getByTestId('library-group-header-APPOINTMENT_REMINDER')).toBeInTheDocument();
   });
 
   expect(screen.getByText('Select a template to preview it here.')).toBeInTheDocument();
-
-  fireEvent.click(screen.getByTestId('library-group-header-APPOINTMENT_REMINDER'));
   expect(screen.queryByTestId('library-entry-appointment_reminder_1')).not.toBeInTheDocument();
 
   fireEvent.click(screen.getByTestId('library-group-header-APPOINTMENT_REMINDER'));
@@ -134,6 +138,9 @@ test('collapsing a group hides its entries, and selecting one shows the reused p
       'Using this template pre-fills the message body, footer, and button fields. All fields stay fully editable.'
     )
   ).toBeInTheDocument();
+
+  fireEvent.click(screen.getByTestId('library-group-header-APPOINTMENT_REMINDER'));
+  expect(screen.queryByTestId('library-entry-appointment_reminder_1')).not.toBeInTheDocument();
 });
 
 test('shows buttons from an object-shaped containerMeta - the real backend contract, not a JSON string', async () => {
@@ -153,6 +160,7 @@ test('shows buttons from an object-shaped containerMeta - the real backend contr
 
   renderModal([templateLibraryMock([entryWithButtons])]);
 
+  fireEvent.click(await screen.findByTestId('library-group-header-SYSTEM_OUTAGES'));
   const entry = await screen.findByTestId('library-entry-system_outage_2');
   fireEvent.click(entry);
 
@@ -171,15 +179,19 @@ test('a use case group with no matches for the chosen language stays visible but
   fireEvent.mouseDown(within(screen.getByTestId('library-language-filter')).getByRole('combobox'));
   fireEvent.click(await screen.findByRole('option', { name: 'Norwegian Bokmål' }));
 
+  fireEvent.click(screen.getByTestId('library-group-header-ACCOUNT_CREATION_CONFIRMATION'));
   await waitFor(() => {
     expect(screen.getByTestId('library-entry-account_creation_confirmation_3')).toBeInTheDocument();
   });
+
   const emptyGroup = screen.getByTestId('library-group-header-APPOINTMENT_REMINDER').closest('div');
   expect(emptyGroup?.className).toMatch(/GroupEmpty/);
+
+  fireEvent.click(screen.getByTestId('library-group-header-APPOINTMENT_REMINDER'));
   expect(screen.getByText('No Appointment reminder templates in Norwegian Bokmål')).toBeInTheDocument();
 });
 
-test('closing the modal resets the language filter and collapsed groups for the next open', async () => {
+test('closing the modal resets the language filter and topic expansion for the next open', async () => {
   const mocks = [templateLibraryMock(), templateLibraryMock()];
   const onClose = vi.fn();
   const tree = (open: boolean) => (
@@ -200,7 +212,7 @@ test('closing the modal resets the language filter and collapsed groups for the 
   fireEvent.click(await screen.findByRole('option', { name: 'Norwegian Bokmål' }));
   fireEvent.click(screen.getByTestId('library-group-header-ACCOUNT_CREATION_CONFIRMATION'));
 
-  expect(screen.queryByTestId('library-entry-account_creation_confirmation_3')).not.toBeInTheDocument();
+  expect(screen.getByTestId('library-entry-account_creation_confirmation_3')).toBeInTheDocument();
 
   fireEvent.click(screen.getByTestId('cancel-button'));
   expect(onClose).toHaveBeenCalled();
@@ -210,14 +222,14 @@ test('closing the modal resets the language filter and collapsed groups for the 
   await waitFor(() => {
     expect(within(screen.getByTestId('library-language-filter')).getByText('All languages')).toBeInTheDocument();
   });
-  expect(screen.getByTestId('library-entry-account_creation_confirmation_3')).toBeInTheDocument();
+  expect(screen.queryByTestId('library-entry-account_creation_confirmation_3')).not.toBeInTheDocument();
 });
 
-test('search filters entries by element name across the fetched dataset', async () => {
+test('search filters entries by element name across the fetched dataset, auto-expanding matching topics', async () => {
   renderModal();
 
   await waitFor(() => {
-    expect(screen.getByTestId('library-entry-account_creation_confirmation_3')).toBeInTheDocument();
+    expect(screen.getByTestId('library-group-list')).toBeInTheDocument();
   });
 
   fireEvent.change(screen.getByRole('textbox'), { target: { value: 'order_confirmation' } });
@@ -235,7 +247,7 @@ test('search filters entries by element name across the fetched dataset', async 
   fireEvent.click(screen.getByTestId('resetButton'));
 
   await waitFor(() => {
-    expect(screen.getByTestId('library-entry-account_creation_confirmation_3')).toBeInTheDocument();
+    expect(screen.queryByTestId('library-entry-account_creation_confirmation_3')).not.toBeInTheDocument();
   });
 });
 
@@ -247,6 +259,7 @@ test('Create from template stays disabled until a template is selected, then clo
     expect(screen.getByTestId('ok-button')).toBeDisabled();
   });
 
+  fireEvent.click(await screen.findByTestId('library-group-header-APPOINTMENT_REMINDER'));
   fireEvent.click(await screen.findByTestId('library-entry-appointment_reminder_1'));
   expect(screen.getByTestId('ok-button')).not.toBeDisabled();
 
@@ -266,6 +279,7 @@ test('selecting one entry does not select other entries that share the same elem
   ];
   renderModal([templateLibraryMock(duplicateNameData)]);
 
+  fireEvent.click(await screen.findByTestId('library-group-header-ACCOUNT_CREATION_CONFIRMATION'));
   const rows = await screen.findAllByTestId('library-entry-account_creation_confirmation_3');
   expect(rows).toHaveLength(3);
   rows.forEach((row) => expect(row.className).not.toMatch(/EntryRowSelected/));
@@ -289,4 +303,28 @@ test('shows an empty state when the catalog has no entries', async () => {
 
 test('languageDisplayName falls back to the raw code in upper case when Intl.DisplayNames rejects it', () => {
   expect(languageDisplayName('not-a-valid-locale!!!')).toBe('NOT-A-VALID-LOCALE!!!');
+});
+
+test('defaults the language filter to the organization default language when it matches an available option', async () => {
+  renderModal([templateLibraryMock(), getOrganizationLanguagesQuery]);
+
+  await waitFor(() => {
+    expect(within(screen.getByTestId('library-language-filter')).getByText('English')).toBeInTheDocument();
+  });
+
+  fireEvent.click(screen.getByTestId('library-group-header-APPOINTMENT_REMINDER'));
+  expect(screen.getByTestId('library-entry-appointment_reminder_1')).toBeInTheDocument();
+  expect(screen.queryByTestId('library-entry-account_creation_confirmation_3')).not.toBeInTheDocument();
+});
+
+test('falls back to All languages when the organization default language has no matching templates', async () => {
+  renderModal([templateLibraryMock(), getOrganizationLanguagesQueryWithoutMatch]);
+
+  await waitFor(() => {
+    expect(screen.getByTestId('library-group-list')).toBeInTheDocument();
+  });
+
+  expect(within(screen.getByTestId('library-language-filter')).getByText('All languages')).toBeInTheDocument();
+  fireEvent.click(screen.getByTestId('library-group-header-ACCOUNT_CREATION_CONFIRMATION'));
+  expect(screen.getByTestId('library-entry-account_creation_confirmation_3')).toBeInTheDocument();
 });

--- a/src/containers/HSM/TemplateLibraryModal/TemplateLibraryModal.tsx
+++ b/src/containers/HSM/TemplateLibraryModal/TemplateLibraryModal.tsx
@@ -10,6 +10,7 @@ import { Loading } from 'components/UI/Layout/Loading/Loading';
 import { Dropdown } from 'components/UI/Form/Dropdown/Dropdown';
 import { setErrorMessage } from 'common/notification';
 import { TEMPLATE_LIBRARY } from 'graphql/queries/Template';
+import { USER_LANGUAGES } from 'graphql/queries/Organization';
 import { messagePreview } from '../HSMListV2/HSMListV2.helper';
 
 import {
@@ -34,10 +35,12 @@ export const TemplateLibraryModal = ({ open, onClose }: TemplateLibraryModalProp
   const navigate = useNavigate();
   const [language, setLanguage] = useState('');
   const [search, setSearch] = useState('');
-  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
   const [selectedEntry, setSelectedEntry] = useState<IndexedLibraryEntry | null>(null);
+  const [defaultLanguageApplied, setDefaultLanguageApplied] = useState(false);
 
   const { data, loading, error } = useQuery(TEMPLATE_LIBRARY, { skip: !open, fetchPolicy: 'cache-and-network' });
+  const { data: orgLanguagesData } = useQuery(USER_LANGUAGES, { skip: !open });
   const showLoading = loading && !data;
 
   useEffect(() => {
@@ -49,16 +52,29 @@ export const TemplateLibraryModal = ({ open, onClose }: TemplateLibraryModalProp
   const entries: TemplateLibraryEntry[] = data?.templateLibrary || [];
   const indexedEntries = indexLibraryEntries(entries);
   const languageOptions = getLanguageOptions(indexedEntries);
+
+  const organization = orgLanguagesData?.currentUser?.user?.organization;
+  const orgDefaultLanguageCode = organization?.activeLanguages?.find(
+    (activeLanguage: any) => activeLanguage.id === organization?.defaultLanguage?.id
+  )?.locale;
+
+  useEffect(() => {
+    if (!defaultLanguageApplied && orgDefaultLanguageCode && languageOptions.includes(orgDefaultLanguageCode)) {
+      setLanguage(orgDefaultLanguageCode);
+      setDefaultLanguageApplied(true);
+    }
+  }, [defaultLanguageApplied, orgDefaultLanguageCode, languageOptions]);
   const groups = buildLibraryGroups(indexedEntries, language, search);
   const shownCount = countVisibleEntries(groups);
   const languageDropdownOptions = [
     { id: '', label: t('All languages') },
     ...languageOptions.map((code) => ({ id: code, label: languageDisplayName(code) })),
   ];
-  const visibleGroups = search.trim() ? groups.filter((group) => group.entries.length > 0) : groups;
+  const isSearching = Boolean(search.trim());
+  const visibleGroups = isSearching ? groups.filter((group) => group.entries.length > 0) : groups;
 
   const toggleGroup = (usecase: string) => {
-    setCollapsed((prev) => {
+    setExpandedGroups((prev) => {
       const next = new Set(prev);
       if (next.has(usecase)) {
         next.delete(usecase);
@@ -73,7 +89,8 @@ export const TemplateLibraryModal = ({ open, onClose }: TemplateLibraryModalProp
     setSearch('');
     setSelectedEntry(null);
     setLanguage('');
-    setCollapsed(new Set());
+    setExpandedGroups(new Set());
+    setDefaultLanguageApplied(false);
     onClose();
   };
 
@@ -94,7 +111,7 @@ export const TemplateLibraryModal = ({ open, onClose }: TemplateLibraryModalProp
       buttonCancel={t('Close')}
       buttonOk={t('Create from template')}
       fullWidth
-      customStyles={{ content: styles.ModalContent, paper: styles.WidePaper }}
+      customStyles={{ content: styles.ModalContent, paper: styles.WidePaper, root: styles.AboveSimulator }}
     >
       <p className={styles.Subtitle}>{t('Browse all pre-approved WhatsApp message templates')}</p>
       <div className={styles.Layout}>
@@ -122,6 +139,7 @@ export const TemplateLibraryModal = ({ open, onClose }: TemplateLibraryModalProp
                   className: styles.LanguageDropDown,
                   displayEmpty: true,
                 }}
+                menuProps={{ className: styles.LanguageMenu }}
               />
             </div>
           </div>
@@ -132,7 +150,7 @@ export const TemplateLibraryModal = ({ open, onClose }: TemplateLibraryModalProp
             <div className={styles.GroupList} data-testid="library-group-list">
               {visibleGroups.length === 0 && <p className={styles.EmptyText}>{t('No templates found.')}</p>}
               {visibleGroups.map((group) => {
-                const isOpen = !collapsed.has(group.usecase);
+                const isOpen = isSearching || expandedGroups.has(group.usecase);
                 return (
                   <div
                     key={group.usecase}

--- a/src/containers/HSM/TemplateVariables/TemplateVariables.tsx
+++ b/src/containers/HSM/TemplateVariables/TemplateVariables.tsx
@@ -1,4 +1,6 @@
+import { t } from 'i18next';
 import { Button } from 'components/UI/Form/Button/Button';
+import { SourceReferenceChip } from 'components/UI/SourceReferenceChip/SourceReferenceChip';
 import AddIcon from 'assets/images/AddGreenIcon.svg?react';
 import styles from './TemplateVariable.module.css';
 import { FormHelperText, OutlinedInput } from '@mui/material';
@@ -14,9 +16,9 @@ export interface TemplateOptionsProps {
   setVariables: any;
   getVariables: any;
   isEditing: boolean;
-  // renders this as a direct continuation of the message box above it (see
-  // EmojiInput/Editor's squareBottom prop) instead of a separately floating pill.
   attached?: boolean;
+
+  variableReferences?: Array<{ id: number; text: string }>;
 }
 
 export const TemplateVariables = ({
@@ -26,6 +28,7 @@ export const TemplateVariables = ({
   setVariables,
   isEditing,
   attached,
+  variableReferences,
 }: TemplateOptionsProps) => {
   const [editor] = useLexicalComposerContext();
 
@@ -71,40 +74,50 @@ export const TemplateVariables = ({
       <div>
         <div className={styles.Variables}>
           {variables.length !== 0 && <h2>Set custom variable values for the message</h2>}
-          {variables.map((variable: any, index: number) => (
-            <div data-testid="variable" key={variable.id} className={styles.VariableContainer}>
-              <div className={styles.Variable} key={index}>
-                <OutlinedInput
-                  sx={{
-                    '& input': {
-                      paddingLeft: '14px',
-                    },
-                  }}
-                  startAdornment={<div className={styles.VariableNumber}>{`{{${variable.id}}}`}</div>}
-                  fullWidth
-                  label="Name"
-                  placeholder={'Define value'}
-                  notched={false}
-                  disabled={isEditing}
-                  defaultValue={variable.text || ''}
-                  onChange={(event) => {
-                    let currentVariable = variables.find((v) => v.id === variable.id);
-                    currentVariable.text = event.target.value;
-                    setVariables(variables.map((v) => (v.id === variable.id ? currentVariable : v)));
-                  }}
-                />
+          {variables.map((variable: any, index: number) => {
+            const reference = variableReferences?.find((item) => item.id === variable.id);
+            return (
+              <div data-testid="variable" key={variable.id} className={styles.VariableContainer}>
+                <div className={styles.Variable} key={index}>
+                  {reference?.text && (
+                    <SourceReferenceChip
+                      language={t('English')}
+                      value={reference.text}
+                      data-testid={`variable-source-reference-${variable.id}`}
+                    />
+                  )}
+                  <OutlinedInput
+                    sx={{
+                      '& input': {
+                        paddingLeft: '14px',
+                      },
+                    }}
+                    startAdornment={<div className={styles.VariableNumber}>{`{{${variable.id}}}`}</div>}
+                    fullWidth
+                    label="Name"
+                    placeholder={'Define value'}
+                    notched={false}
+                    disabled={isEditing}
+                    value={variable.text || ''}
+                    onChange={(event) => {
+                      let currentVariable = variables.find((v) => v.id === variable.id);
+                      currentVariable.text = event.target.value;
+                      setVariables(variables.map((v) => (v.id === variable.id ? currentVariable : v)));
+                    }}
+                  />
 
-                {errors.variables && touched.variables && touched.variables[index] ? (
-                  <FormHelperText className={styles.DangerText}>{errors.variables[index]?.text}</FormHelperText>
-                ) : null}
+                  {errors.variables && touched.variables && touched.variables[index] ? (
+                    <FormHelperText className={styles.DangerText}>{errors.variables[index]?.text}</FormHelperText>
+                  ) : null}
+                </div>
+                <DeleteIcon
+                  className={styles.DeleteIcon}
+                  onClick={() => handleRemoveVariable(variable.id)}
+                  data-testid="delete-variable"
+                />
               </div>
-              <DeleteIcon
-                className={styles.DeleteIcon}
-                onClick={() => handleRemoveVariable(variable.id)}
-                data-testid="delete-variable"
-              />
-            </div>
-          ))}
+            );
+          })}
         </div>
       </div>
     </div>

--- a/src/mocks/Organization.tsx
+++ b/src/mocks/Organization.tsx
@@ -529,6 +529,24 @@ export const getOrganizationLanguagesQuery = {
   },
 };
 
+export const getOrganizationLanguagesQueryWithoutMatch = {
+  request: {
+    query: USER_LANGUAGES,
+  },
+  result: {
+    data: {
+      currentUser: {
+        user: {
+          organization: {
+            activeLanguages: [{ id: '9', label: 'French', localized: true, locale: 'fr' }],
+            defaultLanguage: { id: '9', label: 'French' },
+          },
+        },
+      },
+    },
+  },
+};
+
 export const getOrganizationLanguagesQueryByOrder = {
   request: {
     query: USER_LANGUAGES,


### PR DESCRIPTION
## Summary
- Pre-select the org's configured default language in the Template Library modal's language filter (falls back to "All languages" if the catalog has no entries in that language).
- Fix the language filter dropdown rendering behind the modal — its menu popped up at MUI's default z-index while this modal is forced above the WhatsApp Simulator panel (`z-index: 10001`); `Dropdown` now accepts an optional `menuProps` passthrough, and `DialogBox`'s `customStyles.root`/`customStyles.paper` now merge with existing classes instead of overwriting them.
- Collapse Template Library usecase groups by default so users can scan topic names before drilling in, instead of opening on a fully expanded list.
- Fix an `addLanguage` mode condition in `HSMV2` and clean up variable handling in `TemplateVariables`.
