### PR TITLE
feat(deploy): Dockerfile + nginx for Bunnyshell ephemeral env

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+build
+dist
+.git
+.env
+.env.*
+!.env.example
+cypress
+coverage
+*.log
+.DS_Store
+.vscode
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# Multi-stage build for the Glific staff console (static SPA served by nginx).
+#
+# Vite inlines import.meta.env.VITE_* at BUILD time. The staff app derives the backend
+# origin from VITE_GLIFIC_BACKEND_URL, which src/config/index.ts treats as a BARE HOSTNAME
+# (it prepends window.location.protocol and appends /api and /socket). So pass just the
+# backend host here, with no scheme, no port, no path.
+ARG NODE_VERSION=22.23.1
+
+FROM node:${NODE_VERSION}-alpine AS build
+WORKDIR /app
+
+# Bare backend hostname, e.g. backend-abc123.bunnyenv.com (NOT a full URL).
+ARG VITE_GLIFIC_BACKEND_URL
+# Leave prefix/port empty: when VITE_GLIFIC_BACKEND_URL is set, config/index.ts uses the
+# host verbatim over https:443, so an "api." prefix or :4001 port would break the URL.
+ARG VITE_API_PREFIX=""
+ARG VITE_GLIFIC_API_PORT=""
+ARG VITE_APPLICATION_NAME="Glific: Two way communication platform"
+ENV VITE_GLIFIC_BACKEND_URL=$VITE_GLIFIC_BACKEND_URL \
+    VITE_API_PREFIX=$VITE_API_PREFIX \
+    VITE_GLIFIC_API_PORT=$VITE_GLIFIC_API_PORT \
+    VITE_APPLICATION_NAME=$VITE_APPLICATION_NAME
+
+RUN corepack enable
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+COPY . .
+# `yarn build` runs `yarn setup` (which reinstalls) then vite build; call the steps
+# directly so the cached install above is reused. floweditor copies the flow-editor
+# static bundle into public/ before the build. Output goes to build/ (vite.config outDir).
+RUN yarn floweditor && yarn vite build
+
+FROM nginx:1.27-alpine AS runtime
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # SPA fallback so client-side routes survive a hard refresh.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location = /index.html {
+        add_header Cache-Control "no-cache";
+    }
+}


### PR DESCRIPTION
Container build for the staff console so it can run as a component of a Bunnyshell ephemeral environment. Orchestrated by `bunnyshell.yaml` in the backend repo (glific#5524).

## What's included
- **Dockerfile** — multi-stage Vite build; `VITE_GLIFIC_BACKEND_URL` build arg (bare backend hostname; `config/index.ts` derives the `/api` + `/socket` URLs)
- **nginx.conf** — single-page-app serving
- **.dockerignore**

Infra only — no application code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Docker support for building and running the staff console.
  * Added production serving through Nginx on port 80.
  * Enabled single-page application routing with fallback navigation.
  * Added configurable backend and application environment settings during builds.

* **Chores**
  * Excluded dependencies, build artifacts, environment files, logs, and development metadata from Docker build contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->