### PR TITLE
chore: add noindex meta tag to prevent search engine indexing

### DIFF
--- a/config/nginx.conf.erb
+++ b/config/nginx.conf.erb
@@ -27,6 +27,7 @@ http {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header X-Frame-Options "deny" always;
+    add_header X-Robots-Tag "noindex, nofollow" always;
     add_header Strict-Transport-Security "max-age=63072000; includeSubdomains; preload" always;
 <%
       # --- Content Security Policy ----------------------------------------------------------

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" href="/Glific-Favicon.svg" />
     <meta name="viewport" content="minimum-scale=1, initial-scale=1, width=device-width" />
     <meta name="theme-color" content="#000000" />
+    <meta name="robots" content="noindex, nofollow" />
     <meta name="description" content="Glific: Two way communication platform" />
     <link rel="apple-touch-icon" href="/Glific-Favicon.svg" />
     <!--


### PR DESCRIPTION
## What

Prevents search engines from indexing the Glific app, using two complementary mechanisms:

1. **Meta tag** in `index.html`: `<meta name="robots" content="noindex, nofollow" />`
2. **HTTP response header** in the production nginx config (`config/nginx.conf.erb`): `X-Robots-Tag: noindex, nofollow`

## Why

Glific is an authenticated web application that should not appear in search results.

The meta tag covers all static hosts (including Netlify PR previews, which serve the same build). The `X-Robots-Tag` header is belt-and-suspenders for production (Gigalixir + heroku nginx buildpack): it doesn't depend on the crawler executing JS, so `noindex` is honored even on the raw HTML response of this client-rendered SPA.

## Notes

- `public/robots.txt` is intentionally left allowing crawl (`Disallow:` empty). For `noindex` to be honored, crawlers must be allowed to fetch the page/response so they can read the directive. Blocking in robots.txt would prevent Google from ever seeing the `noindex` — and `noindex` in robots.txt itself is unsupported by Google (deprecated Sept 2019).

🤖 Generated with [Claude Code](https://claude.com/claude-code)