### PR TITLE
chore: Bump version from 6.17.5 to 6.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glific-frontend",
-  "version": "6.17.5",
+  "version": "6.18.0",
   "private": true,
   "type": "module",
   "license": {


### PR DESCRIPTION
Version bump 6.17.5 -> 6.18.0, opened by bin/gigalixir-release.sh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 6.18.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->