### PR TITLE
Bump version from 6.18.0 to 6.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glific-frontend",
-  "version": "6.18.0",
+  "version": "6.18.1",
   "private": true,
   "type": "module",
   "license": {


### PR DESCRIPTION
Version bump 6.18.0 -> 6.18.1, opened by bin/gigalixir-release.sh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 6.18.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->