### PR TITLE
Bump version from 6.18.1 to 6.18.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "glific-frontend",
-  "version": "6.18.1",
+  "version": "6.18.2",
   "private": true,
   "type": "module",
   "license": {


### PR DESCRIPTION
Version bump 6.18.1 -> 6.18.2, opened by bin/gigalixir-release.sh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application package version to 6.18.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->