### PR TITLE
feat: Enhance WhatsApp Forms configuration with JSON viewer and validation improvements

### DIFF
--- a/src/containers/WhatsAppForms/Configure/Configure.test.tsx
+++ b/src/containers/WhatsAppForms/Configure/Configure.test.tsx
@@ -2467,6 +2467,73 @@ describe('round-trip preservation — unsupported components & extra attributes'
     expect(deepDiff(RICH_FOOTER, back)).toEqual([]);
   });
 
+  it('generates option ids and titles when the data-source omits them', () => {
+    const input = makeFlowJSON([
+      {
+        type: 'RadioButtonsGroup',
+        name: 'choice',
+        label: 'Pick',
+        required: true,
+        'data-source': [{}, { title: 'Named' }],
+      },
+    ]);
+
+    const output = convertFormBuilderToFlowJSON(convertFlowJSONToFormBuilder(input));
+    const group = layoutAndFormChildren(output.screens[0]).find((c: any) => c.type === 'RadioButtonsGroup');
+
+    expect(group['data-source']).toEqual([
+      { id: '0_undefined', title: '' },
+      { id: '1_Named', title: 'Named' },
+    ]);
+  });
+
+  it('handles a Form with no children and a Footer with no label', () => {
+    const input = {
+      version: '7.3',
+      screens: [
+        {
+          id: 'screen_one',
+          title: 'Screen 1',
+          terminal: true,
+          data: {},
+          layout: {
+            type: 'SingleColumnLayout',
+            children: [
+              { type: 'Form', name: 'flow_path' },
+              { type: 'Footer', 'on-click-action': { name: 'complete', payload: {} } },
+            ],
+          },
+        },
+      ],
+    };
+
+    const screens = convertFlowJSONToFormBuilder(input);
+    expect(screens[0].buttonLabel).toBe('Continue');
+
+    const output = convertFormBuilderToFlowJSON(screens);
+    const footer = layoutAndFormChildren(output.screens[0]).find((c: any) => c.type === 'Footer');
+    expect(footer.label).toBe('Continue');
+  });
+
+  it('handles a screen with no Footer at all', () => {
+    const input = {
+      version: '7.3',
+      screens: [
+        {
+          id: 'screen_one',
+          title: 'Screen 1',
+          terminal: true,
+          data: {},
+          layout: { type: 'SingleColumnLayout', children: [{ type: 'TextBody', text: 'Just text' }] },
+        },
+      ],
+    };
+
+    const screens = convertFlowJSONToFormBuilder(input);
+    expect(screens[0].buttonLabel).toBe('Continue');
+    expect(screens[0].footerAttributes).toBeUndefined();
+  });
+
   it('preserves an attribute the builder has never heard of', () => {
     // Stand-in for a component attribute Meta adds after this code was written
     const futureAttr = { type: 'TextBody', text: 'Hi', 'some-future-attribute': { nested: true } };
@@ -2553,7 +2620,7 @@ describe('JSON editor — unsupported components are saved, not silently dropped
 
     await waitFor(() => {
       expect(notificationSpy).toHaveBeenCalledWith(
-        'Click "Apply Changes" in the JSON editor before saving, or your edits will be lost.',
+        'Click "Apply Changes" in the JSON editor — that applies and saves your edits.',
         'warning'
       );
     });
@@ -2594,7 +2661,32 @@ describe('JSON editor — unsupported components are saved, not silently dropped
 
     await waitFor(() => expect(screen.getByText('Saving')).toBeInTheDocument());
     expect(notificationSpy).not.toHaveBeenCalledWith(
-      'Click "Apply Changes" in the JSON editor before saving, or your edits will be lost.',
+      'Click "Apply Changes" in the JSON editor — that applies and saves your edits.',
+      'warning'
+    );
+  });
+
+  test('the Form Builder button also clears the unapplied-changes guard', async () => {
+    const notificationSpy = vi.spyOn(Notification, 'setNotification');
+    render(wrapper());
+    await waitFor(() => expect(screen.getAllByTestId('form-screen')).toHaveLength(1));
+
+    fireEvent.click(screen.getByTestId('formJsonBtn'));
+    await waitFor(() => expect(screen.getByText('Form JSON')).toBeInTheDocument());
+
+    const textarea = screen.getByTestId('json-preview') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: JSON.stringify(flow([validScreen()])) } });
+    await waitFor(() => expect(screen.getByTestId('apply-changes')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('Form Builder'));
+
+    await waitFor(() => expect(screen.getAllByTestId('form-screen')).toHaveLength(1));
+
+    fireEvent.click(screen.getByTestId('save-button'));
+
+    await waitFor(() => expect(screen.getByText('Saving')).toBeInTheDocument());
+    expect(notificationSpy).not.toHaveBeenCalledWith(
+      'Click "Apply Changes" in the JSON editor — that applies and saves your edits.',
       'warning'
     );
   });

--- a/src/containers/WhatsAppForms/Configure/Configure.test.tsx
+++ b/src/containers/WhatsAppForms/Configure/Configure.test.tsx
@@ -9,6 +9,7 @@ import {
   computeFieldNames,
   convertFlowJSONToFormBuilder,
   convertFormBuilderToFlowJSON,
+  validateFlowJson,
 } from 'containers/WhatsAppForms/Configure/FormBuilder/FormBuilder.utils';
 
 import {
@@ -1431,29 +1432,51 @@ describe('validateFlowJson — all phases', () => {
     );
   });
 
-  test('phase 3 — CalendarPicker inside Form throws layout placement error', async () => {
-    await setJsonAndExpectError(
-      flow([
-        validScreen({
-          layout: {
-            type: 'SingleColumnLayout',
-            children: [
-              formWith([
-                {
-                  type: 'CalendarPicker',
-                  name: 'appt_date',
-                  label: 'Pick a date',
-                  required: true,
-                  mode: 'single',
-                },
-                footer({ name: 'complete', payload: {} }),
-              ]),
-            ],
-          },
-        }),
-      ]),
-      "'CalendarPicker' must be a direct child of SingleColumnLayout, not inside a Form component"
-    );
+  test('phase 3 — CalendarPicker inside Form is valid and stays inside Form', async () => {
+    render(wrapper());
+    await waitFor(() => expect(screen.getAllByTestId('form-screen')).toHaveLength(1));
+
+    fireEvent.click(screen.getByTestId('formJsonBtn'));
+    await waitFor(() => expect(screen.getByText('Form JSON')).toBeInTheDocument());
+
+    const calendarInsideForm = flow([
+      validScreen({
+        layout: {
+          type: 'SingleColumnLayout',
+          children: [
+            formWith([
+              {
+                type: 'CalendarPicker',
+                name: 'appt_date',
+                label: 'Pick a date',
+                required: true,
+                mode: 'single',
+              },
+              footer({ name: 'complete', payload: {} }),
+            ]),
+          ],
+        },
+      }),
+    ]);
+
+    const textarea = screen.getByTestId('json-preview') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: JSON.stringify(calendarInsideForm) } });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('json-error')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Apply Changes'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('apply-changes')).not.toBeInTheDocument();
+    });
+
+    // The picker must not be hoisted out of the Form on the way back to JSON
+    const roundTripped = JSON.parse((screen.getByTestId('json-preview') as HTMLTextAreaElement).value);
+    const [layoutChild] = roundTripped.screens[0].layout.children;
+    expect(layoutChild.type).toBe('Form');
+    expect(layoutChild.children.find((c: any) => c.type === 'CalendarPicker')).toBeDefined();
   });
 
   test('phase 3 — CalendarPicker as direct layout child with Form+Footer is valid', async () => {
@@ -1745,23 +1768,43 @@ describe('validateFlowJson — all phases', () => {
   });
 
   // ── Phase 5: Unknown component type ──────────────────────────────────────
-  test('phase 5 — unknown component type triggers validation error', async () => {
-    await setJsonAndExpectError(
-      flow([
-        validScreen({
-          layout: {
-            type: 'SingleColumnLayout',
-            children: [
-              formWith([
-                { type: 'SuperWidget', name: 'widget_1', label: 'Widget' },
-                footer({ name: 'complete', payload: {} }),
-              ]),
-            ],
-          },
-        }),
-      ]),
-      "Unknown component type 'SuperWidget'"
-    );
+  test('phase 5 — unknown component type does not block saving', async () => {
+    render(wrapper());
+    await waitFor(() => expect(screen.getAllByTestId('form-screen')).toHaveLength(1));
+
+    fireEvent.click(screen.getByTestId('formJsonBtn'));
+    await waitFor(() => expect(screen.getByText('Form JSON')).toBeInTheDocument());
+
+    const superWidget = { type: 'SuperWidget', name: 'widget_1', label: 'Widget' };
+    const withUnknownComponent = flow([
+      validScreen({
+        layout: {
+          type: 'SingleColumnLayout',
+          children: [formWith([superWidget, footer({ name: 'complete', payload: {} })])],
+        },
+      }),
+    ]);
+
+    const textarea = screen.getByTestId('json-preview') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: JSON.stringify(withUnknownComponent) } });
+
+    // An unknown type is not an error, so the edit can still be applied
+    await waitFor(() => {
+      expect(screen.getByTestId('apply-changes')).toBeEnabled();
+    });
+    expect(screen.queryByTestId('json-error')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Apply Changes'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('apply-changes')).not.toBeInTheDocument();
+    });
+
+    // Preserved verbatim, and its name is not mistaken for a form value
+    const roundTripped = JSON.parse((screen.getByTestId('json-preview') as HTMLTextAreaElement).value);
+    const [form] = roundTripped.screens[0].layout.children;
+    expect(form.children.find((c: any) => c.type === 'SuperWidget')).toEqual(superWidget);
+    expect(form.children.find((c: any) => c.type === 'Footer')['on-click-action'].payload).toEqual({});
   });
 
   // ── Phase 6: Data property validation ────────────────────────────────────
@@ -1857,7 +1900,7 @@ describe('round-trip preservation — unsupported components & extra attributes'
     expect(unsupportedItem!.data.rawComponent).toEqual(photoPicker);
 
     const outputJSON = convertFormBuilderToFlowJSON(screens);
-    const outputChildren = outputJSON.screens[0].layout.children;
+    const outputChildren = outputJSON.screens[0].layout.children[0].children;
     const outputComponent = outputChildren.find((c: any) => c.type === 'PhotoPicker');
 
     expect(outputComponent).toEqual(photoPicker);
@@ -2146,33 +2189,465 @@ describe('round-trip preservation — unsupported components & extra attributes'
   });
 
   test('duplicate Unsupported rawComponent names get _1, _2 suffixes like Text Answer/Selection', () => {
-    const flowJSON = makeFlowJSON([
-      {
-        type: 'EmbeddedLink',
-        name: 'promo',
-        text: 'Promo A',
-        'on-click-action': { name: 'open_url', url: 'https://a.com' },
-      },
-      {
-        type: 'EmbeddedLink',
-        name: 'promo',
-        text: 'Promo B',
-        'on-click-action': { name: 'open_url', url: 'https://b.com' },
-      },
-      {
-        type: 'EmbeddedLink',
-        name: 'promo',
-        text: 'Promo C',
-        'on-click-action': { name: 'open_url', url: 'https://c.com' },
-      },
-    ]);
+    const chips = (name: string, label: string) => ({
+      type: 'ChipsSelector',
+      name,
+      label,
+      'data-source': [{ id: '1', title: 'One' }],
+    });
+
+    const flowJSON = makeFlowJSON([chips('choice', 'A'), chips('choice', 'B'), chips('choice', 'C')]);
 
     const screens = convertFlowJSONToFormBuilder(flowJSON);
     const fieldNameMap = computeFieldNames(screens);
 
     const ids = screens[0].content.map((item) => item.id);
-    expect(fieldNameMap.get(ids[0])).toBe('promo');
-    expect(fieldNameMap.get(ids[1])).toBe('promo_1');
-    expect(fieldNameMap.get(ids[2])).toBe('promo_2');
+    expect(fieldNameMap.get(ids[0])).toBe('choice');
+    expect(fieldNameMap.get(ids[1])).toBe('choice_1');
+    expect(fieldNameMap.get(ids[2])).toBe('choice_2');
+  });
+
+  test('a named non-input passthrough component is not treated as a form value', () => {
+    const navigationList = {
+      type: 'NavigationList',
+      name: 'menu',
+      'list-items': [{ id: 'a', 'main-content': { title: 'Item A' } }],
+    };
+
+    const flowJSON = makeFlowJSON([navigationList]);
+    const screens = convertFlowJSONToFormBuilder(flowJSON);
+
+    // No field name, so nothing lands in the footer payload
+    expect(computeFieldNames(screens).size).toBe(0);
+
+    const outputJSON = convertFormBuilderToFlowJSON(screens);
+    const outputChildren = outputJSON.screens[0].layout.children[0].children;
+    expect(outputChildren.find((c: any) => c.type === 'NavigationList')).toEqual(navigationList);
+    expect(outputChildren.find((c: any) => c.type === 'Footer')['on-click-action'].payload).toEqual({});
+  });
+
+  /**
+   * Every component the builder models, with every attribute Meta's reference page lists —
+   * each has its own conversion branch and its own CONSUMED_ATTRIBUTE_KEYS entry, so each can
+   * break independently.
+   *
+   * Passthrough components all share one code path (`rawComponent` returned verbatim), so only
+   * three representatives are covered: PhotoPicker (an input), Switch (nested children) and
+   * RichText (array-valued attribute). CalendarPicker, DocumentPicker, EmbeddedLink,
+   * NavigationList and ChipsSelector have their own dedicated tests above.
+   *
+   * Source: plans/Components.md (Meta's Flow JSON component reference) + the media upload page.
+   */
+  const COMPONENTS: Record<string, any> = {
+    TextHeading: { type: 'TextHeading', text: 'Heading', visible: true },
+    TextSubheading: { type: 'TextSubheading', text: 'Sub', visible: true },
+    TextBody: {
+      type: 'TextBody',
+      text: 'Body',
+      'font-weight': 'bold',
+      strikethrough: false,
+      visible: true,
+      markdown: true,
+    },
+    TextCaption: {
+      type: 'TextCaption',
+      text: 'Cap',
+      'font-weight': 'italic',
+      strikethrough: true,
+      visible: true,
+      markdown: false,
+    },
+    RichText: { type: 'RichText', text: ['# H1', 'some **bold**'], visible: true },
+    TextInput: {
+      type: 'TextInput',
+      label: 'Name',
+      'input-type': 'text',
+      pattern: '^[a-z]+$',
+      required: true,
+      'min-chars': 2,
+      'max-chars': 40,
+      'helper-text': 'Your name',
+      name: 'full_name',
+      visible: true,
+      'init-value': 'abc',
+      'error-message': 'Bad name',
+    },
+    TextArea: {
+      type: 'TextArea',
+      label: 'Notes',
+      required: false,
+      'max-length': 500,
+      name: 'notes',
+      'helper-text': 'Optional',
+      enabled: true,
+      visible: true,
+      'init-value': 'hi',
+      'error-message': 'Too long',
+    },
+    CheckboxGroup: {
+      type: 'CheckboxGroup',
+      name: 'toppings',
+      label: 'Toppings',
+      required: true,
+      'data-source': [
+        {
+          id: '1',
+          title: 'Cheese',
+          description: 'Extra',
+          metadata: 'meta',
+          enabled: true,
+          image: 'BASE64',
+          'alt-text': 'cheese',
+          color: '#ffffff',
+        },
+      ],
+      'min-selected-items': 1,
+      'max-selected-items': 3,
+      enabled: true,
+      visible: true,
+      'on-select-action': { name: 'update_data', payload: {} },
+      description: 'Pick some',
+      'init-value': ['1'],
+      'error-message': 'Pick one',
+      'media-size': 'regular',
+    },
+    RadioButtonsGroup: {
+      type: 'RadioButtonsGroup',
+      name: 'size',
+      label: 'Size',
+      required: true,
+      'data-source': [
+        {
+          id: '1',
+          title: 'Small',
+          description: 'S',
+          metadata: 'm',
+          enabled: true,
+          image: 'BASE64',
+          'alt-text': 'small',
+          color: '#000000',
+        },
+      ],
+      enabled: true,
+      visible: true,
+      'on-select-action': { name: 'update_data', payload: {} },
+      description: 'Choose',
+      'init-value': '1',
+      'error-message': 'Required',
+      'media-size': 'regular',
+    },
+    Dropdown: {
+      type: 'Dropdown',
+      label: 'City',
+      name: 'city',
+      'data-source': [
+        {
+          id: '1',
+          title: 'Pune',
+          description: 'MH',
+          metadata: 'm',
+          enabled: true,
+          image: 'BASE64',
+          'alt-text': 'pune',
+        },
+      ],
+      required: true,
+      enabled: true,
+      visible: true,
+      'on-select-action': { name: 'update_data', payload: {} },
+      'init-value': '1',
+      'error-message': 'Required',
+    },
+    DatePicker: {
+      type: 'DatePicker',
+      label: 'DOB',
+      'min-date': '1900-01-01',
+      'max-date': '2030-01-01',
+      name: 'dob',
+      'unavailable-dates': ['2025-01-01'],
+      visible: true,
+      'helper-text': 'Pick',
+      enabled: true,
+      'on-select-action': { name: 'update_data', payload: {} },
+      'init-value': '2000-01-01',
+      'error-message': 'Bad date',
+    },
+    OptIn: {
+      type: 'OptIn',
+      label: 'I agree',
+      required: true,
+      name: 'terms',
+      'on-click-action': { name: 'navigate', next: { type: 'screen', name: 'x' }, payload: {} },
+      visible: true,
+      'init-value': false,
+    },
+    Image: {
+      type: 'Image',
+      src: 'QkFTRTY0',
+      width: 200,
+      height: 100,
+      'scale-type': 'cover',
+      'aspect-ratio': 1,
+      'alt-text': 'pic',
+    },
+    PhotoPicker: {
+      type: 'PhotoPicker',
+      name: 'photos',
+      label: 'Photos',
+      description: 'up to 3',
+      'photo-source': 'camera_gallery',
+      'max-file-size-kb': 1024,
+      'min-uploaded-photos': 1,
+      'max-uploaded-photos': 3,
+      enabled: true,
+      visible: true,
+      'error-message': 'req',
+    },
+    Switch: {
+      type: 'Switch',
+      value: '${data.status}',
+      cases: { pending: [{ type: 'TextBody', text: 'p' }], done: [{ type: 'TextBody', text: 'd' }] },
+    },
+  };
+
+  const RICH_FOOTER = {
+    type: 'Footer',
+    label: 'Done',
+    'left-caption': 'L',
+    'right-caption': 'R',
+    enabled: true,
+    'on-click-action': { name: 'complete', payload: {} },
+  };
+
+  const layoutAndFormChildren = (screen: any) => {
+    const out: any[] = [];
+    (screen.layout?.children || []).forEach((c: any) => {
+      if (c.type === 'Form') (c.children || []).forEach((x: any) => out.push(x));
+      else out.push(c);
+    });
+    return out;
+  };
+
+  const deepDiff = (want: any, got: any, path = ''): string[] => {
+    if (Array.isArray(want)) {
+      if (!Array.isArray(got)) return [`${path}: not an array`];
+      return want.flatMap((v, i) => deepDiff(v, got[i], `${path}[${i}]`));
+    }
+    if (want && typeof want === 'object') {
+      if (!got || typeof got !== 'object') return [`${path}: missing`];
+      return Object.keys(want).flatMap((k) =>
+        k in got ? deepDiff(want[k], got[k], path ? `${path}.${k}` : k) : [`${path ? `${path}.` : ''}${k}: DROPPED`]
+      );
+    }
+    return JSON.stringify(want) === JSON.stringify(got)
+      ? []
+      : [`${path}: ${JSON.stringify(want)} -> ${JSON.stringify(got)}`];
+  };
+
+  it.each(Object.keys(COMPONENTS))('%s survives a round-trip with every documented attribute', (name) => {
+    const component = COMPONENTS[name];
+    const input = makeFlowJSON([component]);
+
+    expect(validateFlowJson(input).errors).toEqual([]);
+
+    const output = convertFormBuilderToFlowJSON(convertFlowJSONToFormBuilder(input));
+    const back = layoutAndFormChildren(output.screens[0]).find((c: any) => c.type === name);
+
+    expect(back).toBeDefined();
+    expect(deepDiff(component, back)).toEqual([]);
+  });
+
+  it('preserves Footer attributes the builder does not edit', () => {
+    const input = makeFlowJSON([COMPONENTS.TextBody]);
+    input.screens[0].layout.children[0].children = [COMPONENTS.TextBody, RICH_FOOTER];
+
+    const output = convertFormBuilderToFlowJSON(convertFlowJSONToFormBuilder(input));
+    const back = layoutAndFormChildren(output.screens[0]).find((c: any) => c.type === 'Footer');
+
+    expect(deepDiff(RICH_FOOTER, back)).toEqual([]);
+  });
+
+  it('preserves an attribute the builder has never heard of', () => {
+    // Stand-in for a component attribute Meta adds after this code was written
+    const futureAttr = { type: 'TextBody', text: 'Hi', 'some-future-attribute': { nested: true } };
+    const output = convertFormBuilderToFlowJSON(convertFlowJSONToFormBuilder(makeFlowJSON([futureAttr])));
+    const back = layoutAndFormChildren(output.screens[0]).find((c: any) => c.type === 'TextBody');
+
+    expect(back['some-future-attribute']).toEqual({ nested: true });
+  });
+});
+
+describe('JSON editor — unsupported components are saved, not silently dropped', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  // Reported bug: a PhotoPicker inside a Form was rejected as a layout-placement error, which
+  // hid "Apply Changes", so Save Draft kept persisting the untouched template.
+  test('PhotoPicker inside a Form applies and round-trips verbatim', async () => {
+    render(wrapper());
+    await waitFor(() => expect(screen.getAllByTestId('form-screen')).toHaveLength(1));
+
+    fireEvent.click(screen.getByTestId('formJsonBtn'));
+    await waitFor(() => expect(screen.getByText('Form JSON')).toBeInTheDocument());
+
+    const photoPicker = {
+      type: 'PhotoPicker',
+      'photo-source': 'camera_gallery',
+      name: 'photos',
+      'min-uploaded-photos': 0,
+      'max-uploaded-photos': 10,
+      'max-file-size-kb': 10240,
+      label: 'Dear Teacher, please share 10 photos of your students work.',
+      description: 'Click "Take Photo" to take each photo.',
+    };
+    const pastedJSON = flow([
+      {
+        id: 'Share_student_work',
+        title: 'Share Student Work',
+        terminal: true,
+        data: {},
+        layout: {
+          type: 'SingleColumnLayout',
+          children: [
+            formWith([photoPicker, footer({ name: 'complete', payload: { photos: '${form.photos}' } }, 'Share')]),
+          ],
+        },
+      },
+    ]);
+
+    const textarea = screen.getByTestId('json-preview') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: JSON.stringify(pastedJSON) } });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('json-error')).not.toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Apply Changes'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('apply-changes')).not.toBeInTheDocument();
+    });
+
+    const roundTripped = JSON.parse((screen.getByTestId('json-preview') as HTMLTextAreaElement).value);
+    const [layoutChild] = roundTripped.screens[0].layout.children;
+    expect(layoutChild.type).toBe('Form');
+    expect(layoutChild.children.find((c: any) => c.type === 'PhotoPicker')).toEqual(photoPicker);
+    expect(layoutChild.children.find((c: any) => c.type === 'Footer')['on-click-action'].payload).toEqual({
+      photos: '${form.photos}',
+    });
+  });
+
+  test('Save Draft refuses to run while JSON edits are unapplied', async () => {
+    const notificationSpy = vi.spyOn(Notification, 'setNotification');
+    render(wrapper());
+    await waitFor(() => expect(screen.getAllByTestId('form-screen')).toHaveLength(1));
+
+    fireEvent.click(screen.getByTestId('formJsonBtn'));
+    await waitFor(() => expect(screen.getByText('Form JSON')).toBeInTheDocument());
+
+    const textarea = screen.getByTestId('json-preview') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: JSON.stringify(flow([validScreen()])) } });
+
+    await waitFor(() => expect(screen.getByTestId('apply-changes')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('save-button'));
+
+    await waitFor(() => {
+      expect(notificationSpy).toHaveBeenCalledWith(
+        'Click "Apply Changes" in the JSON editor before saving, or your edits will be lost.',
+        'warning'
+      );
+    });
+    expect(screen.queryByText('Saving')).not.toBeInTheDocument();
+  });
+
+  test('invalid JSON keeps Apply Changes visible but disabled', async () => {
+    render(wrapper());
+    await waitFor(() => expect(screen.getAllByTestId('form-screen')).toHaveLength(1));
+
+    fireEvent.click(screen.getByTestId('formJsonBtn'));
+    await waitFor(() => expect(screen.getByText('Form JSON')).toBeInTheDocument());
+
+    const textarea = screen.getByTestId('json-preview') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: JSON.stringify(flow([validScreen({ title: '' })])) } });
+
+    await waitFor(() => expect(screen.getByTestId('json-error')).toBeInTheDocument());
+    expect(screen.getByTestId('apply-changes')).toBeDisabled();
+  });
+
+  test('closing the JSON editor clears the unapplied-changes guard', async () => {
+    const notificationSpy = vi.spyOn(Notification, 'setNotification');
+    render(wrapper());
+    await waitFor(() => expect(screen.getAllByTestId('form-screen')).toHaveLength(1));
+
+    fireEvent.click(screen.getByTestId('formJsonBtn'));
+    await waitFor(() => expect(screen.getByText('Form JSON')).toBeInTheDocument());
+
+    const textarea = screen.getByTestId('json-preview') as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: JSON.stringify(flow([validScreen()])) } });
+    await waitFor(() => expect(screen.getByTestId('apply-changes')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId('json-viewer-close'));
+
+    await waitFor(() => expect(screen.getAllByTestId('form-screen')).toHaveLength(1));
+
+    fireEvent.click(screen.getByTestId('save-button'));
+
+    await waitFor(() => expect(screen.getByText('Saving')).toBeInTheDocument());
+    expect(notificationSpy).not.toHaveBeenCalledWith(
+      'Click "Apply Changes" in the JSON editor before saving, or your edits will be lost.',
+      'warning'
+    );
+  });
+
+  test('media upload values are kept out of navigate payloads and cross-screen data', () => {
+    const photoPicker = {
+      type: 'PhotoPicker',
+      name: 'photos',
+      label: 'Upload photos',
+      'max-uploaded-photos': 3,
+    };
+
+    const twoScreens = flow([
+      {
+        id: 'screen_one',
+        title: 'Screen One',
+        terminal: false,
+        data: {},
+        layout: {
+          type: 'SingleColumnLayout',
+          children: [
+            formWith([
+              photoPicker,
+              footer({ name: 'navigate', next: { name: 'screen_two', type: 'screen' }, payload: {} }),
+            ]),
+          ],
+        },
+      },
+      {
+        id: 'screen_two',
+        title: 'Screen Two',
+        terminal: true,
+        data: {},
+        layout: {
+          type: 'SingleColumnLayout',
+          children: [
+            formWith([
+              { type: 'TextInput', name: 'notes', label: 'Notes', required: false, 'input-type': 'text' },
+              footer({ name: 'complete', payload: {} }),
+            ]),
+          ],
+        },
+      },
+    ]);
+
+    const outputJSON = convertFormBuilderToFlowJSON(convertFlowJSONToFormBuilder(twoScreens));
+    const [first, second] = outputJSON.screens;
+
+    const navigateFooter = first.layout.children[0].children.find((c: any) => c.type === 'Footer');
+    expect(navigateFooter['on-click-action'].payload).toEqual({});
+    expect(second.data).toEqual({});
+
+    // ...but the picker itself is untouched
+    expect(first.layout.children[0].children.find((c: any) => c.type === 'PhotoPicker')).toEqual(photoPicker);
   });
 });

--- a/src/containers/WhatsAppForms/Configure/Configure.test.tsx
+++ b/src/containers/WhatsAppForms/Configure/Configure.test.tsx
@@ -13,6 +13,8 @@ import {
 } from 'containers/WhatsAppForms/Configure/FormBuilder/FormBuilder.utils';
 
 import {
+  FLOW_JSON_COMPONENTS,
+  FOOTER_WITH_CAPTIONS,
   WHATSAPP_FORM_MOCKS,
   validScreen,
   revertWhatsappFormRevisionMock,
@@ -2226,199 +2228,6 @@ describe('round-trip preservation — unsupported components & extra attributes'
     expect(outputChildren.find((c: any) => c.type === 'Footer')['on-click-action'].payload).toEqual({});
   });
 
-  /**
-   * Every component the builder models, with every attribute Meta's reference page lists —
-   * each has its own conversion branch and its own CONSUMED_ATTRIBUTE_KEYS entry, so each can
-   * break independently.
-   *
-   * Passthrough components all share one code path (`rawComponent` returned verbatim), so only
-   * three representatives are covered: PhotoPicker (an input), Switch (nested children) and
-   * RichText (array-valued attribute). CalendarPicker, DocumentPicker, EmbeddedLink,
-   * NavigationList and ChipsSelector have their own dedicated tests above.
-   *
-   * Source: plans/Components.md (Meta's Flow JSON component reference) + the media upload page.
-   */
-  const COMPONENTS: Record<string, any> = {
-    TextHeading: { type: 'TextHeading', text: 'Heading', visible: true },
-    TextSubheading: { type: 'TextSubheading', text: 'Sub', visible: true },
-    TextBody: {
-      type: 'TextBody',
-      text: 'Body',
-      'font-weight': 'bold',
-      strikethrough: false,
-      visible: true,
-      markdown: true,
-    },
-    TextCaption: {
-      type: 'TextCaption',
-      text: 'Cap',
-      'font-weight': 'italic',
-      strikethrough: true,
-      visible: true,
-      markdown: false,
-    },
-    RichText: { type: 'RichText', text: ['# H1', 'some **bold**'], visible: true },
-    TextInput: {
-      type: 'TextInput',
-      label: 'Name',
-      'input-type': 'text',
-      pattern: '^[a-z]+$',
-      required: true,
-      'min-chars': 2,
-      'max-chars': 40,
-      'helper-text': 'Your name',
-      name: 'full_name',
-      visible: true,
-      'init-value': 'abc',
-      'error-message': 'Bad name',
-    },
-    TextArea: {
-      type: 'TextArea',
-      label: 'Notes',
-      required: false,
-      'max-length': 500,
-      name: 'notes',
-      'helper-text': 'Optional',
-      enabled: true,
-      visible: true,
-      'init-value': 'hi',
-      'error-message': 'Too long',
-    },
-    CheckboxGroup: {
-      type: 'CheckboxGroup',
-      name: 'toppings',
-      label: 'Toppings',
-      required: true,
-      'data-source': [
-        {
-          id: '1',
-          title: 'Cheese',
-          description: 'Extra',
-          metadata: 'meta',
-          enabled: true,
-          image: 'BASE64',
-          'alt-text': 'cheese',
-          color: '#ffffff',
-        },
-      ],
-      'min-selected-items': 1,
-      'max-selected-items': 3,
-      enabled: true,
-      visible: true,
-      'on-select-action': { name: 'update_data', payload: {} },
-      description: 'Pick some',
-      'init-value': ['1'],
-      'error-message': 'Pick one',
-      'media-size': 'regular',
-    },
-    RadioButtonsGroup: {
-      type: 'RadioButtonsGroup',
-      name: 'size',
-      label: 'Size',
-      required: true,
-      'data-source': [
-        {
-          id: '1',
-          title: 'Small',
-          description: 'S',
-          metadata: 'm',
-          enabled: true,
-          image: 'BASE64',
-          'alt-text': 'small',
-          color: '#000000',
-        },
-      ],
-      enabled: true,
-      visible: true,
-      'on-select-action': { name: 'update_data', payload: {} },
-      description: 'Choose',
-      'init-value': '1',
-      'error-message': 'Required',
-      'media-size': 'regular',
-    },
-    Dropdown: {
-      type: 'Dropdown',
-      label: 'City',
-      name: 'city',
-      'data-source': [
-        {
-          id: '1',
-          title: 'Pune',
-          description: 'MH',
-          metadata: 'm',
-          enabled: true,
-          image: 'BASE64',
-          'alt-text': 'pune',
-        },
-      ],
-      required: true,
-      enabled: true,
-      visible: true,
-      'on-select-action': { name: 'update_data', payload: {} },
-      'init-value': '1',
-      'error-message': 'Required',
-    },
-    DatePicker: {
-      type: 'DatePicker',
-      label: 'DOB',
-      'min-date': '1900-01-01',
-      'max-date': '2030-01-01',
-      name: 'dob',
-      'unavailable-dates': ['2025-01-01'],
-      visible: true,
-      'helper-text': 'Pick',
-      enabled: true,
-      'on-select-action': { name: 'update_data', payload: {} },
-      'init-value': '2000-01-01',
-      'error-message': 'Bad date',
-    },
-    OptIn: {
-      type: 'OptIn',
-      label: 'I agree',
-      required: true,
-      name: 'terms',
-      'on-click-action': { name: 'navigate', next: { type: 'screen', name: 'x' }, payload: {} },
-      visible: true,
-      'init-value': false,
-    },
-    Image: {
-      type: 'Image',
-      src: 'QkFTRTY0',
-      width: 200,
-      height: 100,
-      'scale-type': 'cover',
-      'aspect-ratio': 1,
-      'alt-text': 'pic',
-    },
-    PhotoPicker: {
-      type: 'PhotoPicker',
-      name: 'photos',
-      label: 'Photos',
-      description: 'up to 3',
-      'photo-source': 'camera_gallery',
-      'max-file-size-kb': 1024,
-      'min-uploaded-photos': 1,
-      'max-uploaded-photos': 3,
-      enabled: true,
-      visible: true,
-      'error-message': 'req',
-    },
-    Switch: {
-      type: 'Switch',
-      value: '${data.status}',
-      cases: { pending: [{ type: 'TextBody', text: 'p' }], done: [{ type: 'TextBody', text: 'd' }] },
-    },
-  };
-
-  const RICH_FOOTER = {
-    type: 'Footer',
-    label: 'Done',
-    'left-caption': 'L',
-    'right-caption': 'R',
-    enabled: true,
-    'on-click-action': { name: 'complete', payload: {} },
-  };
-
   const layoutAndFormChildren = (screen: any) => {
     const out: any[] = [];
     (screen.layout?.children || []).forEach((c: any) => {
@@ -2444,8 +2253,8 @@ describe('round-trip preservation — unsupported components & extra attributes'
       : [`${path}: ${JSON.stringify(want)} -> ${JSON.stringify(got)}`];
   };
 
-  it.each(Object.keys(COMPONENTS))('%s survives a round-trip with every documented attribute', (name) => {
-    const component = COMPONENTS[name];
+  it.each(Object.keys(FLOW_JSON_COMPONENTS))('%s survives a round-trip with every documented attribute', (name) => {
+    const component = FLOW_JSON_COMPONENTS[name];
     const input = makeFlowJSON([component]);
 
     expect(validateFlowJson(input).errors).toEqual([]);
@@ -2458,13 +2267,13 @@ describe('round-trip preservation — unsupported components & extra attributes'
   });
 
   it('preserves Footer attributes the builder does not edit', () => {
-    const input = makeFlowJSON([COMPONENTS.TextBody]);
-    input.screens[0].layout.children[0].children = [COMPONENTS.TextBody, RICH_FOOTER];
+    const input = makeFlowJSON([FLOW_JSON_COMPONENTS.TextBody]);
+    input.screens[0].layout.children[0].children = [FLOW_JSON_COMPONENTS.TextBody, FOOTER_WITH_CAPTIONS];
 
     const output = convertFormBuilderToFlowJSON(convertFlowJSONToFormBuilder(input));
     const back = layoutAndFormChildren(output.screens[0]).find((c: any) => c.type === 'Footer');
 
-    expect(deepDiff(RICH_FOOTER, back)).toEqual([]);
+    expect(deepDiff(FOOTER_WITH_CAPTIONS, back)).toEqual([]);
   });
 
   it('generates option ids and titles when the data-source omits them', () => {

--- a/src/containers/WhatsAppForms/Configure/Configure.tsx
+++ b/src/containers/WhatsAppForms/Configure/Configure.tsx
@@ -169,8 +169,7 @@ export const Configure = () => {
 
   const handleSaveWhatsappFormRevision = async () => {
     if (hasUnappliedJSON) {
-      setNotification('Click "Apply Changes" in the JSON editor before saving, or your edits will be lost.', 'warning');
-      hasUnsavedChangesRef.current = true;
+      setNotification('Click "Apply Changes" in the JSON editor — that applies and saves your edits.', 'warning');
       return;
     }
 
@@ -202,7 +201,7 @@ export const Configure = () => {
       return;
     }
 
-    if (isViewOnly || !params.id || screens.length === 0) {
+    if (isViewOnly || !params.id || screens.length === 0 || hasUnappliedJSON) {
       return;
     }
 

--- a/src/containers/WhatsAppForms/Configure/Configure.tsx
+++ b/src/containers/WhatsAppForms/Configure/Configure.tsx
@@ -30,6 +30,7 @@ export const Configure = () => {
   const [openDialog, setOpenDialog] = useState(false);
 
   const [showJSON, setShowJSON] = useState(false);
+  const [hasUnappliedJSON, setHasUnappliedJSON] = useState(false);
   const [view, setView] = useState<'preview' | 'variables' | 'versions'>('preview');
   const [isPublished, setIsPublished] = useState(false);
   const [previewingVersion, setPreviewingVersion] = useState<number | null>(null);
@@ -49,6 +50,11 @@ export const Configure = () => {
 
   const handleViewJSON = () => {
     setShowJSON(true);
+  };
+
+  const closeJSONViewer = () => {
+    setShowJSON(false);
+    setHasUnappliedJSON(false);
   };
 
   const handleScreensChange = (newScreens: Screen[] | ((prev: Screen[]) => Screen[])) => {
@@ -109,7 +115,7 @@ export const Configure = () => {
 
   const handleBackToEditing = () => {
     if (showJSON) {
-      setShowJSON(false);
+      closeJSONViewer();
       return;
     }
     setScreens(currentScreensRef.current);
@@ -162,6 +168,12 @@ export const Configure = () => {
   }, [latestRevisionData]);
 
   const handleSaveWhatsappFormRevision = async () => {
+    if (hasUnappliedJSON) {
+      setNotification('Click "Apply Changes" in the JSON editor before saving, or your edits will be lost.', 'warning');
+      hasUnsavedChangesRef.current = true;
+      return;
+    }
+
     const flowJSON = convertFormBuilderToFlowJSON(screens);
 
     try {
@@ -212,7 +224,7 @@ export const Configure = () => {
         clearTimeout(saveTimeoutRef.current);
       }
     };
-  }, [screens, params.id, saveWhatsappFormRevision, isViewOnly]);
+  }, [screens, params.id, saveWhatsappFormRevision, isViewOnly, hasUnappliedJSON]);
 
   let dialog;
   if (openDialog) {
@@ -303,8 +315,9 @@ export const Configure = () => {
           {showJSON ? (
             <JSONViewer
               screens={screens}
-              onClose={() => setShowJSON(false)}
+              onClose={closeJSONViewer}
               onScreensChange={isViewOnly ? undefined : handleScreensChange}
+              onUnappliedChanges={setHasUnappliedJSON}
             />
           ) : (
             <FormBuilder

--- a/src/containers/WhatsAppForms/Configure/FormBuilder/FormBuilder.types.ts
+++ b/src/containers/WhatsAppForms/Configure/FormBuilder/FormBuilder.types.ts
@@ -4,6 +4,7 @@ export interface Screen {
   order: number;
   content: ContentItem[];
   buttonLabel: string;
+  footerAttributes?: Record<string, any>;
 }
 
 export interface ContentItem {
@@ -25,11 +26,13 @@ export interface ContentItemData {
   variableName?: string;
   extraAttributes?: Record<string, any>;
   rawComponent?: any;
+  layoutDirect?: boolean;
 }
 
 export interface ContentOption {
   id: string;
   value: string;
+  extraAttributes?: Record<string, any>;
 }
 
 export interface FormBuilderProps {

--- a/src/containers/WhatsAppForms/Configure/FormBuilder/FormBuilder.utils.ts
+++ b/src/containers/WhatsAppForms/Configure/FormBuilder/FormBuilder.utils.ts
@@ -33,6 +33,35 @@ const generateUniqueScreenIds = (screens: Screen[]): string[] => {
   return ids;
 };
 
+/**
+ * Component types that hold a form value — the ones whose `name` becomes a payload key.
+ * Components outside this list may still carry a `name` (NavigationList, for instance)
+ * without contributing a value, so they must never be added to a footer payload.
+ */
+const INPUT_COMPONENT_TYPES = [
+  'TextInput',
+  'TextArea',
+  'DatePicker',
+  'RadioButtonsGroup',
+  'CheckboxGroup',
+  'Dropdown',
+  'OptIn',
+  'CalendarPicker',
+  'ChipsSelector',
+  'DocumentPicker',
+  'PhotoPicker',
+];
+
+/**
+ * Media upload values cannot be relayed between screens — Meta rejects them in the payload
+ * of a navigate action, so they are only ever emitted on the terminal screen.
+ */
+const MEDIA_UPLOAD_COMPONENT_TYPES = new Set(['PhotoPicker', 'DocumentPicker']);
+
+/** True when a passthrough component holds a form value, so its `name` is a payload key. */
+const isInputComponent = (component: any): boolean =>
+  !!component?.name && INPUT_COMPONENT_TYPES.includes(component.type);
+
 /** Checks whether a content item has validation errors based on its type (empty labels, missing options, etc.). */
 export const hasContentItemError = (item: ContentItem): boolean => {
   const { data, type, name } = item;
@@ -127,12 +156,15 @@ export const convertFormBuilderToFlowJSON = (screens: Screen[]): any => {
     );
 
     screen.content.forEach((item) => {
-      if (item.type === 'Unsupported' && item.data.rawComponent?.name) {
+      if (item.type === 'Unsupported') {
+        const raw = item.data.rawComponent;
+        // Media uploads cannot be relayed to later screens, so they never enter the data schema
+        if (!isInputComponent(raw) || MEDIA_UPLOAD_COMPONENT_TYPES.has(raw.type)) return;
         const fieldName = fieldNameMap.get(item.id);
         if (fieldName) {
           previousScreensPayloadData.push({
             payloadKey: fieldName,
-            fieldType: item.data.rawComponent.type,
+            fieldType: raw.type,
             inputType: 'text',
             screenId: screenIds[index],
           });
@@ -232,9 +264,11 @@ export const computeFieldNames = (screens: Screen[]): Map<string, string> => {
 
   screens.forEach((screen) => {
     screen.content.forEach((item) => {
-      // Unsupported components with a name are input components that need field tracking
-      if (item.type === 'Unsupported' && item.data.rawComponent?.name) {
-        const name = uniqueName(item.data.rawComponent.name, usedNames);
+      // Passthrough components only need field tracking when they actually hold a value
+      if (item.type === 'Unsupported') {
+        const raw = item.data.rawComponent;
+        if (!isInputComponent(raw)) return;
+        const name = uniqueName(raw.name, usedNames);
         usedNames.add(name);
         fieldNameMap.set(item.id, name);
         return;
@@ -267,6 +301,7 @@ const convertContentItemToComponent = (item: ContentItem, fieldNameMap: Map<stri
     return {
       text: data.text,
       type: componentType,
+      ...data.extraAttributes,
     };
   }
 
@@ -289,6 +324,7 @@ const convertContentItemToComponent = (item: ContentItem, fieldNameMap: Map<stri
       required: data.required || false,
       type: 'TextArea',
       ...(data.placeholder && { 'helper-text': data.placeholder }),
+      ...data.extraAttributes,
     };
   }
 
@@ -308,6 +344,7 @@ const convertContentItemToComponent = (item: ContentItem, fieldNameMap: Map<stri
       'data-source': (data.options || []).map((opt, index) => ({
         id: opt.id || `${index}_${opt.value}`,
         title: opt.value,
+        ...opt.extraAttributes,
       })),
       label: data.label,
       name: fieldName,
@@ -322,6 +359,7 @@ const convertContentItemToComponent = (item: ContentItem, fieldNameMap: Map<stri
       'data-source': (data.options || []).map((opt, index) => ({
         id: opt.id || `${index}_${opt.value}`,
         title: opt.value,
+        ...opt.extraAttributes,
       })),
       label: data.label,
       name: fieldName,
@@ -336,6 +374,7 @@ const convertContentItemToComponent = (item: ContentItem, fieldNameMap: Map<stri
       'data-source': (data.options || []).map((opt, index) => ({
         id: opt.id || `${index}_${opt.value}`,
         title: opt.value,
+        ...opt.extraAttributes,
       })),
       label: data.label,
       name: fieldName,
@@ -351,6 +390,7 @@ const convertContentItemToComponent = (item: ContentItem, fieldNameMap: Map<stri
       name: fieldName,
       required: data.required || false,
       type: 'OptIn',
+      ...data.extraAttributes,
     };
   }
 
@@ -361,6 +401,7 @@ const convertContentItemToComponent = (item: ContentItem, fieldNameMap: Map<stri
       src: src || '',
       height: 400,
       'scale-type': 'contain',
+      ...data.extraAttributes,
     };
   }
 
@@ -434,8 +475,13 @@ const generateScreenPayload = (
   });
 
   screenContent.forEach((item) => {
-    if (item.type === 'Unsupported' && item.data.rawComponent?.name && fieldNameMap.has(item.id)) {
-      payload[fieldNameMap.get(item.id)!] = `\${form.${fieldNameMap.get(item.id)!}}`;
+    if (item.type === 'Unsupported') {
+      const raw = item.data.rawComponent;
+      if (!isInputComponent(raw) || !fieldNameMap.has(item.id)) return;
+      // Meta rejects media upload values in a navigate payload — terminal screens only
+      if (MEDIA_UPLOAD_COMPONENT_TYPES.has(raw.type) && !isTerminal) return;
+      const fieldName = fieldNameMap.get(item.id)!;
+      payload[fieldName] = `\${form.${fieldName}}`;
       return;
     }
 
@@ -452,12 +498,6 @@ const generateScreenPayload = (
 
   return payload;
 };
-
-/**
- * Component types that must be direct children of SingleColumnLayout,
- * NOT nested inside a Form component.
- */
-const LAYOUT_DIRECT_COMPONENT_TYPES = new Set(['CalendarPicker', 'DocumentPicker', 'PhotoPicker']);
 
 /** Converts a single form builder screen into a WhatsApp Flow JSON screen object with layout, components, and footer. */
 export const convertScreenToFlowJSON = (
@@ -481,8 +521,7 @@ export const convertScreenToFlowJSON = (
     const component = convertContentItemToComponent(item, fieldNameMap);
     if (!component) return;
 
-    const rawType = item.type === 'Unsupported' ? item.data.rawComponent?.type : null;
-    if (rawType && LAYOUT_DIRECT_COMPONENT_TYPES.has(rawType)) {
+    if (item.data.layoutDirect) {
       layoutDirectChildren.push(component);
     } else {
       formChildren.push(component);
@@ -500,6 +539,7 @@ export const convertScreenToFlowJSON = (
           ? { name: 'complete', payload }
           : { name: 'navigate', next: { name: nextScreenId || 'NEXT_SCREEN', type: 'screen' }, payload },
         type: 'Footer',
+        ...screen.footerAttributes,
       }
     : null;
 
@@ -557,86 +597,66 @@ const getInternalComponentType = (whatsappType: string): { type: string; name: s
 };
 
 /**
- * Extra Meta-spec keys per component type that the form builder does not edit.
- * These are picked from the JSON component and stored in extraAttributes so they
- * are spread back verbatim when converting back to JSON — nothing is lost.
+ * Keys each component type is *modelled* on — the ones the builder writes back itself.
+ * Everything else on a component is captured into extraAttributes and spread back
+ * verbatim, so an attribute the builder does not understand (including one Meta adds
+ * later) survives a round-trip instead of being silently dropped.
  */
-const EXTRA_ATTRIBUTE_KEYS: Record<string, string[]> = {
-  TextInput: ['pattern', 'min-chars', 'max-chars'],
-  DatePicker: [
-    'min-date',
-    'max-date',
-    'unavailable-dates',
-    'visible',
-    'enabled',
-    'on-select-action',
-    'init-value',
-    'error-message',
-  ],
-  RadioButtonsGroup: [
-    'min-selected-items',
-    'max-selected-items',
-    'enabled',
-    'visible',
-    'on-select-action',
-    'on-unselect-action',
-    'description',
-    'init-value',
-    'error-message',
-    'media-size',
-  ],
-  CheckboxGroup: [
-    'min-selected-items',
-    'max-selected-items',
-    'enabled',
-    'visible',
-    'on-select-action',
-    'on-unselect-action',
-    'description',
-    'init-value',
-    'error-message',
-    'media-size',
-  ],
-  Dropdown: ['enabled', 'visible', 'on-select-action', 'on-unselect-action', 'init-value', 'error-message'],
+const CONSUMED_ATTRIBUTE_KEYS: Record<string, string[]> = {
+  TextHeading: ['type', 'text'],
+  TextSubheading: ['type', 'text'],
+  TextCaption: ['type', 'text'],
+  TextBody: ['type', 'text'],
+  TextInput: ['type', 'label', 'name', 'required', 'input-type', 'helper-text'],
+  TextArea: ['type', 'label', 'name', 'required', 'helper-text'],
+  DatePicker: ['type', 'label', 'name', 'required', 'helper-text'],
+  RadioButtonsGroup: ['type', 'label', 'name', 'required', 'data-source'],
+  CheckboxGroup: ['type', 'label', 'name', 'required', 'data-source'],
+  Dropdown: ['type', 'label', 'name', 'required', 'data-source'],
+  OptIn: ['type', 'label', 'name', 'required'],
+  Image: ['type', 'src'],
 };
 
 /**
- * All component types valid per the WhatsApp Flows spec.
- * Supported types are editable in the form builder.
- * Known-but-unsupported types are preserved as raw JSON passthroughs.
- * Anything outside this set triggers a validation error.
+ * Component types known to the WhatsApp Flows spec.
+ * Supported types are editable in the form builder; the rest are preserved as raw JSON
+ * passthroughs. Anything outside this set is reported as a warning, never an error —
+ * Meta adds components faster than this list can track, and an unrecognised type must
+ * not block the form from being saved.
  */
 export const VALID_COMPONENT_TYPES = new Set([
   'TextHeading',
   'TextSubheading',
   'TextCaption',
   'TextBody',
+  'RichText',
   'TextInput',
   'TextArea',
   'DatePicker',
+  'CalendarPicker',
   'RadioButtonsGroup',
   'CheckboxGroup',
   'Dropdown',
+  'ChipsSelector',
   'OptIn',
   'Image',
-  'Footer',
-  'CalendarPicker',
-  'DocumentPicker',
-  'ChipsSelector',
-  'EmbeddedLink',
+  'ImageCarousel',
   'PhotoPicker',
-  'RichText',
+  'DocumentPicker',
+  'EmbeddedLink',
+  'NavigationList',
+  'Footer',
   'If',
   'Switch',
 ]);
 
-/** Picks the known extra Meta-spec attributes from a JSON component that the form builder doesn't edit. */
+/** Picks every attribute of a JSON component that the form builder does not model itself. */
 const extractExtraAttributes = (component: any, componentType: string): Record<string, any> | undefined => {
-  const extraKeys = EXTRA_ATTRIBUTE_KEYS[componentType];
-  if (!extraKeys) return undefined;
+  const consumed = CONSUMED_ATTRIBUTE_KEYS[componentType];
+  if (!consumed) return undefined;
   const extra: Record<string, any> = {};
-  extraKeys.forEach((key) => {
-    if (key in component) extra[key] = component[key];
+  Object.keys(component).forEach((key) => {
+    if (!consumed.includes(key)) extra[key] = component[key];
   });
   return Object.keys(extra).length > 0 ? extra : undefined;
 };
@@ -665,8 +685,10 @@ const convertWhatsAppComponentToContentItem = (component: any, order: number): C
   }
 
   if (['TextHeading', 'TextSubheading', 'TextCaption', 'TextBody'].includes(type)) {
+    const extraAttributes = extractExtraAttributes(component, type);
     contentItem.data = {
       text: component.text || '',
+      ...(extraAttributes && { extraAttributes }),
     };
     return contentItem;
   }
@@ -685,10 +707,12 @@ const convertWhatsAppComponentToContentItem = (component: any, order: number): C
   }
 
   if (type === 'TextArea') {
+    const extraAttributes = extractExtraAttributes(component, type);
     contentItem.data = {
       label: component.label || '',
       required: component.required || false,
       placeholder: component['helper-text'] || '',
+      ...(extraAttributes && { extraAttributes }),
     };
     return contentItem;
   }
@@ -710,27 +734,35 @@ const convertWhatsAppComponentToContentItem = (component: any, order: number): C
     contentItem.data = {
       label: component.label || '',
       required: component.required || false,
-      options: dataSource.map((item: any, index: number) => ({
-        id: item.id || `${index}_${item.title}`,
-        value: item.title || '',
-      })),
+      options: dataSource.map((item: any, index: number) => {
+        const { id, title, ...rest } = item;
+        return {
+          id: id || `${index}_${title}`,
+          value: title || '',
+          ...(Object.keys(rest).length > 0 && { extraAttributes: rest }),
+        };
+      }),
       ...(extraAttributes && { extraAttributes }),
     };
     return contentItem;
   }
 
   if (type === 'OptIn') {
+    const extraAttributes = extractExtraAttributes(component, type);
     contentItem.data = {
       label: component.label || 'Label',
       required: component.required || false,
+      ...(extraAttributes && { extraAttributes }),
     };
     return contentItem;
   }
 
   if (type === 'Image') {
     const src = component.src || '';
+    const extraAttributes = extractExtraAttributes(component, type);
     contentItem.data = {
       text: src && !src.startsWith('data:') ? `data:image/png;base64,${src}` : src,
+      ...(extraAttributes && { extraAttributes }),
     };
     return contentItem;
   }
@@ -746,21 +778,39 @@ export const convertFlowJSONToFormBuilder = (flowJSON: any): Screen[] => {
 
   return flowJSON.screens.map((flowScreen: any, screenIndex: number) => {
     const layoutChildren = flowScreen.layout?.children || [];
-    const formLayout = layoutChildren.find((c: any) => c.type === 'Form');
-    const directLayoutComponents = layoutChildren.filter((c: any) => c.type !== 'Form');
-    const formChildren = formLayout ? formLayout.children || [] : [];
-    const allChildren = [...directLayoutComponents, ...formChildren];
+
+    // Flatten in document order, remembering whether each component sat directly in the
+    // layout or inside the Form, so its placement survives the round-trip untouched.
+    const allChildren: Array<{ component: any; layoutDirect: boolean }> = [];
+    layoutChildren.forEach((child: any) => {
+      if (child.type === 'Form') {
+        (child.children || []).forEach((formChild: any) =>
+          allChildren.push({ component: formChild, layoutDirect: false })
+        );
+      } else {
+        allChildren.push({ component: child, layoutDirect: true });
+      }
+    });
 
     let buttonLabel = 'Continue';
-    const footerComponent = allChildren.find((child: any) => child.type === 'Footer');
-    if (footerComponent) {
-      buttonLabel = footerComponent.label || 'Continue';
+    let footerAttributes: Record<string, any> | undefined;
+    const footer = allChildren.find(({ component }) => component.type === 'Footer');
+    if (footer) {
+      buttonLabel = footer.component.label || 'Continue';
+      const { type, label, 'on-click-action': onClickAction, ...rest } = footer.component;
+      if (Object.keys(rest).length > 0) {
+        footerAttributes = rest;
+      }
     }
 
     const content: ContentItem[] = allChildren
-      .map((component: any, index: number) => {
+      .map(({ component, layoutDirect }, index: number) => {
         const item = convertWhatsAppComponentToContentItem(component, index);
-        if (item && item.type !== 'Unsupported' && component.name) {
+        if (!item) return null;
+        if (layoutDirect) {
+          item.data.layoutDirect = true;
+        }
+        if (item.type !== 'Unsupported' && component.name) {
           item.data.variableName = component.name;
         }
         return item;
@@ -773,6 +823,7 @@ export const convertFlowJSONToFormBuilder = (flowJSON: any): Screen[] => {
       order: screenIndex,
       content,
       buttonLabel,
+      ...(footerAttributes && { footerAttributes }),
     };
   });
 };
@@ -784,24 +835,14 @@ interface FlowJsonError {
 
 interface FlowJsonValidationResult {
   errors: FlowJsonError[];
+  /** Non-blocking notices — the JSON still saves and round-trips unchanged. */
+  warnings: FlowJsonError[];
 }
-
-const INPUT_COMPONENT_TYPES = [
-  'TextInput',
-  'TextArea',
-  'DatePicker',
-  'RadioButtonsGroup',
-  'CheckboxGroup',
-  'Dropdown',
-  'OptIn',
-  'CalendarPicker',
-  'DocumentPicker',
-  'PhotoPicker',
-];
 
 /** Validates a WhatsApp Flow JSON structure, checking screen IDs, titles, layout, actions, components, and data properties. */
 export const validateFlowJson = (parsedJson: any): FlowJsonValidationResult => {
   const errors: FlowJsonError[] = [];
+  const warnings: FlowJsonError[] = [];
 
   // Phase 1: Top-level structure
   if (!parsedJson.version || typeof parsedJson.version !== 'string') {
@@ -810,12 +851,12 @@ export const validateFlowJson = (parsedJson: any): FlowJsonValidationResult => {
 
   if (!parsedJson.screens || !Array.isArray(parsedJson.screens)) {
     errors.push({ message: 'Missing or invalid "screens" array' });
-    return { errors };
+    return { errors, warnings };
   }
 
   if (parsedJson.screens.length === 0) {
     errors.push({ message: 'Screens array cannot be empty' });
-    return { errors };
+    return { errors, warnings };
   }
 
   const { screens } = parsedJson;
@@ -876,16 +917,6 @@ export const validateFlowJson = (parsedJson: any): FlowJsonValidationResult => {
     const formIndex = layoutChildren.findIndex((c: any) => c.type === 'Form');
     const formComponent = formIndex !== -1 ? layoutChildren[formIndex] : undefined;
     const formChildren: any[] = Array.isArray(formComponent?.children) ? formComponent.children : [];
-
-    // Check for layout-direct components incorrectly placed inside Form
-    formChildren.forEach((component: any, j: number) => {
-      if (LAYOUT_DIRECT_COMPONENT_TYPES.has(component.type)) {
-        errors.push({
-          message: `Screen '${screenLabel}': '${component.type}' must be a direct child of SingleColumnLayout, not inside a Form component`,
-          path: `screens[${i}].layout.children[${formIndex}].children[${j}]`,
-        });
-      }
-    });
 
     // Collect all components: direct layout children (non-Form) + Form children
     const directLayoutComponents = layoutChildren.filter((c: any) => c.type !== 'Form');
@@ -1000,8 +1031,8 @@ export const validateFlowJson = (parsedJson: any): FlowJsonValidationResult => {
           directIdx !== -1
             ? `screens[${i}].layout.children[${directIdx}]`
             : `screens[${i}].layout.children[${formIndex}].children[${formChildren.indexOf(component)}]`;
-        errors.push({
-          message: `Screen '${screenLabel}': Unknown component type '${component.type}' at index ${j}`,
+        warnings.push({
+          message: `Screen '${screenLabel}': '${component.type}' at index ${j} is not editable in the form builder — it will be saved exactly as written`,
           path: componentPath,
         });
       }
@@ -1041,5 +1072,5 @@ export const validateFlowJson = (parsedJson: any): FlowJsonValidationResult => {
     }
   });
 
-  return { errors };
+  return { errors, warnings };
 };

--- a/src/containers/WhatsAppForms/Configure/FormBuilder/FormBuilder.utils.ts
+++ b/src/containers/WhatsAppForms/Configure/FormBuilder/FormBuilder.utils.ts
@@ -653,7 +653,6 @@ export const VALID_COMPONENT_TYPES = new Set([
 /** Picks every attribute of a JSON component that the form builder does not model itself. */
 const extractExtraAttributes = (component: any, componentType: string): Record<string, any> | undefined => {
   const consumed = CONSUMED_ATTRIBUTE_KEYS[componentType];
-  if (!consumed) return undefined;
   const extra: Record<string, any> = {};
   Object.keys(component).forEach((key) => {
     if (!consumed.includes(key)) extra[key] = component[key];

--- a/src/containers/WhatsAppForms/Configure/FormBuilder/FormBuilder.utils.ts
+++ b/src/containers/WhatsAppForms/Configure/FormBuilder/FormBuilder.utils.ts
@@ -264,11 +264,8 @@ export const computeFieldNames = (screens: Screen[]): Map<string, string> => {
 
   screens.forEach((screen) => {
     screen.content.forEach((item) => {
-      // Passthrough components only need field tracking when they actually hold a value
-      if (item.type === 'Unsupported') {
-        const raw = item.data.rawComponent;
-        if (!isInputComponent(raw)) return;
-        const name = uniqueName(raw.name, usedNames);
+      if (item.type === 'Unsupported' && isInputComponent(item.data.rawComponent)) {
+        const name = uniqueName(item.data.rawComponent.name, usedNames);
         usedNames.add(name);
         fieldNameMap.set(item.id, name);
         return;

--- a/src/containers/WhatsAppForms/Configure/JSONViewer/JSONViewer.tsx
+++ b/src/containers/WhatsAppForms/Configure/JSONViewer/JSONViewer.tsx
@@ -24,6 +24,7 @@ interface JSONViewerProps {
   screens: Screen[];
   onClose: () => void;
   onScreensChange?: (screens: Screen[]) => void;
+  onUnappliedChanges?: (hasUnapplied: boolean) => void;
 }
 
 const validateJSON = (jsonString: string): ValidationResult => {
@@ -73,7 +74,7 @@ const validateJSON = (jsonString: string): ValidationResult => {
   return result;
 };
 
-export const JSONViewer = ({ screens, onClose, onScreensChange }: JSONViewerProps) => {
+export const JSONViewer = ({ screens, onClose, onScreensChange, onUnappliedChanges }: JSONViewerProps) => {
   const [copySuccess, setCopySuccess] = useState(false);
   const [jsonText, setJsonText] = useState('');
   const [validation, setValidation] = useState<ValidationResult>({
@@ -105,6 +106,13 @@ export const JSONViewer = ({ screens, onClose, onScreensChange }: JSONViewerProp
     setValidation(result);
   }, [jsonText]);
 
+  const isEditable = !!onScreensChange;
+  const hasChanges = jsonText !== JSON.stringify(flowJSON, null, 2);
+
+  useEffect(() => {
+    onUnappliedChanges?.(isEditable && hasChanges);
+  }, [isEditable, hasChanges, onUnappliedChanges]);
+
   const handleCopyJSON = () => {
     copyToClipboard(jsonText);
     setCopySuccess(true);
@@ -121,9 +129,6 @@ export const JSONViewer = ({ screens, onClose, onScreensChange }: JSONViewerProp
     }
   }, [validation, onScreensChange]);
 
-  const isEditable = !!onScreensChange;
-  const hasChanges = jsonText !== JSON.stringify(flowJSON, null, 2);
-
   return (
     <div className={styles.JsonViewerContainer}>
       <div className={styles.JsonActions}>
@@ -134,13 +139,15 @@ export const JSONViewer = ({ screens, onClose, onScreensChange }: JSONViewerProp
           <span>Form JSON</span>
         </div>
         <div className={styles.ActionButtons}>
-          {isEditable && hasChanges && validation.isValidContent && (
+          {isEditable && hasChanges && (
             <Button
               variant="contained"
               color="primary"
               onClick={handleApplyChanges}
+              disabled={!validation.isValidContent}
               size="small"
               className={styles.ApplyButton}
+              data-testid="apply-changes"
             >
               Apply Changes
             </Button>

--- a/src/mocks/WhatsAppForm.tsx
+++ b/src/mocks/WhatsAppForm.tsx
@@ -784,3 +784,196 @@ export const WHATSAPP_FORM_MOCKS = [
 ];
 
 export { syncWhatsappFormQueryWithErrors, syncWhatsappForm };
+
+/**
+ * Every component the builder models, with every attribute Meta's reference page lists —
+ * each has its own conversion branch and its own CONSUMED_ATTRIBUTE_KEYS entry, so each can
+ * break independently.
+ *
+ * Passthrough components all share one code path (`rawComponent` returned verbatim), so only
+ * three representatives are covered: PhotoPicker (an input), Switch (nested children) and
+ * RichText (array-valued attribute). CalendarPicker, DocumentPicker, EmbeddedLink,
+ * NavigationList and ChipsSelector have their own dedicated tests above.
+ *
+ * Source: plans/Components.md (Meta's Flow JSON component reference) + the media upload page.
+ */
+export const FLOW_JSON_COMPONENTS: Record<string, any> = {
+  TextHeading: { type: 'TextHeading', text: 'Heading', visible: true },
+  TextSubheading: { type: 'TextSubheading', text: 'Sub', visible: true },
+  TextBody: {
+    type: 'TextBody',
+    text: 'Body',
+    'font-weight': 'bold',
+    strikethrough: false,
+    visible: true,
+    markdown: true,
+  },
+  TextCaption: {
+    type: 'TextCaption',
+    text: 'Cap',
+    'font-weight': 'italic',
+    strikethrough: true,
+    visible: true,
+    markdown: false,
+  },
+  RichText: { type: 'RichText', text: ['# H1', 'some **bold**'], visible: true },
+  TextInput: {
+    type: 'TextInput',
+    label: 'Name',
+    'input-type': 'text',
+    pattern: '^[a-z]+$',
+    required: true,
+    'min-chars': 2,
+    'max-chars': 40,
+    'helper-text': 'Your name',
+    name: 'full_name',
+    visible: true,
+    'init-value': 'abc',
+    'error-message': 'Bad name',
+  },
+  TextArea: {
+    type: 'TextArea',
+    label: 'Notes',
+    required: false,
+    'max-length': 500,
+    name: 'notes',
+    'helper-text': 'Optional',
+    enabled: true,
+    visible: true,
+    'init-value': 'hi',
+    'error-message': 'Too long',
+  },
+  CheckboxGroup: {
+    type: 'CheckboxGroup',
+    name: 'toppings',
+    label: 'Toppings',
+    required: true,
+    'data-source': [
+      {
+        id: '1',
+        title: 'Cheese',
+        description: 'Extra',
+        metadata: 'meta',
+        enabled: true,
+        image: 'BASE64',
+        'alt-text': 'cheese',
+        color: '#ffffff',
+      },
+    ],
+    'min-selected-items': 1,
+    'max-selected-items': 3,
+    enabled: true,
+    visible: true,
+    'on-select-action': { name: 'update_data', payload: {} },
+    description: 'Pick some',
+    'init-value': ['1'],
+    'error-message': 'Pick one',
+    'media-size': 'regular',
+  },
+  RadioButtonsGroup: {
+    type: 'RadioButtonsGroup',
+    name: 'size',
+    label: 'Size',
+    required: true,
+    'data-source': [
+      {
+        id: '1',
+        title: 'Small',
+        description: 'S',
+        metadata: 'm',
+        enabled: true,
+        image: 'BASE64',
+        'alt-text': 'small',
+        color: '#000000',
+      },
+    ],
+    enabled: true,
+    visible: true,
+    'on-select-action': { name: 'update_data', payload: {} },
+    description: 'Choose',
+    'init-value': '1',
+    'error-message': 'Required',
+    'media-size': 'regular',
+  },
+  Dropdown: {
+    type: 'Dropdown',
+    label: 'City',
+    name: 'city',
+    'data-source': [
+      {
+        id: '1',
+        title: 'Pune',
+        description: 'MH',
+        metadata: 'm',
+        enabled: true,
+        image: 'BASE64',
+        'alt-text': 'pune',
+      },
+    ],
+    required: true,
+    enabled: true,
+    visible: true,
+    'on-select-action': { name: 'update_data', payload: {} },
+    'init-value': '1',
+    'error-message': 'Required',
+  },
+  DatePicker: {
+    type: 'DatePicker',
+    label: 'DOB',
+    'min-date': '1900-01-01',
+    'max-date': '2030-01-01',
+    name: 'dob',
+    'unavailable-dates': ['2025-01-01'],
+    visible: true,
+    'helper-text': 'Pick',
+    enabled: true,
+    'on-select-action': { name: 'update_data', payload: {} },
+    'init-value': '2000-01-01',
+    'error-message': 'Bad date',
+  },
+  OptIn: {
+    type: 'OptIn',
+    label: 'I agree',
+    required: true,
+    name: 'terms',
+    'on-click-action': { name: 'navigate', next: { type: 'screen', name: 'x' }, payload: {} },
+    visible: true,
+    'init-value': false,
+  },
+  Image: {
+    type: 'Image',
+    src: 'QkFTRTY0',
+    width: 200,
+    height: 100,
+    'scale-type': 'cover',
+    'aspect-ratio': 1,
+    'alt-text': 'pic',
+  },
+  PhotoPicker: {
+    type: 'PhotoPicker',
+    name: 'photos',
+    label: 'Photos',
+    description: 'up to 3',
+    'photo-source': 'camera_gallery',
+    'max-file-size-kb': 1024,
+    'min-uploaded-photos': 1,
+    'max-uploaded-photos': 3,
+    enabled: true,
+    visible: true,
+    'error-message': 'req',
+  },
+  Switch: {
+    type: 'Switch',
+    value: '${data.status}',
+    cases: { pending: [{ type: 'TextBody', text: 'p' }], done: [{ type: 'TextBody', text: 'd' }] },
+  },
+};
+
+export const FOOTER_WITH_CAPTIONS = {
+  type: 'Footer',
+  label: 'Done',
+  'left-caption': 'L',
+  'right-caption': 'R',
+  enabled: true,
+  'on-click-action': { name: 'complete', payload: {} },
+};


### PR DESCRIPTION
https://discord.com/channels/717975833226248303/1536647540026376192

- Added state management for unapplied JSON changes in the Configure component.
- Introduced a close function for the JSON viewer to reset unapplied changes state.
- Updated the FormBuilder types to include optional footer attributes and extra attributes for content items and options.
- Enhanced utility functions to handle input components and media uploads correctly.
- Improved JSON conversion functions to preserve extra attributes and layout information.
- Updated validation logic to provide warnings for non-editable components in the JSON structure.
- Modified JSONViewer to track and notify unapplied changes, ensuring users are prompted to apply changes before saving.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* JSON editing preserves supported, unknown, and future component attributes across edits and round trips.
* Unknown components can be saved and retained without blocking configuration.
* Form and footer layouts retain their placement and attributes.
* Media uploads are excluded from navigation data and intermediate-screen schemas.

## Bug Fixes
* Saving is blocked while JSON changes remain unapplied.
* Invalid JSON keeps “Apply Changes” disabled.
* Component names are deduplicated more reliably.
* Closing the JSON editor clears the unapplied-changes warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->