### PR TITLE
fix: disable Run evaluation when the version has not been built

### DIFF
--- a/cypress/e2e/aiAssistant/AssistantEvaluation.spec.ts
+++ b/cypress/e2e/aiAssistant/AssistantEvaluation.spec.ts
@@ -1,7 +1,9 @@
 import { BELOW_STICKY_HEADER } from '../../utils/assistant-flow';
 import {
+  BUILDING_VERSIONS,
   EMPTY_SCORES,
   FAILED_RUN,
+  FAILED_VERSIONS,
   GOLDEN_SETS,
   LIVE_VERSION_ID,
   RUNNING_RUN,
@@ -10,7 +12,12 @@ import {
   UNSCORED_SCORES,
   WEAK_SCORES,
 } from '../../utils/assistant-fixtures';
-import { openAssistant, openAssistantPage, openTab } from '../../utils/assistant-detail';
+import {
+  openAssistant,
+  openAssistantPage,
+  openTab,
+  selectVersion,
+} from '../../utils/assistant-detail';
 
 describe('the Golden Q&A Evaluation tab of a saved assistant', () => {
   beforeEach(() => {
@@ -300,6 +307,40 @@ describe('a run with nothing to suggest from', () => {
     cy.get('[data-testid="suggestedPromptUnscored"]').should(
       'contain',
       'No suggestion for this run'
+    );
+  });
+});
+
+describe('a version the server has not built', () => {
+  const hoverRun = () =>
+    cy
+      .get('[data-testid="runEvaluationButton"]')
+      .parent()
+      .trigger('mouseover', BELOW_STICKY_HEADER);
+
+  it('will not evaluate a failed version, and says why', () => {
+    openAssistant({ versions: FAILED_VERSIONS });
+    selectVersion('2.1');
+    openTab('evaluation');
+
+    cy.get('[data-testid="runEvaluationButton"]').should('be.disabled');
+    hoverRun();
+    cy.get('[role="tooltip"]').should(
+      'contain',
+      'This version failed to build, so it cannot be evaluated'
+    );
+  });
+
+  it('will not evaluate a version that is still being prepared', () => {
+    openAssistant({ versions: BUILDING_VERSIONS });
+    selectVersion('2.1');
+    openTab('evaluation');
+
+    cy.get('[data-testid="runEvaluationButton"]').should('be.disabled');
+    hoverRun();
+    cy.get('[role="tooltip"]').should(
+      'contain',
+      'It can be evaluated once the server has finished building it.'
     );
   });
 });

--- a/src/common/utils.test.ts
+++ b/src/common/utils.test.ts
@@ -1,0 +1,34 @@
+import { downloadFile } from './utils';
+
+describe('downloadFile', () => {
+  const stubLink = () => {
+    const click = vi.fn();
+    const link = { href: '', target: '', download: '', click } as unknown as HTMLAnchorElement;
+    const create = vi.spyOn(document, 'createElement').mockReturnValue(link);
+    const append = vi.spyOn(document.body, 'appendChild').mockImplementation((node) => node);
+    const remove = vi.spyOn(document.body, 'removeChild').mockImplementation((node) => node);
+
+    return { link, click, restore: () => [create, append, remove].forEach((spy) => spy.mockRestore()) };
+  };
+
+  test('opens in a new tab unless told otherwise', () => {
+    const { link, click, restore } = stubLink();
+
+    downloadFile('https://files.test/report.pdf', 'report.pdf');
+
+    expect(link.href).toBe('https://files.test/report.pdf');
+    expect(link.download).toBe('report.pdf');
+    expect(link.target).toBe('_blank');
+    expect(click).toHaveBeenCalled();
+    restore();
+  });
+
+  test('takes the target it is given, so a caller can save in place', () => {
+    const { link, restore } = stubLink();
+
+    downloadFile('https://files.test/report.pdf', 'report.pdf', '_self');
+
+    expect(link.target).toBe('_self');
+    restore();
+  });
+});

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -109,10 +109,10 @@ export const addLogsMethod = (event: string, logData: any) => {
   setLogs(`${event} with data ${JSON.stringify(logData)}`, 'info', false);
 };
 
-export const downloadFile = (url: string, filename: string) => {
+export const downloadFile = (url: string, filename: string, target: string = '_blank') => {
   const link = document.createElement('a');
   link.href = url;
-  link.target = '_blank';
+  link.target = target;
   link.download = filename;
   document.body.appendChild(link);
   link.click();

--- a/src/containers/AIEvaluation/AssistantDetail/AssistantDetail.test.tsx
+++ b/src/containers/AIEvaluation/AssistantDetail/AssistantDetail.test.tsx
@@ -1357,6 +1357,42 @@ describe('version status', () => {
     });
   });
 
+  test('a failed version cannot be evaluated either, and the run button says why', async () => {
+    const failed = { ...version(2, false), status: 'failed' };
+    const evaluationMocks = [
+      {
+        request: { query: LIST_GOLDEN_QA },
+        variableMatcher: () => true,
+        result: {
+          data: { goldenQas: [{ id: 'g1', name: 'core_set', totalItems: 10, insertedAt: '2026-08-10T10:00:00Z' }] },
+        },
+        maxUsageCount: Number.POSITIVE_INFINITY,
+      },
+      {
+        request: { query: LIST_AI_EVALUATIONS },
+        variableMatcher: () => true,
+        result: { data: { aiEvaluations: [] } },
+        maxUsageCount: Number.POSITIVE_INFINITY,
+      },
+    ];
+
+    renderDetail('/assistants/1', [getAssistant('1'), versionsMock([version(1, true), failed]), ...evaluationMocks]);
+
+    fireEvent.click(await screen.findByTestId('versionPill'));
+    fireEvent.click(await screen.findByTestId('versionOption-2.0'));
+    fireEvent.click(screen.getByTestId('tab-evaluation'));
+
+    const runButton = await screen.findByTestId('runEvaluationButton');
+    expect(runButton).toBeDisabled();
+
+    fireEvent.mouseOver(runButton.parentElement as HTMLElement);
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toHaveTextContent(
+        'This version failed to build, so it cannot be evaluated. Save a new version.'
+      );
+    });
+  });
+
   test('a live version being rebuilt keeps its LIVE badge', async () => {
     const rebuildingLive = { ...version(1, true), status: 'in_progress' };
     renderDetail('/assistants/1', [getAssistant('1'), versionsMock([rebuildingLive, version(2, false)])]);

--- a/src/containers/AIEvaluation/AssistantDetail/AssistantDetail.tsx
+++ b/src/containers/AIEvaluation/AssistantDetail/AssistantDetail.tsx
@@ -483,6 +483,7 @@ export const AssistantDetail = () => {
         versionId={selectedVersion?.id}
         liveVersionId={liveVersion?.id}
         versionLabel={selectedVersion?.versionLabel}
+        versionStatus={selectedVersion?.status}
         assistantName={assistant?.name}
         onRunningChange={setEvaluationRunning}
         onLastRunChange={setLastVersionRun}

--- a/src/containers/AIEvaluation/AssistantDetail/Tabs/Evaluation/Evaluation.test.tsx
+++ b/src/containers/AIEvaluation/AssistantDetail/Tabs/Evaluation/Evaluation.test.tsx
@@ -1867,7 +1867,8 @@ test('a markdown table stays as text, because WhatsApp cannot render one', async
 });
 
 test("the judge's summary is shown in the banner", async () => {
-  const summary = 'Overall the run looks healthy. The one mild gap is item_0, which scored 3 on ground truth.';
+  const summary =
+    '**Overall read:** the run looks healthy. The one mild gap is item_0, which scored 3 on ground truth.';
 
   render(
     <MockedProvider
@@ -1916,7 +1917,11 @@ test("the judge's summary is shown in the banner", async () => {
     </MockedProvider>
   );
 
-  expect(await screen.findByTestId('evaluationSummary')).toHaveTextContent('Overall the run looks healthy');
+  const banner = await screen.findByTestId('evaluationSummary');
+
+  expect(banner).toHaveTextContent('the run looks healthy');
+  expect(banner.querySelector('b')).toHaveTextContent('Overall read:');
+  expect(banner.textContent).not.toContain('*');
 });
 
 test('Export CSV downloads the question-level results as a CSV file', async () => {

--- a/src/containers/AIEvaluation/AssistantDetail/Tabs/Evaluation/Evaluation.test.tsx
+++ b/src/containers/AIEvaluation/AssistantDetail/Tabs/Evaluation/Evaluation.test.tsx
@@ -2471,3 +2471,40 @@ test('a failed runs fetch says so instead of claiming nothing has run', async ()
   expect(await screen.findByTestId('evaluationRunsLoadError')).toHaveTextContent('could not be loaded');
   expect(screen.queryByTestId('noEvaluationsYet')).not.toBeInTheDocument();
 });
+
+describe('a version the server has not built', () => {
+  const renderVersion = (versionStatus: string) =>
+    render(
+      <MockedProvider mocks={[listMock(oneSet), noRunsMock]}>
+        <Evaluation assistantId="a1" versionId="v1" versionLabel="1.0" versionStatus={versionStatus} />
+      </MockedProvider>
+    );
+
+  const hoverRun = async () => {
+    const button = await screen.findByTestId('runEvaluationButton');
+    fireEvent.mouseOver(button.parentElement as HTMLElement);
+    return screen.findByRole('tooltip');
+  };
+
+  test('a failed version cannot be evaluated, and says why on hover', async () => {
+    renderVersion('failed');
+
+    expect(await screen.findByTestId('runEvaluationButton')).toBeDisabled();
+    expect(await hoverRun()).toHaveTextContent(
+      'This version failed to build, so it cannot be evaluated. Save a new version.'
+    );
+  });
+
+  test('a version still being prepared cannot be evaluated either', async () => {
+    renderVersion('in_progress');
+
+    expect(await screen.findByTestId('runEvaluationButton')).toBeDisabled();
+    expect(await hoverRun()).toHaveTextContent('It can be evaluated once the server has finished building it.');
+  });
+
+  test('a ready version is left alone', async () => {
+    renderVersion('ready');
+
+    expect(await screen.findByTestId('runEvaluationButton')).toBeEnabled();
+  });
+});

--- a/src/containers/AIEvaluation/AssistantDetail/Tabs/Evaluation/Evaluation.tsx
+++ b/src/containers/AIEvaluation/AssistantDetail/Tabs/Evaluation/Evaluation.tsx
@@ -35,6 +35,7 @@ export interface EvaluationProps {
   versionId?: string;
   liveVersionId?: string;
   versionLabel?: string;
+  versionStatus?: string;
   assistantName?: string;
   onRunningChange?: (running: boolean) => void;
   onLastRunChange?: (run: EvaluationRun | null) => void;
@@ -47,6 +48,7 @@ export const Evaluation = ({
   versionId,
   liveVersionId,
   versionLabel,
+  versionStatus,
   assistantName,
   onRunningChange,
   onLastRunChange,
@@ -116,6 +118,15 @@ export const Evaluation = ({
   const lastUsedSetId = assistantRuns[0]?.goldenQa?.id;
   const latestRun = versionRuns[0];
   const versionRunInProgress = versionRuns.some(isRunInProgress);
+
+  const runBlockedReason = () => {
+    if (versionRunInProgress) return t('An evaluation is already running for this version. Wait for it to finish.');
+    if (versionStatus === 'failed')
+      return t('This version failed to build, so it cannot be evaluated. Save a new version.');
+    if (versionStatus === 'in_progress')
+      return t('This version is still being prepared. It can be evaluated once the server has finished building it.');
+    return '';
+  };
 
   useEffect(() => {
     onRunningChange?.(versionRunInProgress);
@@ -250,20 +261,13 @@ export const Evaluation = ({
             >
               {t('Manage Golden Q&A')}
             </Button>
-            <Tooltip
-              title={
-                versionRunInProgress
-                  ? t('An evaluation is already running for this version. Wait for it to finish.')
-                  : ''
-              }
-              placement="top"
-            >
+            <Tooltip title={runBlockedReason()} placement="top">
               <Button
                 variant="contained"
                 color="primary"
                 className={styles.RunButton}
                 startIcon={<PlayArrowIcon />}
-                disabled={!versionId || versionRunInProgress}
+                disabled={!versionId || Boolean(runBlockedReason())}
                 onClick={() => setRunOpen(true)}
                 data-testid="runEvaluationButton"
               >

--- a/src/containers/AIEvaluation/AssistantDetail/Tabs/Evaluation/EvaluationResult/EvaluationResult.tsx
+++ b/src/containers/AIEvaluation/AssistantDetail/Tabs/Evaluation/EvaluationResult/EvaluationResult.tsx
@@ -5,9 +5,11 @@ import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import { Tooltip } from 'components/UI/Tooltip/Tooltip';
 import { BAND_ICON } from 'containers/AIEvaluation/utils/evaluation/bandIcon';
+import { MarkdownAnswer } from '../../../components';
 import type { EvaluationMetrics, EvaluationRun } from 'containers/AIEvaluation/types/evaluationType';
 import {
   BAND_LABEL,
+  markdownBoldToWhatsApp,
   configVersionLabel,
   MAX_SCORE,
   METRIC_HINT,
@@ -151,7 +153,7 @@ export const EvaluationResult = ({
               </span>
               {summary && (
                 <div className={styles.BannerSummary} data-testid="evaluationSummary">
-                  {summary}
+                  <MarkdownAnswer text={markdownBoldToWhatsApp(summary)} />
                 </div>
               )}
             </div>

--- a/src/containers/AIEvaluation/AssistantDetail/Tabs/Evaluation/EvaluationScores/EvaluationScores.module.css
+++ b/src/containers/AIEvaluation/AssistantDetail/Tabs/Evaluation/EvaluationScores/EvaluationScores.module.css
@@ -39,11 +39,12 @@
 }
 
 .IndexColumn {
-  width: 2.5rem;
+  width: 3.5rem;
   text-align: center;
 }
 
 .Index {
+  white-space: nowrap;
   color: var(--app-color-text-tertiary);
   font-variant-numeric: tabular-nums;
 }

--- a/src/containers/AIEvaluation/AssistantDetail/Tabs/KnowledgeBase/KnowledgeBase.test.tsx
+++ b/src/containers/AIEvaluation/AssistantDetail/Tabs/KnowledgeBase/KnowledgeBase.test.tsx
@@ -386,7 +386,11 @@ test('downloading a file fetches a fresh link and saves it under its own name', 
   fireEvent.click(screen.getByTestId('downloadFileButton'));
 
   await waitFor(() => {
-    expect(download).toHaveBeenCalledWith('https://storage.test/nutrition_faq.pdf?sig=abc', 'nutrition_faq.pdf');
+    expect(download).toHaveBeenCalledWith(
+      'https://storage.test/nutrition_faq.pdf?sig=abc',
+      'nutrition_faq.pdf',
+      '_self'
+    );
   });
 
   download.mockRestore();

--- a/src/containers/AIEvaluation/AssistantDetail/Tabs/KnowledgeBase/KnowledgeBase.tsx
+++ b/src/containers/AIEvaluation/AssistantDetail/Tabs/KnowledgeBase/KnowledgeBase.tsx
@@ -114,7 +114,7 @@ export const KnowledgeBase = ({
         return;
       }
 
-      downloadFile(signedUrl, data?.getFile?.filename || file.filename);
+      downloadFile(signedUrl, data?.getFile?.filename || file.filename, '_self');
     } catch (error: unknown) {
       setErrorMessage(error);
     } finally {

--- a/src/containers/AIEvaluation/utils/evaluation/evaluation.test.ts
+++ b/src/containers/AIEvaluation/utils/evaluation/evaluation.test.ts
@@ -1,20 +1,21 @@
 import {
   configVersionLabel,
-  formatScore,
-  parseOverallScore,
   evaluationRunName,
-  parseEvaluationSummary,
-  shortMetricName,
-  parseEvaluationScores,
-  traceMetricNames,
+  formatScore,
   isRunComplete,
   isRunFailed,
   isRunInProgress,
+  markdownBoldToWhatsApp,
   mergeEvaluationUpdate,
-  parseAssistantHealth,
   overallScore,
+  parseAssistantHealth,
   parseEvaluationResults,
+  parseEvaluationScores,
+  parseEvaluationSummary,
+  parseOverallScore,
   scoreBand,
+  shortMetricName,
+  traceMetricNames,
 } from './evaluation';
 import type { EvaluationRun } from 'containers/AIEvaluation/types/evaluationType';
 
@@ -430,5 +431,25 @@ describe('configVersionLabel', () => {
   test('a run with no config version has no label', () => {
     expect(configVersionLabel(null)).toBe('');
     expect(configVersionLabel(undefined)).toBe('');
+  });
+});
+
+describe('markdownBoldToWhatsApp', () => {
+  test('a markdown pair becomes the single asterisk the renderer understands', () => {
+    expect(markdownBoldToWhatsApp('**Top 3 to check:** questions 2, 22')).toBe('*Top 3 to check:* questions 2, 22');
+  });
+
+  test('every pair in a long summary is collapsed', () => {
+    expect(markdownBoldToWhatsApp('**Overall read:** fine. **Question 58** failed.')).toBe(
+      '*Overall read:* fine. *Question 58* failed.'
+    );
+  });
+
+  test('bold spanning a line break is still collapsed', () => {
+    expect(markdownBoldToWhatsApp('**two\nlines**')).toBe('*two\nlines*');
+  });
+
+  test('text with nothing to collapse is left alone', () => {
+    expect(markdownBoldToWhatsApp('*already whatsapp* and 2 * 3 maths')).toBe('*already whatsapp* and 2 * 3 maths');
   });
 });

--- a/src/containers/AIEvaluation/utils/evaluation/evaluation.ts
+++ b/src/containers/AIEvaluation/utils/evaluation/evaluation.ts
@@ -206,6 +206,8 @@ export const parseScoreMetrics = (raw: unknown): EvaluationMetrics => {
   return parseEvaluationResults(field(asJson(raw), 'score'));
 };
 
+export const markdownBoldToWhatsApp = (text: string) => text.replace(/\*\*([\s\S]+?)\*\*/g, '*$1*');
+
 export const parseEvaluationSummary = (raw: unknown): string | null => {
   const summary = field(asJson(raw), 'score', 'overall', 'ai_summary');
 

--- a/src/i18n/en/en.json
+++ b/src/i18n/en/en.json
@@ -1181,6 +1181,8 @@
   "Consistency check": "Consistency check",
   "Asks each question five times. Catches answers that change between attempts.": "Asks each question five times. Catches answers that change between attempts.",
   "An evaluation is already running for this version. Wait for it to finish.": "An evaluation is already running for this version. Wait for it to finish.",
+  "This version failed to build, so it cannot be evaluated. Save a new version.": "This version failed to build, so it cannot be evaluated. Save a new version.",
+  "This version is still being prepared. It can be evaluated once the server has finished building it.": "This version is still being prepared. It can be evaluated once the server has finished building it.",
   "Knowledge Base ID": "Knowledge Base ID",
   "Edit system instructions": "Edit system instructions",
   "Loading out the overall score": "Loading out the overall score",

--- a/src/i18n/hi/hi.json
+++ b/src/i18n/hi/hi.json
@@ -1046,6 +1046,8 @@
   "Consistency check": "निरंतरता जांच",
   "Asks each question five times. Catches answers that change between attempts.": "हर प्रश्न पांच बार पूछता है। हर बार बदलने वाले उत्तर पकड़ता है।",
   "An evaluation is already running for this version. Wait for it to finish.": "इस वर्ज़न के लिए पहले से एक मूल्यांकन चल रहा है। उसके पूरा होने का इंतज़ार करें।",
+  "This version failed to build, so it cannot be evaluated. Save a new version.": "यह संस्करण तैयार नहीं हो सका, इसलिए इसका मूल्यांकन नहीं हो सकता। नया संस्करण सेव करें।",
+  "This version is still being prepared. It can be evaluated once the server has finished building it.": "यह संस्करण अभी तैयार किया जा रहा है। सर्वर इसे तैयार कर ले, तब इसका मूल्यांकन हो सकेगा।",
   "Knowledge Base ID": "नॉलेज बेस आईडी",
   "Edit system instructions": "सिस्टम निर्देश संपादित करें",
   "Loading out the overall score": "कुल स्कोर निकाला जा रहा है",


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

  Before submitting a pull request, please make sure the following is done:

  1. Fork [the repository](https://github.com/glific/glific-frontend) and create your branch from `master`.
  2. Run `yarn` in the repository root.
  3. If you've fixed a bug or added code that should be tested, add tests!
  4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
  5. Please ensure coding standard and conventions are followed. You can find the details at https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing

-->

Closes https://github.com/glific/glific/issues/5728

## Summary
- **Run evaluation** stayed enabled on a version the server never finished building, so starting a run on it was a dead end. It now behaves like **Go Live**, disabled, with a tooltip on hover saying why.
    - **failed version:** "This version failed to build, so it cannot be evaluated. Save a new version."
    - **version still building:** "This version is still being prepared. It can be evaluated once the server has finished building it."
    - **run already going:** unchanged, keeps its existing message
- The AI summary now renders its markdown
-  A three-digit row number no longer wraps in the results table