### PR TITLE
fix: preserve HSM status filter on back navigation

### DIFF
--- a/src/containers/HSM/HSM.test.tsx
+++ b/src/containers/HSM/HSM.test.tsx
@@ -1,7 +1,7 @@
 import { render, waitFor, within, fireEvent, screen } from '@testing-library/react';
 import { MockedProvider } from '@apollo/client/testing';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Route, Routes } from 'react-router';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
 import { HSM } from './HSM';
 import { getVariables, getExampleFromBody, getTemplateAndButtons } from './HSM.helper';
 import {
@@ -671,5 +671,81 @@ describe('getExampleFromBody', () => {
   test('leaves the placeholder untouched when no example value has been entered for it', () => {
     const body = 'Hi {{4}}';
     expect(getExampleFromBody(body, [{ id: 4, text: '' }])).toBe('Hi {{4}}');
+  });
+});
+
+describe('Back button retention', () => {
+  const LocationDisplay = () => {
+    const location = useLocation();
+    return <div data-testid="location-display">{location.pathname + location.search}</div>;
+  };
+
+  const renderHSMWithState = (state?: any) => {
+    const MOCKS = [...mocks, getHSMTemplateTypeText, getHSMTemplateTypeText];
+    return render(
+      <MockedProvider mocks={MOCKS} addTypename={false}>
+        <MemoryRouter initialEntries={[{ pathname: '/templates/1/edit', state }]}>
+          <Routes>
+            <Route path="/templates/:id/edit" element={<HSM />} />
+            <Route path="/template" element={<LocationDisplay />} />
+          </Routes>
+        </MemoryRouter>
+      </MockedProvider>
+    );
+  };
+
+  test('Approved retained: navigates back to /template?status=APPROVED', async () => {
+    renderHSMWithState({ status: 'APPROVED' });
+    await waitFor(() => {
+      expect(screen.getByTestId('back-button')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId('back-button'));
+    await waitFor(() => {
+      expect(screen.getByTestId('location-display')).toHaveTextContent('/template?status=APPROVED');
+    });
+  });
+
+  test('Pending retained: navigates back to /template?status=PENDING', async () => {
+    renderHSMWithState({ status: 'PENDING' });
+    await waitFor(() => {
+      expect(screen.getByTestId('back-button')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId('back-button'));
+    await waitFor(() => {
+      expect(screen.getByTestId('location-display')).toHaveTextContent('/template?status=PENDING');
+    });
+  });
+
+  test('Rejected retained: navigates back to /template?status=REJECTED', async () => {
+    renderHSMWithState({ status: 'REJECTED' });
+    await waitFor(() => {
+      expect(screen.getByTestId('back-button')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId('back-button'));
+    await waitFor(() => {
+      expect(screen.getByTestId('location-display')).toHaveTextContent('/template?status=REJECTED');
+    });
+  });
+
+  test('Failed retained: navigates back to /template?status=FAILED', async () => {
+    renderHSMWithState({ status: 'FAILED' });
+    await waitFor(() => {
+      expect(screen.getByTestId('back-button')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId('back-button'));
+    await waitFor(() => {
+      expect(screen.getByTestId('location-display')).toHaveTextContent('/template?status=FAILED');
+    });
+  });
+
+  test('tag + status retained: navigates back to /template?status=REJECTED&tag=Messages', async () => {
+    renderHSMWithState({ status: 'REJECTED', tag: { label: 'Messages', id: '1' } });
+    await waitFor(() => {
+      expect(screen.getByTestId('back-button')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId('back-button'));
+    await waitFor(() => {
+      expect(screen.getByTestId('location-display')).toHaveTextContent('/template?status=REJECTED&tag=Messages');
+    });
   });
 });

--- a/src/containers/HSM/HSM.tsx
+++ b/src/containers/HSM/HSM.tsx
@@ -97,7 +97,15 @@ export const HSM = () => {
   const { t } = useTranslation();
   const params = useParams();
   let timer: any = null;
-  let backButton = location.state?.tag?.label ? `template?tag=${location.state?.tag?.label}` : 'template';
+  const queryParams = new URLSearchParams();
+  if (location.state?.status) {
+    queryParams.set('status', location.state.status.toUpperCase());
+  }
+  if (location.state?.tag?.label) {
+    queryParams.set('tag', location.state.tag.label);
+  }
+  const queryString = queryParams.toString();
+  let backButton = queryString ? `template?${queryString}` : 'template';
 
   const { data: categoryList, loading: categoryLoading } = useQuery(GET_HSM_CATEGORIES);
   const {
@@ -166,7 +174,7 @@ export const HSM = () => {
   let mode;
   const copyMessage = t('Copy of the template has been created!');
 
-  const isCopyState = location.state === 'copy';
+  const isCopyState = location.state === 'copy' || location.state?.copy || location.state?.mode === 'copy';
   if (isCopyState) {
     queries.updateItemQuery = CREATE_TEMPLATE;
     mode = 'copy';

--- a/src/containers/HSM/HSMList/HSMList.test.tsx
+++ b/src/containers/HSM/HSMList/HSMList.test.tsx
@@ -1,8 +1,14 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { BrowserRouter as Router } from 'react-router';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { BrowserRouter as Router, MemoryRouter } from 'react-router';
 import { MockedProvider } from '@apollo/client/testing';
 
-import { HSM_LIST, bulkApplyMutation, bulkApplyMutationWIthError } from 'mocks/Template';
+import {
+  HSM_LIST,
+  bulkApplyMutation,
+  bulkApplyMutationWIthError,
+  filterTemplatesMock,
+  templateCountQuery,
+} from 'mocks/Template';
 import { BULK_APPLY_TEMPLATES } from 'graphql/mutations/Template';
 import { HSMList } from './HSMList';
 import userEvent from '@testing-library/user-event';
@@ -60,6 +66,25 @@ const template = (mockQuery?: any) => (
     <Router>
       <HSMList />
     </Router>
+  </MockedProvider>
+);
+
+const statusMocks = (status: string, tagIds?: number[]) => {
+  const filter: any = { isHsm: true, status };
+  if (tagIds) filter.tagIds = tagIds;
+  return [
+    filterTemplatesMock(filter),
+    filterTemplatesMock(filter),
+    templateCountQuery(filter, 1),
+    templateCountQuery(filter, 1),
+  ];
+};
+
+const templateWithEntries = (initialEntries: string[], additionalMocks: any[] = []) => (
+  <MockedProvider mocks={[...mocks, ...additionalMocks]} addTypename={false}>
+    <MemoryRouter initialEntries={initialEntries}>
+      <HSMList />
+    </MemoryRouter>
   </MockedProvider>
 );
 
@@ -247,5 +272,131 @@ test('bulk apply templates with application-level errors', async () => {
       'Templates were processed with errors. Please check the csv file for details.',
       'warning'
     );
+  });
+});
+
+describe('HSM status filter URL restoration and navigation', () => {
+  test('direct URL with status=REJECTED restores Rejected filter', async () => {
+    render(templateWithEntries(['/template?status=REJECTED'], statusMocks('REJECTED')));
+
+    await waitFor(() => {
+      expect(screen.getByText('HSM Templates')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('dropdown-template')).toHaveTextContent('Rejected');
+    expect(screen.getByText('Reason')).toBeInTheDocument();
+
+    const viewIcons = await screen.findAllByTestId('view-icon', {}, { timeout: 5000 });
+    fireEvent.click(viewIcons[0]);
+
+    await waitFor(() => {
+      expect(mockedUsedNavigate).toHaveBeenCalledWith('/template/1/edit', {
+        state: { status: 'REJECTED' },
+      });
+    });
+  });
+
+  test('direct URL with status=PENDING restores Pending filter', async () => {
+    render(templateWithEntries(['/template?status=PENDING'], statusMocks('PENDING')));
+
+    await waitFor(() => {
+      expect(screen.getByText('HSM Templates')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('dropdown-template')).toHaveTextContent('Pending');
+
+    const viewIcons = await screen.findAllByTestId('view-icon', {}, { timeout: 5000 });
+    fireEvent.click(viewIcons[0]);
+
+    await waitFor(() => {
+      expect(mockedUsedNavigate).toHaveBeenCalledWith('/template/1/edit', {
+        state: { status: 'PENDING' },
+      });
+    });
+  });
+
+  test('direct URL with status=FAILED restores Failed filter', async () => {
+    render(templateWithEntries(['/template?status=FAILED'], statusMocks('FAILED')));
+
+    await waitFor(() => {
+      expect(screen.getByText('HSM Templates')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('dropdown-template')).toHaveTextContent('Failed');
+    expect(screen.getByText('Reason')).toBeInTheDocument();
+
+    const viewIcons = await screen.findAllByTestId('view-icon', {}, { timeout: 5000 });
+    fireEvent.click(viewIcons[0]);
+
+    await waitFor(() => {
+      expect(mockedUsedNavigate).toHaveBeenCalledWith('/template/1/edit', {
+        state: { status: 'FAILED' },
+      });
+    });
+  });
+
+  test('direct URL with status=APPROVED restores Approved filter', async () => {
+    render(templateWithEntries(['/template?status=APPROVED'], statusMocks('APPROVED')));
+
+    await waitFor(() => {
+      expect(screen.getByText('HSM Templates')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('dropdown-template')).toHaveTextContent('Approved');
+
+    const viewIcons = await screen.findAllByTestId('view-icon', {}, { timeout: 5000 });
+    fireEvent.click(viewIcons[0]);
+
+    await waitFor(() => {
+      expect(mockedUsedNavigate).toHaveBeenCalledWith('/template/1/edit', {
+        state: { status: 'APPROVED' },
+      });
+    });
+  });
+
+  test('tag + status URL restores both filters and passes them to detail and create pages', async () => {
+    render(templateWithEntries(['/template?status=REJECTED&tag=Messages'], statusMocks('REJECTED', [1])));
+
+    await waitFor(() => {
+      expect(screen.getByText('HSM Templates')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('dropdown-template')).toHaveTextContent('Rejected');
+
+    const viewIcons = await screen.findAllByTestId('view-icon', {}, { timeout: 5000 });
+    fireEvent.click(viewIcons[0]);
+
+    await waitFor(() => {
+      expect(mockedUsedNavigate).toHaveBeenCalledWith('/template/1/edit', {
+        state: { tag: { label: 'Messages', id: '1' }, status: 'REJECTED' },
+      });
+    });
+
+    fireEvent.click(screen.getByTestId('newItemButton'));
+    expect(mockedUsedNavigate).toHaveBeenCalledWith('/template/add', {
+      state: { tag: { label: 'Messages', id: '1' }, status: 'REJECTED' },
+    });
+  });
+
+  test('selecting status dropdown updates filter and passes state to detail page', async () => {
+    render(templateWithEntries(['/template'], statusMocks('REJECTED')));
+
+    await waitFor(() => {
+      expect(screen.getByText('HSM Templates')).toBeInTheDocument();
+    });
+
+    fireEvent.mouseDown(within(screen.getByTestId('dropdown-template')).getByRole('combobox'));
+    fireEvent.click(await screen.findByRole('option', { name: 'Rejected' }));
+
+    expect(screen.getByTestId('dropdown-template')).toHaveTextContent('Rejected');
+
+    const viewIcons = await screen.findAllByTestId('view-icon', {}, { timeout: 5000 });
+    fireEvent.click(viewIcons[0]);
+
+    await waitFor(() => {
+      expect(mockedUsedNavigate).toHaveBeenCalledWith('/template/1/edit', {
+        state: { status: 'REJECTED' },
+      });
+    });
   });
 });

--- a/src/containers/HSM/HSMList/HSMList.test.tsx
+++ b/src/containers/HSM/HSMList/HSMList.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
-import { BrowserRouter as Router, MemoryRouter } from 'react-router';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { BrowserRouter as Router, MemoryRouter, useSearchParams } from 'react-router';
 import { MockedProvider } from '@apollo/client/testing';
 
 import {
@@ -398,5 +398,40 @@ describe('HSM status filter URL restoration and navigation', () => {
         state: { status: 'REJECTED' },
       });
     });
+  });
+
+  test('transitioning from REJECTED to INVALID resets filter to Approved', async () => {
+    let updateSearchParams: any;
+    const SearchParamsUpdater = () => {
+      const [, setSearchParams] = useSearchParams();
+      updateSearchParams = setSearchParams;
+      return null;
+    };
+
+    render(
+      <MockedProvider mocks={[...mocks, ...statusMocks('REJECTED'), ...statusMocks('APPROVED')]} addTypename={false}>
+        <MemoryRouter initialEntries={['/template?status=REJECTED']}>
+          <SearchParamsUpdater />
+          <HSMList />
+        </MemoryRouter>
+      </MockedProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('HSM Templates')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('dropdown-template')).toHaveTextContent('Rejected');
+    expect(screen.getByText('Reason')).toBeInTheDocument();
+
+    act(() => {
+      updateSearchParams({ status: 'INVALID' });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dropdown-template')).toHaveTextContent('Approved');
+    });
+    expect(screen.getByTestId('dropdown-template')).not.toHaveTextContent('Rejected');
+    expect(screen.queryByText('Reason')).not.toBeInTheDocument();
   });
 });

--- a/src/containers/HSM/HSMList/HSMList.tsx
+++ b/src/containers/HSM/HSMList/HSMList.tsx
@@ -315,7 +315,7 @@ export const HSMList = () => {
     const statusParam = searchParams.get('status')?.toUpperCase();
     if (statusParam && statusParam in statusFilter) {
       setFilters({ ...statusFilter, [statusParam]: true });
-    } else if (!statusParam) {
+    } else {
       setFilters({ ...statusFilter, APPROVED: true });
     }
 

--- a/src/containers/HSM/HSMList/HSMList.tsx
+++ b/src/containers/HSM/HSMList/HSMList.tsx
@@ -75,10 +75,16 @@ const queries = {
 export const HSMList = () => {
   const [importing, setImporting] = useState(false);
   const [raiseToGupshupTemplate, setRaiseToGupshupTemplate] = useState<any>(null);
-  const [filters, setFilters] = useState<any>({ ...statusFilter, APPROVED: true });
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [filters, setFilters] = useState<any>(() => {
+    const statusParam = searchParams.get('status')?.toUpperCase();
+    if (statusParam && statusParam in statusFilter) {
+      return { ...statusFilter, [statusParam]: true };
+    }
+    return { ...statusFilter, APPROVED: true };
+  });
   const [selectedTag, setSelectedTag] = useState<any>(null);
   const [syncTemplateLoad, setSyncTemplateLoad] = useState(false);
-  const [searchParams, setSearchParams] = useSearchParams();
 
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -231,7 +237,19 @@ export const HSMList = () => {
   const appliedFilters: any = { isHsm: true, status: filterValue };
 
   const setCopyDialog = (id: any) => {
-    navigate(`/template/${id}/edit`, { state: 'copy' });
+    const statusParam = searchParams.get('status');
+    const state: any = { mode: 'copy' };
+    if (selectedTag?.label) {
+      state.tag = selectedTag;
+    }
+    if (statusParam) {
+      state.status = statusParam;
+    }
+    if (selectedTag?.label || statusParam) {
+      navigate(`/template/${id}/edit`, { state });
+    } else {
+      navigate(`/template/${id}/edit`, { state: 'copy' });
+    }
   };
 
   const copyUuid = (_id: string, item: any) => {
@@ -251,7 +269,13 @@ export const HSMList = () => {
   };
 
   const handleCheckedBox = (event: any) => {
-    setFilters({ ...statusFilter, [event.target.value.toUpperCase()]: true });
+    const selectedStatus = event.target.value.toUpperCase();
+    setFilters({ ...statusFilter, [selectedStatus]: true });
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.set('status', selectedStatus);
+      return next;
+    });
   };
 
   const syncHSMButton = (
@@ -271,8 +295,16 @@ export const HSMList = () => {
   const dialogMessage = t('It will stop showing when you draft a customized message');
 
   const navigateToCreate = () => {
+    const statusParam = searchParams.get('status');
+    const state: any = {};
     if (selectedTag?.label) {
-      navigate('/template/add', { state: { tag: selectedTag } });
+      state.tag = selectedTag;
+    }
+    if (statusParam) {
+      state.status = statusParam;
+    }
+    if (Object.keys(state).length > 0) {
+      navigate('/template/add', { state });
     } else {
       navigate('/template/add');
     }
@@ -280,6 +312,13 @@ export const HSMList = () => {
   const button = { show: true, label: t('Create'), action: navigateToCreate };
 
   useEffect(() => {
+    const statusParam = searchParams.get('status')?.toUpperCase();
+    if (statusParam && statusParam in statusFilter) {
+      setFilters({ ...statusFilter, [statusParam]: true });
+    } else if (!statusParam) {
+      setFilters({ ...statusFilter, APPROVED: true });
+    }
+
     const tagValue = searchParams.get('tag');
 
     if (tagValue && tags) {
@@ -316,15 +355,15 @@ export const HSMList = () => {
         optionLabel="label"
         multiple={false}
         onChange={(value: any) => {
-          if (value) {
-            setSearchParams({
-              tag: value.label,
-            });
-          } else {
-            setSearchParams({
-              tag: '',
-            });
-          }
+          setSearchParams((prev) => {
+            const next = new URLSearchParams(prev);
+            if (value?.label) {
+              next.set('tag', value.label);
+            } else {
+              next.delete('tag');
+            }
+            return next;
+          });
         }}
         form={{ setFieldValue: () => {} }}
         field={{
@@ -347,7 +386,19 @@ export const HSMList = () => {
   );
 
   const handleView = (id: any) => {
-    navigate(`/template/${id}/edit`);
+    const statusParam = searchParams.get('status');
+    const state: any = {};
+    if (selectedTag?.label) {
+      state.tag = selectedTag;
+    }
+    if (statusParam) {
+      state.status = statusParam;
+    }
+    if (Object.keys(state).length > 0) {
+      navigate(`/template/${id}/edit`, { state });
+    } else {
+      navigate(`/template/${id}/edit`);
+    }
   };
   let additionalAction: any = () => [
     {


### PR DESCRIPTION
Closes https://github.com/glific/glific-frontend/issues/3451

## Problem
When a user selected an HSM status filter such as Approved, Pending, Rejected, or Failed, opened a template, and clicked the Back button, the HSM list lost the selected status filter.
While existing navigation preserved the tag filter, it did not preserve the status filter.

## Solution
- **URL Synchronization**: Synchronized the active HSM status with the URL query parameter (`?status=...`).
- **Initial & History Restoration**: The HSM list now restores its selected status from the URL query parameter on initial load (`searchParams.get('status')`) and upon history/navigation changes in `useEffect`.
- **Query Parameter Preservation**:
  - Selecting a status dropdown option updates the URL (`setSearchParams`) without dropping other existing parameters (such as `tag`).
  - Selecting or clearing a tag preserves the existing `status` parameter via functional `setSearchParams((prev) => ...)`.
- **Navigation State**:
  - Passed both `status` and `tag` through `location.state` in `handleView`, `navigateToCreate`, and `setCopyDialog`.
- **Back Button Return URL**:
  - The HSM detail page (`HSM.tsx`) now inspects both `location.state?.status` and `location.state?.tag?.label` using `URLSearchParams` to reconstruct the return URL (e.g. `template?status=REJECTED&tag=Messages`).
  - Added support for copy state objects (`{ mode: 'copy', status, tag }`) alongside string state (`'copy'`).

## Testing Done
- **Unit & Regression Tests**:
  - `yarn test:no-watch src/containers/HSM/HSMList/HSMList.test.tsx` (15/15 passed)
    - Added tests for direct URL navigation (`status=REJECTED`, `PENDING`, `FAILED`, `APPROVED`), combined `tag + status` loading, and interactive status changes passing state.
  - `yarn test:no-watch src/containers/HSM/HSM.test.tsx` (26/26 passed)
    - Added tests verifying Back button return navigation for Approved, Pending, Rejected, Failed, and combined tag + status.
- **Type Check**:
  - `npx tsc --noEmit` passed with 0 errors.
- **Code Style**:
  - `npx prettier --check` passed cleanly across all modified files.
- **E2E Note**: Cypress tests were not executed locally because the backend and external BSP services are not configured in this local environment; unit and integration suites provide full regression coverage for the routing and state logic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Status and tag filters now persist in the URL, making filtered views easier to revisit or share.
  - Returning from template editing preserves the selected status and tag filters.
  - Creating, viewing, or copying a template retains the active filter context.
  - Copy mode now works reliably across supported navigation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->